### PR TITLE
Issue/1257

### DIFF
--- a/.github/workflows/build_test_lint.yml
+++ b/.github/workflows/build_test_lint.yml
@@ -58,7 +58,6 @@ jobs:
         run: npm run test -w packages/smart-forms-renderer
       - uses: codecov/codecov-action@v4
 
-
   jest-extract-tests:
     name: Jest Tests - Template-Based Extract
     runs-on: ubuntu-latest

--- a/apps/smart-forms-app/src/utils/manageForm.ts
+++ b/apps/smart-forms-app/src/utils/manageForm.ts
@@ -1,4 +1,4 @@
-import { buildForm, destroyForm } from '@aehrc/smart-forms-renderer';
+import { buildForm, destroyForm, questionnaireStore } from '@aehrc/smart-forms-renderer';
 import type { Questionnaire, QuestionnaireResponse } from 'fhir/r4';
 import { fetchTargetStructureMap } from '../features/playground/api/extract.ts';
 import { extractDebuggerStore } from '../features/playground/stores/extractDebuggerStore.ts';
@@ -15,6 +15,9 @@ export async function buildFormWrapper(
   if (targetStructureMap) {
     extractDebuggerStore.getState().setStructuredMapExtractMap(targetStructureMap);
   }
+
+  // Destroy previous questionnaire state before building a new one
+  questionnaireStore.getState().destroySourceQuestionnaire();
 
   return buildForm(
     questionnaire,

--- a/package-lock.json
+++ b/package-lock.json
@@ -36987,7 +36987,7 @@
     },
     "packages/sdc-populate": {
       "name": "@aehrc/sdc-populate",
-      "version": "4.1.0",
+      "version": "4.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "dayjs": "^1.11.10",

--- a/packages/sdc-populate/package.json
+++ b/packages/sdc-populate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aehrc/sdc-populate",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Performs the $populate operation from the HL7 FHIR SDC (Structured Data Capture) specification: http://hl7.org/fhir/uv/sdc",
   "scripts": {
     "compile": "tsup src/index.ts --format cjs,esm --dts --clean --sourcemap",

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/constructResponse.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/constructResponse.ts
@@ -526,17 +526,24 @@ async function constructRepeatGroupInstances(
   const terminologyServerUrl = fetchTerminologyRequestConfig?.terminologyServerUrl ?? null;
 
   // Look in initialExpressions of each of the child items to relate back to the itemPopulationContext its using
-  // FIXME eventually need to consider initialExpressions other than the first one
-  const itemPopulationContextExpression =
-    initialExpressions[qRepeatGroupParent.item[0].linkId]?.expression;
+  let itemPopulationContextExpression: string | undefined;
+  let itemPopulationContext: ItemPopulationContext | undefined;
+  for (const childItem of qRepeatGroupParent.item) {
+    const expression = initialExpressions[childItem.linkId]?.expression;
+    if (!expression) continue;
 
-  if (!itemPopulationContextExpression) {
-    return [];
+    const contextName = getItemPopulationContextName(expression);
+    const context = contextName ? itemPopulationContexts[contextName] : undefined;
+
+    if (context && context.value) {
+      itemPopulationContextExpression = expression;
+      itemPopulationContext = context;
+      break; // Stop at the first valid match
+    }
   }
 
-  const itemPopulationContextName = getItemPopulationContextName(itemPopulationContextExpression);
-  const itemPopulationContext = itemPopulationContexts[itemPopulationContextName];
-  if (!itemPopulationContext || !itemPopulationContext.value) {
+  // No itemPopulationContext is found, return an empty array
+  if (!itemPopulationContextExpression || !itemPopulationContext || !itemPopulationContext.value) {
     return [];
   }
 


### PR DESCRIPTION
Miscellaneous fixes.

**SDC-Populate:**
Fix issue where itemPopulationContext usage only looks at the first item's initialExpression. Resolves https://github.com/aehrc/smart-forms/issues/1258.

**Smart Forms app**
Clean up previous questionnaire state before building a new one. Prevents issues where when a new questionnaire is "rebuilt" in Playground, the old variables are still present in "See Additional properties".