### PR TITLE
Use fasts-equals deepEqual and expose getSectionHeading as a library function

### DIFF
--- a/.github/workflows/publish_container.yaml
+++ b/.github/workflows/publish_container.yaml
@@ -1,13 +1,12 @@
 name: Build and Push Docker Image
 
-
 on:
   workflow_dispatch:
-  
+
   push:
-#    branches-ignore:
-#      - main
-#      - alpha
+    #    branches-ignore:
+    #      - main
+    #      - alpha
     paths:
       - 'apps/smart-forms-app/Dockerfile' # Trigger only if Dockerfile is modified
       - 'apps/smart-forms-app/src/**' # Trigger if anything in the src folder is changed.

--- a/CHANGELOG.alpha.md
+++ b/CHANGELOG.alpha.md
@@ -8,6 +8,13 @@ This changelog only includes changes from version 1.0.0-alpha.1 onwards. For sta
 
 WARNING: Alpha releases are not stable and may contain breaking changes. Changes are also most likely to be undocumented.
 
+## [1.0.0-alpha.56] - 2025-05-26
+### Added
+- Exposed getSectionHeading() as a library function
+
+### Changed
+- Use fast-equals deepEqual() instead of lodash.isEqual() for better performance.
+
 ## [1.0.0-alpha.55] - 2025-05-07
 ### Added
 - Updated @aehrc/sdc-populate to 4.1.0. It now uses the same removeEmptyAnswers() implementation as the renderer, which is more battle tested.

--- a/apps/demo-renderer-app/package-lock.json
+++ b/apps/demo-renderer-app/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@aehrc/sdc-populate": "^4.0.0",
-        "@aehrc/smart-forms-renderer": "^1.0.0-alpha.53",
+        "@aehrc/smart-forms-renderer": "^1.0.0-alpha.55",
         "@radix-ui/react-collapsible": "^1.1.0",
         "@radix-ui/react-slot": "^1.1.2",
         "@radix-ui/react-switch": "^1.1.0",
@@ -43,9 +43,9 @@
       }
     },
     "node_modules/@aehrc/sdc-populate": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@aehrc/sdc-populate/-/sdc-populate-4.0.0.tgz",
-      "integrity": "sha512-OaXHNJuBg33hA/0LTF41lvp11XpV1uDRrCS/iQ2M8IffoS1HN3YLXQNeB5z+4tApsE19jr6887DIAfvWSWaqvQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@aehrc/sdc-populate/-/sdc-populate-4.1.0.tgz",
+      "integrity": "sha512-jplCFvecbFzPr1TSIFj25JocIk0iSd73srkcFXhokbJX/9Leeoxu/jiRYM224H60M79okkdIUR86sB7sFTMFUA==",
       "dependencies": {
         "dayjs": "^1.11.10",
         "fhir-sdc-helpers": "^0.1.0",
@@ -56,11 +56,11 @@
       }
     },
     "node_modules/@aehrc/smart-forms-renderer": {
-      "version": "1.0.0-alpha.53",
-      "resolved": "https://registry.npmjs.org/@aehrc/smart-forms-renderer/-/smart-forms-renderer-1.0.0-alpha.53.tgz",
-      "integrity": "sha512-R5St83bw06eZujbNE3xS+/W+HaD/TFrCp56aAG5je56Hu3QAQGmI2mdUzAvIRrKhCBWT3jfXHiBZJ0SbfCZWEw==",
+      "version": "1.0.0-alpha.55",
+      "resolved": "https://registry.npmjs.org/@aehrc/smart-forms-renderer/-/smart-forms-renderer-1.0.0-alpha.55.tgz",
+      "integrity": "sha512-/OezbhmqoDFqNcct1Rpfu4WvOYEEil0mEPP6q9W7LO9GZIO1DGpx16S20nkP+ecxBYobGLssuDrv8FPmaEbBqg==",
       "dependencies": {
-        "@aehrc/sdc-populate": "^4.0.0",
+        "@aehrc/sdc-populate": "^4.1.0",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
         "@fontsource/inter": "^5.2.5",

--- a/apps/demo-renderer-app/package.json
+++ b/apps/demo-renderer-app/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@aehrc/sdc-populate": "^4.0.0",
-    "@aehrc/smart-forms-renderer": "^1.0.0-alpha.53",
+    "@aehrc/smart-forms-renderer": "^1.0.0-alpha.55",
     "@radix-ui/react-collapsible": "^1.1.0",
     "@radix-ui/react-slot": "^1.1.2",
     "@radix-ui/react-switch": "^1.1.0",

--- a/apps/smart-forms-app/package.json
+++ b/apps/smart-forms-app/package.json
@@ -27,7 +27,7 @@
     "@aehrc/sdc-assemble": "^2.0.1",
     "@aehrc/sdc-populate": "^4.0.1",
     "@aehrc/sdc-template-extract": "^0.1.0",
-    "@aehrc/smart-forms-renderer": "^1.0.0-alpha.54",
+    "@aehrc/smart-forms-renderer": "^1.0.0-alpha.56",
     "@dnd-kit/core": "^6.3.1",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@aehrc/sdc-assemble": "^2.0.1",
         "@aehrc/sdc-populate": "^4.0.1",
         "@aehrc/sdc-template-extract": "^0.1.0",
-        "@aehrc/smart-forms-renderer": "^1.0.0-alpha.54",
+        "@aehrc/smart-forms-renderer": "^1.0.0-alpha.56",
         "@dnd-kit/core": "^6.3.1",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
@@ -11514,15 +11514,6 @@
         "@types/lodash": "*"
       }
     },
-    "node_modules/@types/lodash.isequal": {
-      "version": "4.5.8",
-      "resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.8.tgz",
-      "integrity": "sha512-uput6pg4E/tj2LGxCZo9+y27JNyB2OZuuI/T5F+ylVDYuqICLG2/ktjxx0v6GvVntAf8TvEzeQLcV0ffRirXuA==",
-      "dev": true,
-      "dependencies": {
-        "@types/lodash": "*"
-      }
-    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -17981,6 +17972,14 @@
       "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
       "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true
+    },
+    "node_modules/fast-equals": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
+      "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -37089,7 +37088,7 @@
     },
     "packages/smart-forms-renderer": {
       "name": "@aehrc/smart-forms-renderer",
-      "version": "1.0.0-alpha.55",
+      "version": "1.0.0-alpha.56",
       "license": "Apache-2.0",
       "dependencies": {
         "@aehrc/sdc-populate": "^4.1.0",
@@ -37106,6 +37105,7 @@
         "@tanstack/react-query": "^5.72.1",
         "dayjs": "^1.11.13",
         "deep-diff": "^1.0.2",
+        "fast-equals": "^5.2.2",
         "fhirclient": "^2.5.5",
         "fhirpath": "3.18.0",
         "html-react-parser": "^4.2.10",
@@ -37114,7 +37114,6 @@
         "lodash.difference": "^4.5.0",
         "lodash.differencewith": "^4.5.0",
         "lodash.intersection": "^4.4.0",
-        "lodash.isequal": "^4.5.0",
         "nanoid": "^5.1.5",
         "react-beautiful-dnd": "^13.1.1",
         "react-dnd": "^16.0.1",
@@ -37145,7 +37144,6 @@
         "@types/lodash.difference": "^4.5.9",
         "@types/lodash.differencewith": "^4.5.9",
         "@types/lodash.intersection": "^4.4.9",
-        "@types/lodash.isequal": "^4.5.8",
         "@types/react": "^19.1.0",
         "@types/react-beautiful-dnd": "^13.1.8",
         "@types/react-dom": "^19.1.1",

--- a/packages/smart-forms-renderer/package.json
+++ b/packages/smart-forms-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aehrc/smart-forms-renderer",
-  "version": "1.0.0-alpha.55",
+  "version": "1.0.0-alpha.56",
   "description": "FHIR Structured Data Captured (SDC) rendering engine for Smart Forms",
   "main": "lib/index.js",
   "scripts": {
@@ -41,6 +41,7 @@
     "@tanstack/react-query": "^5.72.1",
     "dayjs": "^1.11.13",
     "deep-diff": "^1.0.2",
+    "fast-equals": "^5.2.2",
     "fhirclient": "^2.5.5",
     "fhirpath": "3.18.0",
     "html-react-parser": "^4.2.10",
@@ -49,7 +50,6 @@
     "lodash.difference": "^4.5.0",
     "lodash.differencewith": "^4.5.0",
     "lodash.intersection": "^4.4.0",
-    "lodash.isequal": "^4.5.0",
     "nanoid": "^5.1.5",
     "react-beautiful-dnd": "^13.1.1",
     "react-dnd": "^16.0.1",
@@ -84,7 +84,6 @@
     "@types/lodash.difference": "^4.5.9",
     "@types/lodash.differencewith": "^4.5.9",
     "@types/lodash.intersection": "^4.4.9",
-    "@types/lodash.isequal": "^4.5.8",
     "@types/react": "^19.1.0",
     "@types/react-beautiful-dnd": "^13.1.8",
     "@types/react-dom": "^19.1.1",

--- a/packages/smart-forms-renderer/src/index.ts
+++ b/packages/smart-forms-renderer/src/index.ts
@@ -96,7 +96,8 @@ export {
   generateItemsToRepopulate,
   repopulateResponse,
   extractObservationBased,
-  getQuestionnaireItem
+  getQuestionnaireItem,
+  getSectionHeading
 } from './utils';
 
 // theme provider exports

--- a/packages/smart-forms-renderer/src/utils/calculatedExpression.ts
+++ b/packages/smart-forms-renderer/src/utils/calculatedExpression.ts
@@ -32,7 +32,7 @@ import { getQrItemsIndex, mapQItemsIndex } from './mapItem';
 import { createEmptyQrGroup, updateQrItemsInGroup } from './qrItem';
 import dayjs from 'dayjs';
 import { updateQuestionnaireResponse } from './genericRecursive';
-import isEqual from 'lodash.isequal';
+import { deepEqual } from 'fast-equals';
 import type { Variables } from '../interfaces';
 import type { ComputedNewAnswers } from '../interfaces/computedUpdates.interface';
 
@@ -65,7 +65,7 @@ export async function evaluateInitialCalculatedExpressions(
 
   // Return early if initialResponse is empty or there are no calculated expressions to evaluate
   if (
-    isEqual(initialResponse, structuredClone(emptyResponse)) ||
+    deepEqual(initialResponse, structuredClone(emptyResponse)) ||
     Object.keys(calculatedExpressions).length === 0
   ) {
     return {
@@ -123,7 +123,7 @@ export async function evaluateInitialCalculatedExpressions(
         }
 
         // Only update calculatedExpressions if length of result array > 0
-        if (result.length > 0 && !isEqual(calcExpression.value, result[0])) {
+        if (result.length > 0 && !deepEqual(calcExpression.value, result[0])) {
           calcExpression.value = result[0];
         }
       } catch (e) {
@@ -203,9 +203,17 @@ export async function evaluateCalculatedExpressions(
           fhirPathTerminologyCache[cacheKey] = result;
         }
 
+        if (
+          typeof calcExpression.value === 'string' &&
+          calcExpression.value.startsWith('Blood tests')
+        ) {
+          console.log(calcExpression.value, structuredClone(result), calcExpression.expression);
+        }
+
         // Update calculatedExpressions if length of result array > 0
         // Only update when current calcExpression value is different from the result, otherwise it will result in an infinite loop as per issue #733
-        if (result.length > 0 && !isEqual(calcExpression.value, result[0])) {
+        if (result.length > 0 && !deepEqual(calcExpression.value, result[0])) {
+          // console.log(calcExpression.value, structuredClone(result));
           isUpdated = true;
           calcExpression.value = result[0];
 

--- a/packages/smart-forms-renderer/src/utils/index.ts
+++ b/packages/smart-forms-renderer/src/utils/index.ts
@@ -34,4 +34,4 @@ export { generateItemsToRepopulate } from './repopulateItems';
 export { repopulateResponse } from './repopulateIntoResponse';
 export { extractObservationBased } from './extractObservation';
 
-export { getQuestionnaireItem } from './misc';
+export { getQuestionnaireItem, getSectionHeading } from './misc';

--- a/packages/smart-forms-renderer/src/utils/misc.ts
+++ b/packages/smart-forms-renderer/src/utils/misc.ts
@@ -259,8 +259,13 @@ function getRepeatGroupParentItemRecursive(
   return null;
 }
 
-/*
- Used for getting the tab section heading for Smart Form's re-population
+/**
+ * Returns the section heading text for a given linkId in a questionnaire, used to label tab sections.
+ *
+ * @param questionnaire - The FHIR Questionnaire to search through.
+ * @param targetLinkId - The linkId of the target item.
+ * @param tabs - Tab definitions used to match section headings.
+ * @returns The section heading text if found, otherwise null.
  */
 export function getSectionHeading(
   questionnaire: Questionnaire,

--- a/packages/smart-forms-renderer/src/utils/openChoice.ts
+++ b/packages/smart-forms-renderer/src/utils/openChoice.ts
@@ -23,7 +23,7 @@ import type {
 } from 'fhir/r4';
 import { OpenChoiceItemControl } from '../interfaces/choice.enum';
 import { isSpecificItemControl } from './itemControl';
-import isEqual from 'lodash.isequal';
+import { deepEqual } from 'fast-equals';
 import differenceWith from 'lodash.differencewith';
 
 /**
@@ -101,7 +101,7 @@ export function updateOpenLabelAnswer(
 
   // Old open label answer equals to new open label answer
   // This should not happen, but return oldQrItem
-  if (isEqual(oldOpenLabelAnswer, newOpenLabelAnswer)) {
+  if (deepEqual(oldOpenLabelAnswer, newOpenLabelAnswer)) {
     return oldQrItem;
   }
 
@@ -128,7 +128,7 @@ export function getOldOpenLabelAnswer(
     return rest as QuestionnaireResponseItemAnswer;
   });
 
-  const outliers = differenceWith(answersWithoutId, options, isEqual);
+  const outliers = differenceWith(answersWithoutId, options, deepEqual);
 
   return outliers?.[0] ?? null;
 }

--- a/packages/smart-forms-renderer/src/utils/repopulateItems.ts
+++ b/packages/smart-forms-renderer/src/utils/repopulateItems.ts
@@ -32,7 +32,7 @@ import { createQuestionnaireResponseItemMap } from './questionnaireResponseStore
 import { getQuestionnaireItem, getSectionHeading } from './misc';
 import difference from 'lodash.difference';
 import intersection from 'lodash.intersection';
-import isEqual from 'lodash.isequal';
+import { deepEqual } from 'fast-equals';
 
 /**
  * ItemToRepopulate interface
@@ -459,7 +459,7 @@ function retrieveSingleOldQRItem(
     return;
   }
 
-  if (isEqual(oldQRItem, newQRItem)) {
+  if (deepEqual(oldQRItem, newQRItem)) {
     delete itemsToRepopulate[qItem.linkId];
     return;
   }
@@ -481,7 +481,7 @@ function retrieveRepeatGroupOldQRItems(
     return;
   }
 
-  if (isEqual(oldQRItems, newQRItems)) {
+  if (deepEqual(oldQRItems, newQRItems)) {
     delete itemsToRepopulate[qItem.linkId];
     return;
   }
@@ -526,7 +526,7 @@ function retrieveGridGroupOldQRItems(
       continue;
     }
 
-    if (isEqual(oldGridChildQrItem, newGridChildQRItem)) {
+    if (deepEqual(oldGridChildQrItem, newGridChildQRItem)) {
       newGridChildQRItemMap.delete(gridChildQItem.linkId);
     } else {
       oldGridChildQRItems.push(oldGridChildQrItem);


### PR DESCRIPTION
Changes:
- Exposed getSectionHeading() as a library function
- Use fast-equals deepEqual() instead of lodash.isEqual() for better performance.

Updates renderer version to alpha.56.