### PR TITLE
Issue/1350

### DIFF
--- a/CHANGELOG.alpha.md
+++ b/CHANGELOG.alpha.md
@@ -8,6 +8,12 @@ This changelog only includes changes from version 1.0.0-alpha.1 onwards. For sta
 
 WARNING: Alpha releases are not stable and may contain breaking changes. Changes are also most likely to be undocumented.
 
+## [1.0.0-alpha.73] - 2025-07-08
+#### Fixed
+- Fix an issue where invalidItems not updated immediately when target constraint is unmet.
+- Fix an issue where in the Playground, existing RendererStylingStore state is wiped (and reverts to the default values) when a button that calls `setRendererStylingStore()` is clicked.
+
+
 ## [1.0.0-alpha.72] - 2025-07-01
 #### Fixed
 - Added getItemTerminologyServerToUse() as a cleaner way to an item to decide which terminology server to use.

--- a/apps/demo-renderer-app/package-lock.json
+++ b/apps/demo-renderer-app/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@aehrc/sdc-populate": "^4.0.0",
-        "@aehrc/smart-forms-renderer": "^1.0.0-alpha.71",
+        "@aehrc/smart-forms-renderer": "^1.0.0-alpha.72",
         "@radix-ui/react-collapsible": "^1.1.0",
         "@radix-ui/react-slot": "^1.1.2",
         "@radix-ui/react-switch": "^1.1.0",
@@ -71,9 +71,9 @@
       }
     },
     "node_modules/@aehrc/smart-forms-renderer": {
-      "version": "1.0.0-alpha.71",
-      "resolved": "https://registry.npmjs.org/@aehrc/smart-forms-renderer/-/smart-forms-renderer-1.0.0-alpha.71.tgz",
-      "integrity": "sha512-bWGHCqR78oSKvCXdwX0S1hoxMHxHTz2r9ke33rZE/RN4YxwKK7VqPFdnLmpOvzC3/ywmRMYxCDJwK2GhwMjC4Q==",
+      "version": "1.0.0-alpha.72",
+      "resolved": "https://registry.npmjs.org/@aehrc/smart-forms-renderer/-/smart-forms-renderer-1.0.0-alpha.72.tgz",
+      "integrity": "sha512-Mf7jhgV3oKTmlDg6xmQF7p6Vv8Ym6/Qvy1RFbpK5LBvhKJi/CQWg156m1yqy7UiMG7t4qzjsv7EGfc5YyFvPlQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aehrc/sdc-populate": "^4.3.1",

--- a/apps/demo-renderer-app/package.json
+++ b/apps/demo-renderer-app/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@aehrc/sdc-populate": "^4.0.0",
-    "@aehrc/smart-forms-renderer": "^1.0.0-alpha.71",
+    "@aehrc/smart-forms-renderer": "^1.0.0-alpha.72",
     "@radix-ui/react-collapsible": "^1.1.0",
     "@radix-ui/react-slot": "^1.1.2",
     "@radix-ui/react-switch": "^1.1.0",

--- a/apps/smart-forms-app/package.json
+++ b/apps/smart-forms-app/package.json
@@ -27,7 +27,7 @@
     "@aehrc/sdc-assemble": "^2.0.1",
     "@aehrc/sdc-populate": "^4.3.1",
     "@aehrc/sdc-template-extract": "^1.0.5",
-    "@aehrc/smart-forms-renderer": "^1.0.0-alpha.72",
+    "@aehrc/smart-forms-renderer": "^1.0.0-alpha.73",
     "@dnd-kit/core": "^6.3.1",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@aehrc/sdc-assemble": "^2.0.1",
         "@aehrc/sdc-populate": "^4.3.1",
         "@aehrc/sdc-template-extract": "^1.0.5",
-        "@aehrc/smart-forms-renderer": "^1.0.0-alpha.72",
+        "@aehrc/smart-forms-renderer": "^1.0.0-alpha.73",
         "@dnd-kit/core": "^6.3.1",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
@@ -40693,7 +40693,7 @@
     },
     "packages/smart-forms-renderer": {
       "name": "@aehrc/smart-forms-renderer",
-      "version": "1.0.0-alpha.72",
+      "version": "1.0.0-alpha.73",
       "license": "Apache-2.0",
       "dependencies": {
         "@aehrc/sdc-populate": "^4.3.1",

--- a/packages/smart-forms-renderer/package.json
+++ b/packages/smart-forms-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aehrc/smart-forms-renderer",
-  "version": "1.0.0-alpha.72",
+  "version": "1.0.0-alpha.73",
   "description": "FHIR Structured Data Captured (SDC) rendering engine for Smart Forms",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/smart-forms-renderer/src/hooks/useValidationFeedback.ts
+++ b/packages/smart-forms-renderer/src/hooks/useValidationFeedback.ts
@@ -48,8 +48,8 @@ function useValidationFeedback(
     for (const targetConstraintKey of targetConstraintKeys) {
       const targetConstraint = targetConstraints[targetConstraintKey];
       if (targetConstraint) {
-        const { isEnabled, human } = targetConstraint;
-        if (isEnabled) {
+        const { isInvalid, human } = targetConstraint;
+        if (isInvalid) {
           return human;
         }
       }

--- a/packages/smart-forms-renderer/src/interfaces/targetConstraint.interface.ts
+++ b/packages/smart-forms-renderer/src/interfaces/targetConstraint.interface.ts
@@ -1,13 +1,52 @@
 import type { Expression, Extension } from 'fhir/r4';
 
+/**
+ * Represents a FHIR SDC (Structured Data Capture) targetConstraint extension,
+ * used to define custom validation rules for Questionnaire items.
+ *
+ * Each TargetConstraint specifies a unique key, severity, validation expression,
+ * and a human-readable error or warning message. Optionally, it can include
+ * location or linkId references and a flag indicating validation status.
+ */
 export interface TargetConstraint {
+  /**
+   * Unique identifier for this constraint, used for reference and traceability.
+   */
   key: string;
+
+  /**
+   * The severity of the constraint violation.
+   * - 'error': Prevents submission if the constraint fails.
+   * - 'warning': Allows submission but alerts the user.
+   */
   severityCode: 'error' | 'warning';
+
+  /**
+   * The FHIRPath expression that defines the valid condition for the item.
+   * Should evaluate to true when the value is valid.
+   */
   valueExpression: Expression;
+
+  /**
+   * Human-readable message explaining the constraint,
+   * shown to users when the constraint fails.
+   */
   human: string;
+
+  /**
+   * (Optional) FHIRPath location string indicating where the constraint applies.
+   */
   location?: string;
+
+  /**
+   * (Optional) The linkId of the Questionnaire item this constraint applies to.
+   */
   linkId?: string;
-  isEnabled?: boolean;
+
+  /**
+   * (Optional) Indicates if the current value is invalid according to this constraint.
+   */
+  isInvalid?: boolean;
 }
 
 export interface TargetConstraintKey extends Extension {

--- a/packages/smart-forms-renderer/src/stores/questionnaireResponseStore.ts
+++ b/packages/smart-forms-renderer/src/stores/questionnaireResponseStore.ts
@@ -64,10 +64,7 @@ export interface QuestionnaireResponseStoreType {
   invalidItems: Record<string, OperationOutcome>;
   requiredItemsIsHighlighted: boolean;
   responseIsValid: boolean;
-  validateQuestionnaire: (
-    questionnaire: Questionnaire,
-    updatedResponse: QuestionnaireResponse
-  ) => void;
+  validateResponse: (questionnaire: Questionnaire, updatedResponse: QuestionnaireResponse) => void;
   buildSourceResponse: (response: QuestionnaireResponse) => void;
   setUpdatableResponseAsPopulated: (populatedResponse: QuestionnaireResponse) => void;
   updateResponse: (updatedResponse: QuestionnaireResponse, debugType: 'initial' | 'async') => void;
@@ -94,10 +91,7 @@ export const questionnaireResponseStore = createStore<QuestionnaireResponseStore
     invalidItems: {},
     requiredItemsIsHighlighted: false,
     responseIsValid: true,
-    validateQuestionnaire: (
-      questionnaire: Questionnaire,
-      updatedResponse: QuestionnaireResponse
-    ) => {
+    validateResponse: (questionnaire: Questionnaire, updatedResponse: QuestionnaireResponse) => {
       const updatedInvalidItems = validateForm(questionnaire, updatedResponse);
 
       set(() => ({

--- a/packages/smart-forms-renderer/src/stores/rendererStylingStore.ts
+++ b/packages/smart-forms-renderer/src/stores/rendererStylingStore.ts
@@ -164,29 +164,23 @@ export const rendererStylingStore = createStore<RendererStylingStoreType>()((set
   disablePageButtons: false,
   disableTabButtons: false,
   setRendererStyling: (params: RendererStyling) => {
-    set(() => ({
-      readOnlyVisualStyle: params.readOnlyVisualStyle ?? 'disabled',
-      requiredIndicatorPosition: params.requiredIndicatorPosition ?? 'start',
-      itemResponsive: params.itemResponsive ?? {
-        labelBreakpoints: { xs: 12, md: 4 },
-        fieldBreakpoints: { xs: 12, md: 8 },
-        columnGapPixels: 32,
-        rowGapPixels: 4
-      },
-      tabListWidthOrResponsive: params.tabListWidthOrResponsive ?? {
-        tabListBreakpoints: { xs: 12, md: 3, lg: 2.75 },
-        tabContentBreakpoints: { xs: 12, md: 9, lg: 9.25 }
-      },
-      showTabbedFormAt: params.showTabbedFormAt ?? { query: 'up', start: 'md' },
-      textFieldWidth: params.textFieldWidth ?? 320,
-      inputsFlexGrow: params.inputsFlexGrow ?? false,
-      reverseBooleanYesNo: params.reverseBooleanYesNo ?? false,
-      hideClearButton: params.hideClearButton ?? false,
-      hideQuantityComparatorField: params.hideQuantityComparatorField ?? false,
-      enableWhenAsReadOnly: params.enableWhenAsReadOnly ?? false,
-      disablePageCardView: params.disablePageCardView ?? false,
-      disablePageButtons: params.disablePageButtons ?? false,
-      disableTabButtons: params.disableTabButtons ?? false
+    set((state) => ({
+      readOnlyVisualStyle: params.readOnlyVisualStyle ?? state.readOnlyVisualStyle,
+      requiredIndicatorPosition:
+        params.requiredIndicatorPosition ?? state.requiredIndicatorPosition,
+      itemResponsive: params.itemResponsive ?? state.itemResponsive,
+      tabListWidthOrResponsive: params.tabListWidthOrResponsive ?? state.tabListWidthOrResponsive,
+      showTabbedFormAt: params.showTabbedFormAt ?? state.showTabbedFormAt,
+      textFieldWidth: params.textFieldWidth ?? state.textFieldWidth,
+      inputsFlexGrow: params.inputsFlexGrow ?? state.inputsFlexGrow,
+      reverseBooleanYesNo: params.reverseBooleanYesNo ?? state.reverseBooleanYesNo,
+      hideClearButton: params.hideClearButton ?? state.hideClearButton,
+      hideQuantityComparatorField:
+        params.hideQuantityComparatorField ?? state.hideQuantityComparatorField,
+      enableWhenAsReadOnly: params.enableWhenAsReadOnly ?? state.enableWhenAsReadOnly,
+      disablePageCardView: params.disablePageCardView ?? state.disablePageCardView,
+      disablePageButtons: params.disablePageButtons ?? state.disablePageButtons,
+      disableTabButtons: params.disableTabButtons ?? state.disableTabButtons
     }));
   }
 }));

--- a/packages/smart-forms-renderer/src/utils/targetConstraint.ts
+++ b/packages/smart-forms-renderer/src/utils/targetConstraint.ts
@@ -61,7 +61,7 @@ export async function evaluateInitialTargetConstraints(
   fhirPathTerminologyCache = fhirPathEvalResult.fhirPathTerminologyCache;
 
   for (const key in targetConstraints) {
-    const initialValue = targetConstraints[key].isEnabled;
+    const initialValue = targetConstraints[key].isInvalid;
     const expression = targetConstraints[key].valueExpression?.expression;
     if (!expression) {
       continue;
@@ -86,19 +86,19 @@ export async function evaluateInitialTargetConstraints(
       const result = await handleFhirPathResult(fhirPathResult);
 
       // Update targetConstraints if length of result array > 0
-      // Only update when current isEnabled value is different from the result, otherwise it will result in am infinite loop as per #733
+      // Only update when current isInvalid value is different from the result, otherwise it will result in am infinite loop as per #733
       if (result.length > 0 && initialValue !== result[0] && typeof result[0] === 'boolean') {
-        targetConstraints[key].isEnabled = result[0];
+        targetConstraints[key].isInvalid = result[0];
       }
 
-      // Update isEnabled value to false if no result is returned
+      // Update isInvalid value to false if no result is returned
       if (result.length === 0 && initialValue !== false) {
-        targetConstraints[key].isEnabled = false;
+        targetConstraints[key].isInvalid = false;
       }
 
       // handle intersect edge case - evaluate() returns empty array if result is false
       if (expression.includes('intersect') && result.length === 0 && initialValue !== false) {
-        targetConstraints[key].isEnabled = false;
+        targetConstraints[key].isInvalid = false;
       }
 
       // If fhirPathResult is an async terminology call, cache the result
@@ -128,7 +128,7 @@ export async function evaluateTargetConstraints(
 }> {
   let isUpdated = false;
   for (const key in targetConstraints) {
-    const initialValue = targetConstraints[key].isEnabled;
+    const initialValue = targetConstraints[key].isInvalid;
     const expression = targetConstraints[key].valueExpression?.expression;
     if (!expression) {
       continue;
@@ -147,21 +147,21 @@ export async function evaluateTargetConstraints(
       const result = await handleFhirPathResult(fhirPathResult);
 
       // Update targetConstraints if length of result array > 0
-      // Only update when current isEnabled value is different from the result, otherwise it will result in am infinite loop as per #733
+      // Only update when current isInvalid value is different from the result, otherwise it will result in am infinite loop as per #733
       if (result.length > 0 && initialValue !== result[0] && typeof result[0] === 'boolean') {
-        targetConstraints[key].isEnabled = result[0];
+        targetConstraints[key].isInvalid = result[0];
         isUpdated = true;
       }
 
-      // Update isEnabled value to false if no result is returned
+      // Update isInvalid value to false if no result is returned
       if (result.length === 0 && initialValue !== false) {
-        targetConstraints[key].isEnabled = false;
+        targetConstraints[key].isInvalid = false;
         isUpdated = true;
       }
 
       // handle intersect edge case - evaluate() returns empty array if result is false
       if (expression.includes('intersect') && result.length === 0 && initialValue !== false) {
-        targetConstraints[key].isEnabled = false;
+        targetConstraints[key].isInvalid = false;
         isUpdated = true;
       }
 

--- a/packages/smart-forms-renderer/src/utils/validate.ts
+++ b/packages/smart-forms-renderer/src/utils/validate.ts
@@ -108,7 +108,7 @@ export function validateTargetConstraint(): Record<string, OperationOutcome> {
   const targetConstraints = questionnaireStore.getState().targetConstraints;
   const invalidItems: Record<string, OperationOutcome> = {};
   for (const [, targetConstraint] of Object.entries(targetConstraints)) {
-    if (targetConstraint.isEnabled) {
+    if (targetConstraint.isInvalid) {
       const locationExpression = targetConstraint.location
         ? `${targetConstraint.valueExpression.expression ?? 'unknown FHIRPath expression'} at ${
             targetConstraint.location


### PR DESCRIPTION
Resolves #1350.

## Changes: [1.0.0-alpha.73] - 2025-07-08
#### Fixed
- Fix an issue where invalidItems not updated immediately when target constraint is unmet.
- Fix an issue where in the Playground, existing RendererStylingStore state is wiped (and reverts to the default values) when a button that calls `setRendererStylingStore()` is clicked.


