### PR TITLE
Issue/1276

### DIFF
--- a/apps/smart-forms-app/package.json
+++ b/apps/smart-forms-app/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@aehrc/sdc-assemble": "^2.0.1",
     "@aehrc/sdc-populate": "^4.3.0",
-    "@aehrc/sdc-template-extract": "^1.0.1",
+    "@aehrc/sdc-template-extract": "^1.0.2",
     "@aehrc/smart-forms-renderer": "^1.0.0-alpha.66",
     "@dnd-kit/core": "^6.3.1",
     "@emotion/react": "^11.14.0",

--- a/apps/smart-forms-app/package.json
+++ b/apps/smart-forms-app/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@aehrc/sdc-assemble": "^2.0.1",
     "@aehrc/sdc-populate": "^4.3.0",
-    "@aehrc/sdc-template-extract": "^1.0.2",
+    "@aehrc/sdc-template-extract": "^1.0.3",
     "@aehrc/smart-forms-renderer": "^1.0.0-alpha.66",
     "@dnd-kit/core": "^6.3.1",
     "@emotion/react": "^11.14.0",

--- a/apps/smart-forms-app/src/features/playground/components/ExtractMenu.tsx
+++ b/apps/smart-forms-app/src/features/playground/components/ExtractMenu.tsx
@@ -131,7 +131,7 @@ function ExtractMenu(props: ExtractMenuProps) {
               <ListItemIcon>
                 <Iconify icon="mdi:file-document" />
               </ListItemIcon>
-              <ListItemText>Template-based $extract</ListItemText>
+              <ListItemText>Template-based $extract [{TEMPLATE_EXTRACT_VERSION}]</ListItemText>
             </MenuItem>
           </span>
         </Tooltip>
@@ -146,7 +146,9 @@ function ExtractMenu(props: ExtractMenuProps) {
               <ListItemIcon>
                 <Iconify icon="mdi:file-document-edit" />
               </ListItemIcon>
-              <ListItemText>Template-based $extract (modified only)</ListItemText>
+              <ListItemText>
+                Template-based $extract (modified only) [{TEMPLATE_EXTRACT_VERSION}]
+              </ListItemText>
             </MenuItem>
           </span>
         </Tooltip>

--- a/apps/smart-forms-app/src/vite-env.d.ts
+++ b/apps/smart-forms-app/src/vite-env.d.ts
@@ -23,6 +23,7 @@ declare module '*.jpeg';
 declare module '*.jpg';
 
 declare const RENDERER_VERSION: string;
+declare const TEMPLATE_EXTRACT_VERSION: string;
 
 interface ImportMetaEnv {
   readonly VITE_APP_TITLE: string;

--- a/apps/smart-forms-app/vite.config.ts
+++ b/apps/smart-forms-app/vite.config.ts
@@ -11,7 +11,10 @@ export default ({ mode }) => {
   return defineConfig({
     plugins: [react(), svgr()],
     define: {
-      RENDERER_VERSION: JSON.stringify(packageJson.dependencies['@aehrc/smart-forms-renderer'])
+      RENDERER_VERSION: JSON.stringify(packageJson.dependencies['@aehrc/smart-forms-renderer']),
+      TEMPLATE_EXTRACT_VERSION: JSON.stringify(
+        packageJson.dependencies['@aehrc/sdc-template-extract']
+      )
     }
   });
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
       "dependencies": {
         "@aehrc/sdc-assemble": "^2.0.1",
         "@aehrc/sdc-populate": "^4.3.0",
-        "@aehrc/sdc-template-extract": "^1.0.1",
+        "@aehrc/sdc-template-extract": "^1.0.3",
         "@aehrc/smart-forms-renderer": "^1.0.0-alpha.66",
         "@dnd-kit/core": "^6.3.1",
         "@emotion/react": "^11.14.0",
@@ -37659,7 +37659,7 @@
     },
     "packages/sdc-template-extract": {
       "name": "@aehrc/sdc-template-extract",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "clean-deep": "^3.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37659,7 +37659,7 @@
     },
     "packages/sdc-template-extract": {
       "name": "@aehrc/sdc-template-extract",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "clean-deep": "^3.4.0",

--- a/packages/sdc-template-extract/package.json
+++ b/packages/sdc-template-extract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aehrc/sdc-template-extract",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Performs template-based extraction from the HL7 FHIR SDC (Structured Data Capture) specification: https://build.fhir.org/ig/HL7/sdc/extraction.html#template-based-extraction",
   "scripts": {
     "compile": "tsup src/index.ts --format cjs,esm --dts --clean --sourcemap",

--- a/packages/sdc-template-extract/package.json
+++ b/packages/sdc-template-extract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aehrc/sdc-template-extract",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Performs template-based extraction from the HL7 FHIR SDC (Structured Data Capture) specification: https://build.fhir.org/ig/HL7/sdc/extraction.html#template-based-extraction",
   "scripts": {
     "compile": "tsup src/index.ts --format cjs,esm --dts --clean --sourcemap",

--- a/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/interfaces/templateExtractReference.interface.ts
+++ b/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/interfaces/templateExtractReference.interface.ts
@@ -44,9 +44,9 @@ export interface IfNoneExistExtensionSlice extends Extension {
 }
 
 // FHIRPath expression string indicating the resource type of an extracted resource to populate request.url property in `Bundle.entry`
-export interface ResourceTypeExtensionSlice extends Extension {
-  name: 'resourceType';
-  valueString: string;
+export interface TypeExtensionSlice extends Extension {
+  name: 'type';
+  valueCode: string;
 }
 
 /**
@@ -98,8 +98,9 @@ export interface TemplateExtractReference {
 
   /**
    * A custom slice. FHIRPath expression string indicating the resource type of an extracted resource, if the template's resourceType is different e.g. Parameters.
+   * Should be binded to http://hl7.org/fhir/R4/valueset-resource-types.html.
    * Currently used to populate the `url` field in the `request` of a `Bundle.entry`.
-   * Extracted from the `valueString` of the custom `resourceType` slice.
+   * Extracted from the `valueCode` of the custom `type` slice.
    */
-  resourceType?: string;
+  type?: string;
 }

--- a/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/interfaces/templateExtractReference.interface.ts
+++ b/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/interfaces/templateExtractReference.interface.ts
@@ -43,7 +43,8 @@ export interface IfNoneExistExtensionSlice extends Extension {
   valueString: string;
 }
 
-// FHIRPath expression string indicating the resource type of an extracted resource to populate request.url property in `Bundle.entry`
+// ValueCode indicating the resource type of an extracted resource to populate request.url property in `Bundle.entry`.
+// Must be binded to http://hl7.org/fhir/R4/valueset-resource-types.html.
 export interface TypeExtensionSlice extends Extension {
   name: 'type';
   valueCode: string;
@@ -97,8 +98,8 @@ export interface TemplateExtractReference {
   ifNoneExist?: string;
 
   /**
-   * A custom slice. FHIRPath expression string indicating the resource type of an extracted resource, if the template's resourceType is different e.g. Parameters.
-   * Should be binded to http://hl7.org/fhir/R4/valueset-resource-types.html.
+   * A custom slice. ValueCode indicating the resource type of an extracted resource, if the template's resourceType is different e.g. Parameters.
+   * Must be binded to http://hl7.org/fhir/R4/valueset-resource-types.html.
    * Currently used to populate the `url` field in the `request` of a `Bundle.entry`.
    * Extracted from the `valueCode` of the custom `type` slice.
    */

--- a/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/resources/questionnaires/QMedicalHistoryCurrentProblemsWithPatch.ts
+++ b/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/resources/questionnaires/QMedicalHistoryCurrentProblemsWithPatch.ts
@@ -651,8 +651,8 @@ export const QMedicalHistoryCurrentProblemsWithPatch: Questionnaire = {
                       valueString: "item.where(linkId='conditionId').answer.value"
                     },
                     {
-                      url: 'resourceType',
-                      valueString: 'Condition'
+                      url: 'type',
+                      valueCode: 'Condition'
                     }
                   ]
                 }

--- a/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/utils/buildBundle.ts
+++ b/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/utils/buildBundle.ts
@@ -117,7 +117,6 @@ export function buildTransactionBundle(
       // resourceType (custom)
       let resourceType = cleanedExtractedResource.resourceType;
       if (templateExtractReference.type) {
-        console.log(templateExtractReference.type);
         resourceType = templateExtractReference.type as FhirResource['resourceType'];
       }
 

--- a/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/utils/buildBundle.ts
+++ b/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/utils/buildBundle.ts
@@ -116,8 +116,9 @@ export function buildTransactionBundle(
 
       // resourceType (custom)
       let resourceType = cleanedExtractedResource.resourceType;
-      if (templateExtractReference.resourceType) {
-        resourceType = templateExtractReference.resourceType as FhirResource['resourceType'];
+      if (templateExtractReference.type) {
+        console.log(templateExtractReference.type);
+        resourceType = templateExtractReference.type as FhirResource['resourceType'];
       }
 
       // fullUrl

--- a/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/utils/templateExtractRef.ts
+++ b/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/utils/templateExtractRef.ts
@@ -7,8 +7,8 @@ import {
   isIfNoneExistExtensionSlice,
   isIfNoneMatchExtensionSlice,
   isResourceIdExtensionSlice,
-  isResourceTypeExtensionSlice,
-  isTemplateExtensionSlice
+  isTemplateExtensionSlice,
+  isTypeExtensionSlice
 } from './typePredicates';
 import { createInvalidWarningIssue } from './operationOutcome';
 
@@ -122,8 +122,8 @@ export function hasTemplateExtractRefExtension(item: QuestionnaireItem | Questio
       templateExtractRef.ifNoneExist = slice.valueString;
     }
 
-    if (isResourceTypeExtensionSlice(slice)) {
-      templateExtractRef.resourceType = slice.valueString;
+    if (isTypeExtensionSlice(slice)) {
+      templateExtractRef.type = slice.valueCode;
     }
   }
 

--- a/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/utils/typePredicates.ts
+++ b/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/utils/typePredicates.ts
@@ -29,8 +29,8 @@ import type {
   IfNoneExistExtensionSlice,
   IfNoneMatchExtensionSlice,
   ResourceIdExtensionSlice,
-  ResourceTypeExtensionSlice,
-  TemplateExtensionSlice
+  TemplateExtensionSlice,
+  TypeExtensionSlice
 } from '../interfaces/templateExtractReference.interface';
 import type { FhirPatchParameters } from '../interfaces/fhirpatch.interface';
 
@@ -108,10 +108,8 @@ export function isIfNoneExistExtensionSlice(
   return extension.url === 'ifNoneExist' && !!extension.valueString;
 }
 
-export function isResourceTypeExtensionSlice(
-  extension: Extension
-): extension is ResourceTypeExtensionSlice {
-  return extension.url === 'resourceType' && !!extension.valueString;
+export function isTypeExtensionSlice(extension: Extension): extension is TypeExtensionSlice {
+  return extension.url === 'type' && !!extension.valueCode;
 }
 
 export function valueIsCoding(value: any): value is Coding {


### PR DESCRIPTION
Changes:
- Change templateExtract custom resourceType slice to "type" and valueCode. e.g.
```json
{
  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-templateExtract",
  "extension": [
    {
      "url": "template",
      "valueReference": {
        "reference": "#ConditionPatchTemplate"
      }
    },
    {
      "url": "resourceId",
      "valueString": "item.where(linkId='conditionId').answer.value"
    },
    {
      "url": "type",
      "valueCode": "Condition"
    }
  ]
}
```
- Add sdc-template-extract version to Playground