### PR TITLE
CQF load on pre-pop

### DIFF
--- a/CHANGELOG.alpha.md
+++ b/CHANGELOG.alpha.md
@@ -8,6 +8,15 @@ This changelog only includes changes from version 1.0.0-alpha.1 onwards. For sta
 
 WARNING: Alpha releases are not stable and may contain breaking changes. Changes are also most likely to be undocumented.
 
+## [1.0.0-alpha.64] - 2025-06-05
+### Fixed
+- Fixed an issue where cqfExpressions are not evaluated when the QuestionnaireResponse is first initialised.
+
+### Changed
+- Changed how additionalVariables in buildForm() (and it's variants) work. Instead of <name, extension obj> which doesn't provide much value, 
+  it now works more like a fhirPathContext <name, value> where `value` is the evaluated value from fhirpath.evaluate(). additionalVariables likely will come from a pre-population module (like sdc-populate) which then can be injected into the renderer's fhirPathContext.
+
+
 ## [1.0.0-alpha.63] - 2025-06-05
 ### Fixed
 - Fixed an issue where group table cells content is not centre-aligned.

--- a/apps/demo-renderer-app/package-lock.json
+++ b/apps/demo-renderer-app/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@aehrc/sdc-populate": "^4.0.0",
-        "@aehrc/smart-forms-renderer": "^1.0.0-alpha.61",
+        "@aehrc/smart-forms-renderer": "^1.0.0-alpha.63",
         "@radix-ui/react-collapsible": "^1.1.0",
         "@radix-ui/react-slot": "^1.1.2",
         "@radix-ui/react-switch": "^1.1.0",
@@ -56,9 +56,9 @@
       }
     },
     "node_modules/@aehrc/smart-forms-renderer": {
-      "version": "1.0.0-alpha.61",
-      "resolved": "https://registry.npmjs.org/@aehrc/smart-forms-renderer/-/smart-forms-renderer-1.0.0-alpha.61.tgz",
-      "integrity": "sha512-eWLOu/8VYXC4BVXhjp1kEfmL0dygbHgBrJbnwouu8uozCwjT2FftPJiKl9JxYdTUWPVL2iHZOEjbhtdL4Mg/8w==",
+      "version": "1.0.0-alpha.63",
+      "resolved": "https://registry.npmjs.org/@aehrc/smart-forms-renderer/-/smart-forms-renderer-1.0.0-alpha.63.tgz",
+      "integrity": "sha512-Ek3kpxbLgOrsAZn6ikLbt7RJZkh3mV6sxO+URguF5SSlHqjBEvfqRiBr+Qa6uwiEBV+MGFFiLe2nmjPUzCfN6Q==",
       "dependencies": {
         "@aehrc/sdc-populate": "^4.3.0",
         "@emotion/react": "^11.14.0",

--- a/apps/demo-renderer-app/package.json
+++ b/apps/demo-renderer-app/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@aehrc/sdc-populate": "^4.0.0",
-    "@aehrc/smart-forms-renderer": "^1.0.0-alpha.61",
+    "@aehrc/smart-forms-renderer": "^1.0.0-alpha.63",
     "@radix-ui/react-collapsible": "^1.1.0",
     "@radix-ui/react-slot": "^1.1.2",
     "@radix-ui/react-switch": "^1.1.0",

--- a/apps/smart-forms-app/package.json
+++ b/apps/smart-forms-app/package.json
@@ -27,7 +27,7 @@
     "@aehrc/sdc-assemble": "^2.0.1",
     "@aehrc/sdc-populate": "^4.3.0",
     "@aehrc/sdc-template-extract": "^0.2.0",
-    "@aehrc/smart-forms-renderer": "^1.0.0-alpha.63",
+    "@aehrc/smart-forms-renderer": "^1.0.0-alpha.64",
     "@dnd-kit/core": "^6.3.1",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",

--- a/apps/smart-forms-app/src/features/playground/components/PlaygroundRenderer.tsx
+++ b/apps/smart-forms-app/src/features/playground/components/PlaygroundRenderer.tsx
@@ -87,8 +87,11 @@ function PlaygroundRenderer(props: PlaygroundRendererProps) {
         sourceQuestionnaire,
         populatedResponse,
         undefined,
-        terminologyServerUrl
+        terminologyServerUrl,
+        populatedContext
       );
+
+      // TODO eventually we want to deprecate this in 1.0.0, populatedContext is now passed to buildFormWrapper and is automatically added to the FhirPathContext
       if (populatedContext) {
         setPopulatedContext(populatedContext, true);
       }

--- a/apps/smart-forms-app/src/utils/manageForm.ts
+++ b/apps/smart-forms-app/src/utils/manageForm.ts
@@ -8,7 +8,7 @@ export async function buildFormWrapper(
   questionnaireResponse?: QuestionnaireResponse,
   readOnly?: boolean,
   terminologyServerUrl?: string,
-  additionalVariables?: Record<string, object>
+  additionalVariables?: Record<string, any>
 ) {
   extractDebuggerStore.getState().resetStore();
   const targetStructureMap = await fetchTargetStructureMap(questionnaire);

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@aehrc/sdc-assemble": "^2.0.1",
         "@aehrc/sdc-populate": "^4.3.0",
         "@aehrc/sdc-template-extract": "^0.2.0",
-        "@aehrc/smart-forms-renderer": "^1.0.0-alpha.63",
+        "@aehrc/smart-forms-renderer": "^1.0.0-alpha.64",
         "@dnd-kit/core": "^6.3.1",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
@@ -37151,7 +37151,7 @@
     },
     "packages/smart-forms-renderer": {
       "name": "@aehrc/smart-forms-renderer",
-      "version": "1.0.0-alpha.63",
+      "version": "1.0.0-alpha.64",
       "license": "Apache-2.0",
       "dependencies": {
         "@aehrc/sdc-populate": "^4.3.0",

--- a/packages/smart-forms-renderer/package-lock.json
+++ b/packages/smart-forms-renderer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aehrc/smart-forms-renderer",
-  "version": "1.0.0-alpha.63",
+  "version": "1.0.0-alpha.64",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aehrc/smart-forms-renderer",
-      "version": "1.0.0-alpha.63",
+      "version": "1.0.0-alpha.64",
       "license": "Apache-2.0",
       "dependencies": {
         "@aehrc/sdc-populate": "^4.0.0",

--- a/packages/smart-forms-renderer/package.json
+++ b/packages/smart-forms-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aehrc/smart-forms-renderer",
-  "version": "1.0.0-alpha.63",
+  "version": "1.0.0-alpha.64",
   "description": "FHIR Structured Data Captured (SDC) rendering engine for Smart Forms",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/smart-forms-renderer/src/components/Renderer/SmartFormsRenderer.tsx
+++ b/packages/smart-forms-renderer/src/components/Renderer/SmartFormsRenderer.tsx
@@ -43,7 +43,7 @@ import RendererThemeProvider from '../../theme/RendererThemeProvider';
 export interface SmartFormsRendererProps {
   questionnaire: Questionnaire;
   questionnaireResponse?: QuestionnaireResponse;
-  additionalVariables?: Record<string, object>;
+  additionalVariables?: Record<string, any>;
   terminologyServerUrl?: string;
   fhirClient?: Client;
   readOnly?: boolean;

--- a/packages/smart-forms-renderer/src/hooks/useBuildForm.ts
+++ b/packages/smart-forms-renderer/src/hooks/useBuildForm.ts
@@ -31,10 +31,10 @@ import type { QItemOverrideComponentProps, SdcUiOverrideComponentProps } from '.
  * @param questionnaireResponse - Pre-populated/draft/loaded QuestionnaireResponse to be rendered (optional)
  * @param readOnly - Applies read-only mode to all items in the form view
  * @param terminologyServerUrl - Terminology server url to fetch terminology. If not provided, the default terminology server will be used. (optional)
- * @param additionalVariables - Additional key-value pair of SDC variables `Record<name, variable extension>` for testing (optional)
+ * @param additionalVariables - Additional key-value pair of SDC variables + values to be fed into the renderer's FhirPathContext `Record<name, value>` (likely coming from a pre-population module) e.g. `{ 'ObsBodyHeight': <Bundle of height observations> } }`.
  * @param rendererStylingOptions - Renderer styling to be applied to the form. See docs for styling options. (optional)
- * @param qItemOverrideComponents - FIXME add comment
- * @param sdcUiOverrideComponents - FIXME add comment
+ * @param qItemOverrideComponents - Key-value pair of React component overrides for Questionnaire Items via linkId `Record<linkId, React component>`
+ * @param sdcUiOverrideComponents - Key-value pair of React component overrides for SDC UI Controls https://hl7.org/fhir/extensions/ValueSet-questionnaire-item-control.html `Record<SDC UI code, React component>`
  *
  *
  * @author Sean Fong
@@ -44,7 +44,7 @@ function useBuildForm(
   questionnaireResponse?: QuestionnaireResponse,
   readOnly?: boolean,
   terminologyServerUrl?: string,
-  additionalVariables?: Record<string, object>,
+  additionalVariables?: Record<string, any>,
   rendererStylingOptions?: RendererStyling,
   qItemOverrideComponents?: Record<string, ComponentType<QItemOverrideComponentProps>>,
   sdcUiOverrideComponents?: Record<string, ComponentType<SdcUiOverrideComponentProps>>

--- a/packages/smart-forms-renderer/src/hooks/useInitialiseForm.ts
+++ b/packages/smart-forms-renderer/src/hooks/useInitialiseForm.ts
@@ -43,7 +43,7 @@ function useInitialiseForm(
   questionnaireResponse?: QuestionnaireResponse,
   readOnly?: boolean,
   terminologyServerUrl?: string,
-  additionalVariables?: Record<string, object>,
+  additionalVariables?: Record<string, any>,
   fhirClient?: Client
 ): boolean {
   const [isFhirClientReady, setIsFhirClientReady] = useState(true);

--- a/packages/smart-forms-renderer/src/stories/storybookWrappers/InitialiseFormWrapperForStorybook.tsx
+++ b/packages/smart-forms-renderer/src/stories/storybookWrappers/InitialiseFormWrapperForStorybook.tsx
@@ -33,7 +33,7 @@ export interface InitialiseFormWrapperProps {
   questionnaireResponse?: QuestionnaireResponse;
   readOnly?: boolean;
   terminologyServerUrl?: string;
-  additionalVariables?: Record<string, object>;
+  additionalVariables?: Record<string, any>;
   fhirClient?: Client;
 }
 

--- a/packages/smart-forms-renderer/src/utils/manageForm.ts
+++ b/packages/smart-forms-renderer/src/utils/manageForm.ts
@@ -23,9 +23,9 @@ import type { QItemOverrideComponentProps, SdcUiOverrideComponentProps } from '.
  * @param questionnaireResponse - Pre-populated/draft/loaded QuestionnaireResponse to be rendered (optional)
  * @param readOnly - Applies read-only mode to all items in the form view
  * @param terminologyServerUrl - Terminology server url to fetch terminology. If not provided, the default terminology server will be used. (optional)
- * @param additionalVariables - Additional key-value pair of SDC variables `Record<name, variable extension>` for testing (optional)
- * @param qItemOverrideComponents - FIXME add comment
- * @param sdcUiOverrideComponents - FIXME add comment
+ * @param additionalVariables - Additional key-value pair of SDC variables + values to be fed into the renderer's FhirPathContext `Record<name, value>` (likely coming from a pre-population module) e.g. `{ 'ObsBodyHeight': <Bundle of height observations> } }`.
+ * @param qItemOverrideComponents - Key-value pair of React component overrides for Questionnaire Items via linkId `Record<linkId, React component>`
+ * @param sdcUiOverrideComponents - Key-value pair of React component overrides for SDC UI Controls https://hl7.org/fhir/extensions/ValueSet-questionnaire-item-control.html `Record<SDC UI code, React component>`
  *
  * @author Sean Fong
  */
@@ -34,7 +34,7 @@ export async function buildForm(
   questionnaireResponse?: QuestionnaireResponse,
   readOnly?: boolean,
   terminologyServerUrl?: string,
-  additionalVariables?: Record<string, object>,
+  additionalVariables?: Record<string, any>,
   qItemOverrideComponents?: Record<string, ComponentType<QItemOverrideComponentProps>>,
   sdcUiOverrideComponents?: Record<string, ComponentType<SdcUiOverrideComponentProps>>
 ): Promise<void> {

--- a/packages/smart-forms-renderer/src/utils/questionnaireStoreUtils/createQuestionaireModel.ts
+++ b/packages/smart-forms-renderer/src/utils/questionnaireStoreUtils/createQuestionaireModel.ts
@@ -28,7 +28,6 @@ import { extractContainedValueSets } from './extractContainedValueSets';
 import { extractOtherExtensions } from './extractOtherExtensions';
 import type { Variables } from '../../interfaces/variables.interface';
 import { resolveValueSets } from './resolveValueSets';
-import { addAdditionalVariables } from './addAdditionalVariables';
 import { getLinkIdPreferredTerminologyServerTuples, getLinkIdTypeTuples } from '../qItem';
 import { addDisplayToAnswerOptions, addDisplayToCacheCodings } from './addDisplayToCodings';
 import type { TargetConstraint } from '../../interfaces/targetConstraint.interface';
@@ -36,7 +35,6 @@ import { extractTargetConstraints } from './extractTargetConstraint';
 
 export async function createQuestionnaireModel(
   questionnaire: Questionnaire,
-  additionalVariables: Record<string, object>,
   terminologyServerUrl: string
 ): Promise<QuestionnaireModel> {
   if (!questionnaire.item) {
@@ -55,7 +53,12 @@ export async function createQuestionnaireModel(
     extractTargetConstraints(questionnaire);
 
   let variables: Variables = extractQuestionnaireLevelVariables(questionnaire);
-  variables = addAdditionalVariables(variables, additionalVariables);
+
+  // TODO reminder to remove/have documentation when upgrading to 1.0.0 - 05/06/2025
+  // TODO additionalVariables is defined to be <"name", "extension"> previously, which provides no real value.
+  // TODO the definition of additionalVariables is now <"name", "value">, which allows it to be injected into the renderer's fhirPathContext.
+  // TODO as an example, populatedContext from a pre-pop module can now be inserted into the renderer for further use.
+  // variables = addAdditionalVariables(variables, additionalVariables);
 
   const extractContainedValueSetsResult = extractContainedValueSets(
     questionnaire,


### PR DESCRIPTION
### Fixed
- Fixed an issue where cqfExpressions are not evaluated when the QuestionnaireResponse is first initialised.

### Changed
- Changed how additionalVariables in buildForm() (and it's variants) work. Instead of <name, extension obj> which doesn't provide much value, 
  it now works more like a fhirPathContext <name, value> where `value` is the evaluated value from fhirpath.evaluate(). additionalVariables likely will come from a pre-population module (like sdc-populate) which then can be injected into the renderer's fhirPathContext.