### PR TITLE
Overhaul narrative generation in QuestionnaireResponse.text.div

### DIFF
--- a/CHANGELOG.alpha.md
+++ b/CHANGELOG.alpha.md
@@ -8,6 +8,10 @@ This changelog only includes changes from version 1.0.0-alpha.1 onwards. For sta
 
 WARNING: Alpha releases are not stable and may contain breaking changes. Changes are also most likely to be undocumented.
 
+## [1.0.0-alpha.76] - 2025-07-13
+#### Added
+- Added parseFhirDateTimeToDisplayDateTime() as a library function that parses a FHIR dateTime to a human-readable format.
+
 ## [1.0.0-alpha.75] - 2025-07-10
 #### Added
 - Updated sdc-populate to v4.4.0. Changes as follows:

--- a/apps/demo-renderer-app/package-lock.json
+++ b/apps/demo-renderer-app/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@aehrc/sdc-populate": "^4.0.0",
-        "@aehrc/smart-forms-renderer": "^1.0.0-alpha.73",
+        "@aehrc/smart-forms-renderer": "^1.0.0-alpha.75",
         "@radix-ui/react-collapsible": "^1.1.0",
         "@radix-ui/react-slot": "^1.1.2",
         "@radix-ui/react-switch": "^1.1.0",
@@ -58,9 +58,10 @@
       }
     },
     "node_modules/@aehrc/sdc-populate": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@aehrc/sdc-populate/-/sdc-populate-4.3.1.tgz",
-      "integrity": "sha512-zWqPKX3JcXIMHMunPfPapJUgo1N9Vtq3+T4n3ja4WCNzjyX341KrwOMdUZO/b7KBpJktokvqD949j2zJLpYXvQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@aehrc/sdc-populate/-/sdc-populate-4.4.0.tgz",
+      "integrity": "sha512-BrSzF/57jn70BiQje2urK+bkrRUSyQOJPSj5R5Glbyk1LNuZ9LlhVtuzDOZZRMaLfxYKfZiLgyZvaw0SiDh8qA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "dayjs": "^1.11.10",
         "fhir-sdc-helpers": "^0.1.0",
@@ -71,17 +72,17 @@
       }
     },
     "node_modules/@aehrc/smart-forms-renderer": {
-      "version": "1.0.0-alpha.73",
-      "resolved": "https://registry.npmjs.org/@aehrc/smart-forms-renderer/-/smart-forms-renderer-1.0.0-alpha.73.tgz",
-      "integrity": "sha512-HvG9lGGH1iMcGEYcty4TPvPf3uT5w0lYXxf6irEgOXb9qWADye8TUOFGVDPkwaNNpak6YgCF2VC81JZHDZEoCg==",
+      "version": "1.0.0-alpha.75",
+      "resolved": "https://registry.npmjs.org/@aehrc/smart-forms-renderer/-/smart-forms-renderer-1.0.0-alpha.75.tgz",
+      "integrity": "sha512-BUwQE+0OdT36jX/c5QU8xGTEYZ4XMTMtiwRSDHDuWl3yZ32E5vRrvfdgakqatXYI+EG1m58P9IO9ILfd9089jQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aehrc/sdc-populate": "^4.3.1",
+        "@aehrc/sdc-populate": "^4.4.0",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
-        "@fontsource/inter": "^5.2.5",
+        "@fontsource/inter": "^5.2.6",
         "@fontsource/material-icons": "^5.2.5",
-        "@fontsource/roboto": "^5.2.5",
+        "@fontsource/roboto": "^5.2.6",
         "@iconify/react": "^5.2.1",
         "@mui/icons-material": "^7.1.1",
         "@mui/lab": "^7.0.0-beta.13",
@@ -91,6 +92,7 @@
         "dayjs": "^1.11.13",
         "deep-diff": "^1.0.2",
         "fast-equals": "^5.2.2",
+        "fhir-sdc-helpers": "^0.1.0",
         "fhirclient": "^2.6.0",
         "fhirpath": "3.18.0",
         "html-react-parser": "^4.2.10",
@@ -3419,9 +3421,10 @@
       }
     },
     "node_modules/@fontsource/inter": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.5.tgz",
-      "integrity": "sha512-kbsPKj0S4p44JdYRFiW78Td8Ge2sBVxi/PIBwmih+RpSXUdvS9nbs1HIiuUSPtRMi14CqLEZ/fbk7dj7vni1Sg==",
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.6.tgz",
+      "integrity": "sha512-CZs9S1CrjD0jPwsNy9W6j0BhsmRSQrgwlTNkgQXTsAeDRM42LBRLo3eo9gCzfH4GvV7zpyf78Ozfl773826csw==",
+      "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
       }
@@ -3435,9 +3438,10 @@
       }
     },
     "node_modules/@fontsource/roboto": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-5.2.5.tgz",
-      "integrity": "sha512-70r2UZ0raqLn5W+sPeKhqlf8wGvUXFWlofaDlcbt/S3d06+17gXKr3VNqDODB0I1ASme3dGT5OJj9NABt7OTZQ==",
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-5.2.6.tgz",
+      "integrity": "sha512-hzarG7yAhMoP418smNgfY4fO7UmuUEm5JUtbxCoCcFHT0hOJB+d/qAEyoNjz7YkPU5OjM2LM8rJnW8hfm0JLaA==",
+      "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
       }

--- a/apps/demo-renderer-app/package.json
+++ b/apps/demo-renderer-app/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@aehrc/sdc-populate": "^4.0.0",
-    "@aehrc/smart-forms-renderer": "^1.0.0-alpha.73",
+    "@aehrc/smart-forms-renderer": "^1.0.0-alpha.75",
     "@radix-ui/react-collapsible": "^1.1.0",
     "@radix-ui/react-slot": "^1.1.2",
     "@radix-ui/react-switch": "^1.1.0",

--- a/apps/smart-forms-app/package.json
+++ b/apps/smart-forms-app/package.json
@@ -27,7 +27,7 @@
     "@aehrc/sdc-assemble": "^2.0.1",
     "@aehrc/sdc-populate": "^4.4.0",
     "@aehrc/sdc-template-extract": "^1.0.5",
-    "@aehrc/smart-forms-renderer": "^1.0.0-alpha.75",
+    "@aehrc/smart-forms-renderer": "^1.0.0-alpha.76",
     "@dnd-kit/core": "^6.3.1",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",

--- a/apps/smart-forms-app/src/features/prepopulate/utils/createInputParameters.ts
+++ b/apps/smart-forms-app/src/features/prepopulate/utils/createInputParameters.ts
@@ -31,6 +31,7 @@ import type {
   QuestionnaireLevelXFhirQueryVariable,
   SourceQuery
 } from '../types/populate.interface.ts';
+import { constructName } from '../../smartAppLaunch/utils/launchContext.ts';
 
 function createPatientSubject(questionnaire: Questionnaire, patient: Patient): Reference | null {
   const subjectTypes = questionnaire.subjectType;
@@ -45,7 +46,8 @@ function createPatientSubject(questionnaire: Questionnaire, patient: Patient): R
 
   return {
     type: 'Patient',
-    reference: 'Patient/' + patient.id
+    reference: 'Patient/' + patient.id,
+    display: constructName(patient.name)
   };
 }
 

--- a/apps/smart-forms-app/src/features/preview/utils/preview.ts
+++ b/apps/smart-forms-app/src/features/preview/utils/preview.ts
@@ -13,1096 +13,15 @@ import {
   parseFhirDateToDisplayDate
 } from '@aehrc/smart-forms-renderer';
 
-// Inline GitHub Markdown Light CSS for headings, paragraphs, tables, etc.
-const GITHUB_MARKDOWN_INLINE = `
-/* light */
-.markdown-body {
-  color-scheme: light;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  color: #1f2328;
-  background-color: #ffffff;
-  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
-  font-size: 16px;
-  line-height: 1.5;
-  word-wrap: break-word;
-}
 
-.markdown-body details,
-.markdown-body figcaption,
-.markdown-body figure {
-  display: block;
-}
-
-.markdown-body summary {
-  display: list-item;
-}
-
-.markdown-body [hidden] {
-  display: none !important;
-}
-
-.markdown-body a {
-  background-color: transparent;
-  color: #0969da;
-  text-decoration: none;
-}
-
-.markdown-body abbr[title] {
-  border-bottom: none;
-  -webkit-text-decoration: underline dotted;
-  text-decoration: underline dotted;
-}
-
-.markdown-body b,
-.markdown-body strong {
-  font-weight: 600;
-}
-
-.markdown-body dfn {
-  font-style: italic;
-}
-
-.markdown-body h1 {
-  margin: .67em 0;
-  font-weight: 600;
-  padding-bottom: .3em;
-  font-size: 2em;
-  border-bottom: 1px solid #d1d9e0b3;
-}
-
-.markdown-body mark {
-  background-color: #fff8c5;
-  color: #1f2328;
-}
-
-.markdown-body small {
-  font-size: 90%;
-}
-
-.markdown-body sub,
-.markdown-body sup {
-  font-size: 75%;
-  line-height: 0;
-  position: relative;
-  vertical-align: baseline;
-}
-
-.markdown-body sub {
-  bottom: -0.25em;
-}
-
-.markdown-body sup {
-  top: -0.5em;
-}
-
-.markdown-body img {
-  border-style: none;
-  max-width: 100%;
-  box-sizing: content-box;
-}
-
-.markdown-body code,
-.markdown-body kbd,
-.markdown-body pre,
-.markdown-body samp {
-  font-family: monospace;
-  font-size: 1em;
-}
-
-.markdown-body figure {
-  margin: 1em 2.5rem;
-}
-
-.markdown-body hr {
-  box-sizing: content-box;
-  overflow: hidden;
-  background: transparent;
-  border-bottom: 1px solid #d1d9e0b3;
-  height: .25em;
-  padding: 0;
-  margin: 1.5rem 0;
-  background-color: #d1d9e0;
-  border: 0;
-}
-
-.markdown-body input {
-  font: inherit;
-  margin: 0;
-  overflow: visible;
-  font-family: inherit;
-  font-size: inherit;
-  line-height: inherit;
-}
-
-.markdown-body [type=button],
-.markdown-body [type=reset],
-.markdown-body [type=submit] {
-  -webkit-appearance: button;
-  appearance: button;
-}
-
-.markdown-body [type=checkbox],
-.markdown-body [type=radio] {
-  box-sizing: border-box;
-  padding: 0;
-}
-
-.markdown-body [type=number]::-webkit-inner-spin-button,
-.markdown-body [type=number]::-webkit-outer-spin-button {
-  height: auto;
-}
-
-.markdown-body [type=search]::-webkit-search-cancel-button,
-.markdown-body [type=search]::-webkit-search-decoration {
-  -webkit-appearance: none;
-  appearance: none;
-}
-
-.markdown-body ::-webkit-input-placeholder {
-  color: inherit;
-  opacity: .54;
-}
-
-.markdown-body ::-webkit-file-upload-button {
-  -webkit-appearance: button;
-  appearance: button;
-  font: inherit;
-}
-
-.markdown-body a:hover {
-  text-decoration: underline;
-}
-
-.markdown-body ::placeholder {
-  color: #59636e;
-  opacity: 1;
-}
-
-.markdown-body hr::before {
-  display: table;
-  content: "";
-}
-
-.markdown-body hr::after {
-  display: table;
-  clear: both;
-  content: "";
-}
-
-.markdown-body table {
-  border-spacing: 0;
-  border-collapse: collapse;
-  display: block;
-  width: max-content;
-  max-width: 100%;
-  overflow: auto;
-  font-variant: tabular-nums;
-}
-
-.markdown-body td,
-.markdown-body th {
-  padding: 0;
-}
-
-.markdown-body details summary {
-  cursor: pointer;
-}
-
-.markdown-body a:focus,
-.markdown-body [role=button]:focus,
-.markdown-body input[type=radio]:focus,
-.markdown-body input[type=checkbox]:focus {
-  outline: 2px solid #0969da;
-  outline-offset: -2px;
-  box-shadow: none;
-}
-
-.markdown-body a:focus:not(:focus-visible),
-.markdown-body [role=button]:focus:not(:focus-visible),
-.markdown-body input[type=radio]:focus:not(:focus-visible),
-.markdown-body input[type=checkbox]:focus:not(:focus-visible) {
-  outline: solid 1px transparent;
-}
-
-.markdown-body a:focus-visible,
-.markdown-body [role=button]:focus-visible,
-.markdown-body input[type=radio]:focus-visible,
-.markdown-body input[type=checkbox]:focus-visible {
-  outline: 2px solid #0969da;
-  outline-offset: -2px;
-  box-shadow: none;
-}
-
-.markdown-body a:not([class]):focus,
-.markdown-body a:not([class]):focus-visible,
-.markdown-body input[type=radio]:focus,
-.markdown-body input[type=radio]:focus-visible,
-.markdown-body input[type=checkbox]:focus,
-.markdown-body input[type=checkbox]:focus-visible {
-  outline-offset: 0;
-}
-
-.markdown-body kbd {
-  display: inline-block;
-  padding: 0.25rem;
-  font: 11px ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
-  line-height: 10px;
-  color: #1f2328;
-  vertical-align: middle;
-  background-color: #f6f8fa;
-  border: solid 1px #d1d9e0b3;
-  border-bottom-color: #d1d9e0b3;
-  border-radius: 6px;
-  box-shadow: inset 0 -1px 0 #d1d9e0b3;
-}
-
-.markdown-body h1,
-.markdown-body h2,
-.markdown-body h3,
-.markdown-body h4,
-.markdown-body h5,
-.markdown-body h6 {
-  margin-top: 1.5rem;
-  margin-bottom: 1rem;
-  font-weight: 600;
-  line-height: 1.25;
-}
-
-.markdown-body h2 {
-  font-weight: 600;
-  padding-bottom: .3em;
-  font-size: 1.5em;
-  border-bottom: 1px solid #d1d9e0b3;
-}
-
-.markdown-body h3 {
-  font-weight: 600;
-  font-size: 1.25em;
-}
-
-.markdown-body h4 {
-  font-weight: 600;
-  font-size: 1em;
-}
-
-.markdown-body h5 {
-  font-weight: 600;
-  font-size: .875em;
-}
-
-.markdown-body h6 {
-  font-weight: 600;
-  font-size: .85em;
-  color: #59636e;
-}
-
-.markdown-body p {
-  margin-top: 0;
-  margin-bottom: 10px;
-}
-
-.markdown-body blockquote {
-  margin: 0;
-  padding: 0 1em;
-  color: #59636e;
-  border-left: .25em solid #d1d9e0;
-}
-
-.markdown-body ul,
-.markdown-body ol {
-  margin-top: 0;
-  margin-bottom: 0;
-  padding-left: 2em;
-}
-
-.markdown-body ol ol,
-.markdown-body ul ol {
-  list-style-type: lower-roman;
-}
-
-.markdown-body ul ul ol,
-.markdown-body ul ol ol,
-.markdown-body ol ul ol,
-.markdown-body ol ol ol {
-  list-style-type: lower-alpha;
-}
-
-.markdown-body dd {
-  margin-left: 0;
-}
-
-.markdown-body tt,
-.markdown-body code,
-.markdown-body samp {
-  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
-  font-size: 12px;
-}
-
-.markdown-body pre {
-  margin-top: 0;
-  margin-bottom: 0;
-  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
-  font-size: 12px;
-  word-wrap: normal;
-}
-
-.markdown-body .octicon {
-  display: inline-block;
-  overflow: visible !important;
-  vertical-align: text-bottom;
-  fill: currentColor;
-}
-
-.markdown-body input::-webkit-outer-spin-button,
-.markdown-body input::-webkit-inner-spin-button {
-  margin: 0;
-  appearance: none;
-}
-
-.markdown-body .mr-2 {
-  margin-right: 0.5rem !important;
-}
-
-.markdown-body::before {
-  display: table;
-  content: "";
-}
-
-.markdown-body::after {
-  display: table;
-  clear: both;
-  content: "";
-}
-
-.markdown-body>*:first-child {
-  margin-top: 0 !important;
-}
-
-.markdown-body>*:last-child {
-  margin-bottom: 0 !important;
-}
-
-.markdown-body a:not([href]) {
-  color: inherit;
-  text-decoration: none;
-}
-
-.markdown-body .absent {
-  color: #d1242f;
-}
-
-.markdown-body .anchor {
-  float: left;
-  padding-right: 0.25rem;
-  margin-left: -20px;
-  line-height: 1;
-}
-
-.markdown-body .anchor:focus {
-  outline: none;
-}
-
-.markdown-body p,
-.markdown-body blockquote,
-.markdown-body ul,
-.markdown-body ol,
-.markdown-body dl,
-.markdown-body table,
-.markdown-body pre,
-.markdown-body details {
-  margin-top: 0;
-  margin-bottom: 1rem;
-  font-weight: 400;
-}
-
-.markdown-body blockquote>:first-child {
-  margin-top: 0;
-}
-
-.markdown-body blockquote>:last-child {
-  margin-bottom: 0;
-}
-
-.markdown-body h1 .octicon-link,
-.markdown-body h2 .octicon-link,
-.markdown-body h3 .octicon-link,
-.markdown-body h4 .octicon-link,
-.markdown-body h5 .octicon-link,
-.markdown-body h6 .octicon-link {
-  color: #1f2328;
-  vertical-align: middle;
-  visibility: hidden;
-}
-
-.markdown-body h1:hover .anchor,
-.markdown-body h2:hover .anchor,
-.markdown-body h3:hover .anchor,
-.markdown-body h4:hover .anchor,
-.markdown-body h5:hover .anchor,
-.markdown-body h6:hover .anchor {
-  text-decoration: none;
-}
-
-.markdown-body h1:hover .anchor .octicon-link,
-.markdown-body h2:hover .anchor .octicon-link,
-.markdown-body h3:hover .anchor .octicon-link,
-.markdown-body h4:hover .anchor .octicon-link,
-.markdown-body h5:hover .anchor .octicon-link,
-.markdown-body h6:hover .anchor .octicon-link {
-  visibility: visible;
-}
-
-.markdown-body h1 tt,
-.markdown-body h1 code,
-.markdown-body h2 tt,
-.markdown-body h2 code,
-.markdown-body h3 tt,
-.markdown-body h3 code,
-.markdown-body h4 tt,
-.markdown-body h4 code,
-.markdown-body h5 tt,
-.markdown-body h5 code,
-.markdown-body h6 tt,
-.markdown-body h6 code {
-  padding: 0 .2em;
-  font-size: inherit;
-}
-
-.markdown-body summary h1,
-.markdown-body summary h2,
-.markdown-body summary h3,
-.markdown-body summary h4,
-.markdown-body summary h5,
-.markdown-body summary h6 {
-  display: inline-block;
-}
-
-.markdown-body summary h1 .anchor,
-.markdown-body summary h2 .anchor,
-.markdown-body summary h3 .anchor,
-.markdown-body summary h4 .anchor,
-.markdown-body summary h5 .anchor,
-.markdown-body summary h6 .anchor {
-  margin-left: -40px;
-}
-
-.markdown-body summary h1,
-.markdown-body summary h2 {
-  padding-bottom: 0;
-  border-bottom: 0;
-}
-
-.markdown-body ul.no-list,
-.markdown-body ol.no-list {
-  padding: 0;
-  list-style-type: none;
-}
-
-.markdown-body ol[type="a s"] {
-  list-style-type: lower-alpha;
-}
-
-.markdown-body ol[type="A s"] {
-  list-style-type: upper-alpha;
-}
-
-.markdown-body ol[type="i s"] {
-  list-style-type: lower-roman;
-}
-
-.markdown-body ol[type="I s"] {
-  list-style-type: upper-roman;
-}
-
-.markdown-body ol[type="1"] {
-  list-style-type: decimal;
-}
-
-.markdown-body div>ol:not([type]) {
-  list-style-type: decimal;
-}
-
-.markdown-body ul ul,
-.markdown-body ul ol,
-.markdown-body ol ol,
-.markdown-body ol ul {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.markdown-body li>p {
-  margin-top: 1rem;
-}
-
-.markdown-body li+li {
-  margin-top: .25em;
-}
-
-.markdown-body dl {
-  padding: 0;
-}
-
-.markdown-body dl dt {
-  padding: 0;
-  margin-top: 1rem;
-  font-size: 1em;
-  font-style: italic;
-  font-weight: 600;
-}
-
-.markdown-body dl dd {
-  padding: 0 1rem;
-  margin-bottom: 1rem;
-}
-
-.markdown-body table th {
-  font-weight: 600;
-}
-
-.markdown-body table th,
-.markdown-body table td {
-  padding: 6px 13px;
-  border: 1px solid #d1d9e0;
-}
-
-.markdown-body table td>:last-child {
-  margin-bottom: 0;
-}
-
-.markdown-body table tr {
-  background-color: #ffffff;
-  border-top: 1px solid #d1d9e0b3;
-}
-
-.markdown-body table tr:nth-child(2n) {
-  background-color: #f6f8fa;
-}
-
-.markdown-body table img {
-  background-color: transparent;
-}
-
-.markdown-body img[align=right] {
-  padding-left: 20px;
-}
-
-.markdown-body img[align=left] {
-  padding-right: 20px;
-}
-
-.markdown-body .emoji {
-  max-width: none;
-  vertical-align: text-top;
-  background-color: transparent;
-}
-
-.markdown-body span.frame {
-  display: block;
-  overflow: hidden;
-}
-
-.markdown-body span.frame>span {
-  display: block;
-  float: left;
-  width: auto;
-  padding: 7px;
-  margin: 13px 0 0;
-  overflow: hidden;
-  border: 1px solid #d1d9e0;
-}
-
-.markdown-body span.frame span img {
-  display: block;
-  float: left;
-}
-
-.markdown-body span.frame span span {
-  display: block;
-  padding: 5px 0 0;
-  clear: both;
-  color: #1f2328;
-}
-
-.markdown-body span.align-center {
-  display: block;
-  overflow: hidden;
-  clear: both;
-}
-
-.markdown-body span.align-center>span {
-  display: block;
-  margin: 13px auto 0;
-  overflow: hidden;
-  text-align: center;
-}
-
-.markdown-body span.align-center span img {
-  margin: 0 auto;
-  text-align: center;
-}
-
-.markdown-body span.align-right {
-  display: block;
-  overflow: hidden;
-  clear: both;
-}
-
-.markdown-body span.align-right>span {
-  display: block;
-  margin: 13px 0 0;
-  overflow: hidden;
-  text-align: right;
-}
-
-.markdown-body span.align-right span img {
-  margin: 0;
-  text-align: right;
-}
-
-.markdown-body span.float-left {
-  display: block;
-  float: left;
-  margin-right: 13px;
-  overflow: hidden;
-}
-
-.markdown-body span.float-left span {
-  margin: 13px 0 0;
-}
-
-.markdown-body span.float-right {
-  display: block;
-  float: right;
-  margin-left: 13px;
-  overflow: hidden;
-}
-
-.markdown-body span.float-right>span {
-  display: block;
-  margin: 13px auto 0;
-  overflow: hidden;
-  text-align: right;
-}
-
-.markdown-body code,
-.markdown-body tt {
-  padding: .2em .4em;
-  margin: 0;
-  font-size: 85%;
-  white-space: break-spaces;
-  background-color: #818b981f;
-  border-radius: 6px;
-}
-
-.markdown-body code br,
-.markdown-body tt br {
-  display: none;
-}
-
-.markdown-body del code {
-  text-decoration: inherit;
-}
-
-.markdown-body samp {
-  font-size: 85%;
-}
-
-.markdown-body pre code {
-  font-size: 100%;
-}
-
-.markdown-body pre>code {
-  padding: 0;
-  margin: 0;
-  word-break: normal;
-  white-space: pre;
-  background: transparent;
-  border: 0;
-}
-
-.markdown-body .highlight {
-  margin-bottom: 1rem;
-}
-
-.markdown-body .highlight pre {
-  margin-bottom: 0;
-  word-break: normal;
-}
-
-.markdown-body .highlight pre,
-.markdown-body pre {
-  padding: 1rem;
-  overflow: auto;
-  font-size: 85%;
-  line-height: 1.45;
-  color: #1f2328;
-  background-color: #f6f8fa;
-  border-radius: 6px;
-}
-
-.markdown-body pre code,
-.markdown-body pre tt {
-  display: inline;
-  max-width: auto;
-  padding: 0;
-  margin: 0;
-  overflow: visible;
-  line-height: inherit;
-  word-wrap: normal;
-  background-color: transparent;
-  border: 0;
-}
-
-.markdown-body .csv-data td,
-.markdown-body .csv-data th {
-  padding: 5px;
-  overflow: hidden;
-  font-size: 12px;
-  line-height: 1;
-  text-align: left;
-  white-space: nowrap;
-}
-
-.markdown-body .csv-data .blob-num {
-  padding: 10px 0.5rem 9px;
-  text-align: right;
-  background: #ffffff;
-  border: 0;
-}
-
-.markdown-body .csv-data tr {
-  border-top: 0;
-}
-
-.markdown-body .csv-data th {
-  font-weight: 600;
-  background: #f6f8fa;
-  border-top: 0;
-}
-
-.markdown-body [data-footnote-ref]::before {
-  content: "[";
-}
-
-.markdown-body [data-footnote-ref]::after {
-  content: "]";
-}
-
-.markdown-body .footnotes {
-  font-size: 12px;
-  color: #59636e;
-  border-top: 1px solid #d1d9e0;
-}
-
-.markdown-body .footnotes ol {
-  padding-left: 1rem;
-}
-
-.markdown-body .footnotes ol ul {
-  display: inline-block;
-  padding-left: 1rem;
-  margin-top: 1rem;
-}
-
-.markdown-body .footnotes li {
-  position: relative;
-}
-
-.markdown-body .footnotes li:target::before {
-  position: absolute;
-  top: calc(0.5rem*-1);
-  right: calc(0.5rem*-1);
-  bottom: calc(0.5rem*-1);
-  left: calc(1.5rem*-1);
-  pointer-events: none;
-  content: "";
-  border: 2px solid #0969da;
-  border-radius: 6px;
-}
-
-.markdown-body .footnotes li:target {
-  color: #1f2328;
-}
-
-.markdown-body .footnotes .data-footnote-backref g-emoji {
-  font-family: monospace;
-}
-
-.markdown-body body:has(:modal) {
-  padding-right: var(--dialog-scrollgutter) !important;
-}
-
-.markdown-body .pl-c {
-  color: #59636e;
-}
-
-.markdown-body .pl-c1,
-.markdown-body .pl-s .pl-v {
-  color: #0550ae;
-}
-
-.markdown-body .pl-e,
-.markdown-body .pl-en {
-  color: #6639ba;
-}
-
-.markdown-body .pl-smi,
-.markdown-body .pl-s .pl-s1 {
-  color: #1f2328;
-}
-
-.markdown-body .pl-ent {
-  color: #0550ae;
-}
-
-.markdown-body .pl-k {
-  color: #cf222e;
-}
-
-.markdown-body .pl-s,
-.markdown-body .pl-pds,
-.markdown-body .pl-s .pl-pse .pl-s1,
-.markdown-body .pl-sr,
-.markdown-body .pl-sr .pl-cce,
-.markdown-body .pl-sr .pl-sre,
-.markdown-body .pl-sr .pl-sra {
-  color: #0a3069;
-}
-
-.markdown-body .pl-v,
-.markdown-body .pl-smw {
-  color: #953800;
-}
-
-.markdown-body .pl-bu {
-  color: #82071e;
-}
-
-.markdown-body .pl-ii {
-  color: #f6f8fa;
-  background-color: #82071e;
-}
-
-.markdown-body .pl-c2 {
-  color: #f6f8fa;
-  background-color: #cf222e;
-}
-
-.markdown-body .pl-sr .pl-cce {
-  font-weight: bold;
-  color: #116329;
-}
-
-.markdown-body .pl-ml {
-  color: #3b2300;
-}
-
-.markdown-body .pl-mh,
-.markdown-body .pl-mh .pl-en,
-.markdown-body .pl-ms {
-  font-weight: bold;
-  color: #0550ae;
-}
-
-.markdown-body .pl-mi {
-  font-style: italic;
-  color: #1f2328;
-}
-
-.markdown-body .pl-mb {
-  font-weight: bold;
-  color: #1f2328;
-}
-
-.markdown-body .pl-md {
-  color: #82071e;
-  background-color: #ffebe9;
-}
-
-.markdown-body .pl-mi1 {
-  color: #116329;
-  background-color: #dafbe1;
-}
-
-.markdown-body .pl-mc {
-  color: #953800;
-  background-color: #ffd8b5;
-}
-
-.markdown-body .pl-mi2 {
-  color: #d1d9e0;
-  background-color: #0550ae;
-}
-
-.markdown-body .pl-mdr {
-  font-weight: bold;
-  color: #8250df;
-}
-
-.markdown-body .pl-ba {
-  color: #59636e;
-}
-
-.markdown-body .pl-sg {
-  color: #818b98;
-}
-
-.markdown-body .pl-corl {
-  text-decoration: underline;
-  color: #0a3069;
-}
-
-.markdown-body [role=button]:focus:not(:focus-visible),
-.markdown-body [role=tabpanel][tabindex="0"]:focus:not(:focus-visible),
-.markdown-body button:focus:not(:focus-visible),
-.markdown-body summary:focus:not(:focus-visible),
-.markdown-body a:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.markdown-body [tabindex="0"]:focus:not(:focus-visible),
-.markdown-body details-dialog:focus:not(:focus-visible) {
-  outline: none;
-}
-
-.markdown-body g-emoji {
-  display: inline-block;
-  min-width: 1ch;
-  font-family: "Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-  font-size: 1em;
-  font-style: normal !important;
-  font-weight: 400;
-  line-height: 1;
-  vertical-align: -0.075em;
-}
-
-.markdown-body g-emoji img {
-  width: 1em;
-  height: 1em;
-}
-
-.markdown-body .task-list-item {
-  list-style-type: none;
-}
-
-.markdown-body .task-list-item label {
-  font-weight: 400;
-}
-
-.markdown-body .task-list-item.enabled label {
-  cursor: pointer;
-}
-
-.markdown-body .task-list-item+.task-list-item {
-  margin-top: 0.25rem;
-}
-
-.markdown-body .task-list-item .handle {
-  display: none;
-}
-
-.markdown-body .task-list-item-checkbox {
-  margin: 0 .2em .25em -1.4em;
-  vertical-align: middle;
-}
-
-.markdown-body ul:dir(rtl) .task-list-item-checkbox {
-  margin: 0 -1.6em .25em .2em;
-}
-
-.markdown-body ol:dir(rtl) .task-list-item-checkbox {
-  margin: 0 -1.6em .25em .2em;
-}
-
-.markdown-body .contains-task-list:hover .task-list-item-convert-container,
-.markdown-body .contains-task-list:focus-within .task-list-item-convert-container {
-  display: block;
-  width: auto;
-  height: 24px;
-  overflow: visible;
-  clip: auto;
-}
-
-.markdown-body ::-webkit-calendar-picker-indicator {
-  filter: invert(50%);
-}
-
-.markdown-body .markdown-alert {
-  padding: 0.5rem 1rem;
-  margin-bottom: 1rem;
-  color: inherit;
-  border-left: .25em solid #d1d9e0;
-}
-
-.markdown-body .markdown-alert>:first-child {
-  margin-top: 0;
-}
-
-.markdown-body .markdown-alert>:last-child {
-  margin-bottom: 0;
-}
-
-.markdown-body .markdown-alert .markdown-alert-title {
-  display: flex;
-  font-weight: 500;
-  align-items: center;
-  line-height: 1;
-}
-
-.markdown-body .markdown-alert.markdown-alert-note {
-  border-left-color: #0969da;
-}
-
-.markdown-body .markdown-alert.markdown-alert-note .markdown-alert-title {
-  color: #0969da;
-}
-
-.markdown-body .markdown-alert.markdown-alert-important {
-  border-left-color: #8250df;
-}
-
-.markdown-body .markdown-alert.markdown-alert-important .markdown-alert-title {
-  color: #8250df;
-}
-
-.markdown-body .markdown-alert.markdown-alert-warning {
-  border-left-color: #9a6700;
-}
-
-.markdown-body .markdown-alert.markdown-alert-warning .markdown-alert-title {
-  color: #9a6700;
-}
-
-.markdown-body .markdown-alert.markdown-alert-tip {
-  border-left-color: #1a7f37;
-}
-
-.markdown-body .markdown-alert.markdown-alert-tip .markdown-alert-title {
-  color: #1a7f37;
-}
-
-.markdown-body .markdown-alert.markdown-alert-caution {
-  border-left-color: #cf222e;
-}
-
-.markdown-body .markdown-alert.markdown-alert-caution .markdown-alert-title {
-  color: #d1242f;
-}
-
-.markdown-body>*:first-child>.heading-element:first-child {
-  margin-top: 0 !important;
-}
-
-.markdown-body .highlight pre:has(+.zeroclipboard-container) {
-  min-height: 52px;
-}
-
-
-`;
-
+/**
+ * Converts a FHIR Questionnaire and corresponding QuestionnaireResponse into styled XHTML using GitHub-flavored Markdown styles applied as inline styles.
+ * GitHub-flavored Markdown styles lifted from https://github.com/sindresorhus/github-markdown-css/blob/main/github-markdown-light.css
+ *
+ * @param {Questionnaire} questionnaire - The FHIR Questionnaire resource, used for structure and display text.
+ * @param {QuestionnaireResponse} questionnaireResponse - The response data to populate into the HTML.
+ * @returns {string} An XHTML string containing the rendered questionnaire response in styled HTML format.
+ */
 export function qrToHTML(
   questionnaire: Questionnaire,
   questionnaireResponse: QuestionnaireResponse
@@ -1116,13 +35,12 @@ export function qrToHTML(
     return '';
   }
 
-  let html = `<style>${GITHUB_MARKDOWN_INLINE}</style>`;
-  html += `<article class="markdown-body">`;
-
-  // add the map and iterate qItems instead of QRItems
+  let html = `<article class="markdown-body" style="color-scheme: light; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; margin: 0; color: #1f2328; background-color: #ffffff; font-family: -apple-system,BlinkMacSystemFont,'Segoe UI','Noto Sans',Helvetica,Arial,sans-serif,'Apple Color Emoji','Segoe UI Emoji'; font-size: 16px; line-height: 1.5; word-wrap: break-word;">`;
 
   // Title as h1
-  html += `<h1>${he.encode(questionnaire.title ?? 'Questionnaire Response')}</h1>`;
+  html += `<h1 style="margin-top: 0; margin-bottom: .67em; font-weight: 600; padding-bottom: .3em; font-size: 2em; border-bottom: 1px solid #d1d9e0b3;">
+  ${he.encode(questionnaire.title ?? 'Questionnaire Response')}
+  </h1>`;
 
   // Add Patient/Author/Authored block
   html += renderMetadataHtml(questionnaireResponse);
@@ -1150,9 +68,15 @@ export function qrToHTML(
   }
 
   html += `</article>`;
+
+  // Wrap in a div with XHTML namespace
   return `<div xmlns="http://www.w3.org/1999/xhtml">${html}</div>`;
 }
 
+/**
+ * Renders metadata information from a QuestionnaireResponse into HTML.
+ * This includes Patient, Author, and Date Authored information from subject.display, author.display, and authored fields.
+ */
 export function renderMetadataHtml(questionnaireResponse: QuestionnaireResponse): string {
   const lines: string[] = [];
 
@@ -1160,7 +84,7 @@ export function renderMetadataHtml(questionnaireResponse: QuestionnaireResponse)
   if (questionnaireResponse.subject) {
     const subjectDisplay = questionnaireResponse.subject.display;
     if (subjectDisplay) {
-      lines.push(`<strong>Patient</strong>: ${he.encode(subjectDisplay)}`);
+      lines.push(`<strong style="font-weight: 600;">Patient</strong>: ${he.encode(subjectDisplay)}`);
     }
   }
 
@@ -1168,7 +92,7 @@ export function renderMetadataHtml(questionnaireResponse: QuestionnaireResponse)
   if (questionnaireResponse.author) {
     const authorDisplay = questionnaireResponse.author.display;
     if (authorDisplay) {
-      lines.push(`<strong>Author</strong>: ${he.encode(authorDisplay)}`);
+      lines.push(`<strong style="font-weight: 600;">Author</strong>: ${he.encode(authorDisplay)}`);
     }
   }
 
@@ -1179,16 +103,26 @@ export function renderMetadataHtml(questionnaireResponse: QuestionnaireResponse)
     );
     const authoredDisplay = !dateParseFail ? displayDate : questionnaireResponse.authored;
 
-    lines.push(`<strong>Date Authored</strong>: ${he.encode(authoredDisplay)}`);
+    lines.push(`<strong style="font-weight: 600;">Date Authored</strong>: ${he.encode(authoredDisplay)}`);
   }
 
   if (lines.length === 0) {
     return '';
   }
 
-  return `<p>${lines.join('<br />')}</p>`;
+  return `<p style="margin-top: 0; margin-bottom: 1rem; font-weight: 400;">${lines.join('<br />')}</p>`;
 }
 
+/**
+ * Recursively renders a QuestionnaireItem and its corresponding QuestionnaireResponseItem(s) into HTML,
+ * including groups, answers, and nested items, using inline styles that match GitHub Markdown.
+ *
+ * @param {QuestionnaireItem} qItem - The Questionnaire item structure.
+ * @param {QuestionnaireResponseItem | QuestionnaireResponseItem[] | null} qrItemOrItems - The matching response item(s).
+ * @param {number} groupNestLevel - Nesting depth to determine heading levels.
+ * @param {string} html - Current accumulated HTML output to append to.
+ * @returns {string} Updated HTML string including the rendered item.
+ */
 function renderItemHtmlRecursive(
   qItem: QuestionnaireItem,
   qrItemOrItems: QuestionnaireResponseItem | QuestionnaireResponseItem[] | null,
@@ -1248,15 +182,16 @@ function renderItemHtmlRecursive(
     const label = he.encode(qrItem.text ?? '');
 
     if (qItem.repeats && qItem.type !== 'group') {
-      html += `<p><strong>${label}</strong></p>`;
-      html += `<ul>`;
+      // TODO Add margin below (later) when changing styles to inline
+      html += `<div style="margin-bottom: 0.5em;"><strong style="font-weight: 600;">${label}</strong></div>`;
+      html += `<ul style="margin-top:0;margin-bottom:1rem;font-weight:400;padding-left:2em;">`;
       for (const a of qrItem.answer) {
         html += `<li>${he.encode(answerToString(a))}</li>`;
       }
       html += `</ul>`;
     } else {
       html += qrItem.answer
-        .map((a) => `<p><strong>${label}</strong><br/>${he.encode(answerToString(a))}</p>`)
+        .map((a) => `<p style="margin-top: 0; margin-bottom: 1rem; font-weight: 400;"><strong style="font-weight: 600;">${label}</strong><br/>${he.encode(answerToString(a))}</p>`)
         .join('');
     }
   }
@@ -1264,6 +199,13 @@ function renderItemHtmlRecursive(
   return html;
 }
 
+/**
+ * Renders an inline-styled HTML heading tag (`<h2>` to `<h4>`) for a group QuestionnaireItem, based on its nesting level.
+ *
+ * @param {QuestionnaireItem} qItem - The group Questionnaire item to render.
+ * @param {number} nestedLevel - The depth of the group in the item tree.
+ * @returns {string} An HTML heading tag string or empty string if level is 0 or no text is present.
+ */
 function getGroupHeading(qItem: QuestionnaireItem, nestedLevel: number): string {
   // if item is tab-container, it will only have a nestedLevel of 0, hence do not render a heading
   // <h1> is really only reserved for the main title of the Questionnaire
@@ -1271,29 +213,41 @@ function getGroupHeading(qItem: QuestionnaireItem, nestedLevel: number): string 
     return '';
   }
 
-  const headingText = qItem.text ?? '';
+  if (!qItem.text) {
+    return '';
+  }
+
+  const headingText = qItem.text;
 
   let headingTag: string;
+  let inlineStyle = '';
   switch (nestedLevel) {
-    case 0:
-      headingTag = 'h1';
-      break;
     case 1:
       headingTag = 'h2';
+      inlineStyle = 'margin-top:1.5rem;margin-bottom:1rem;font-weight:600;line-height:1.25;padding-bottom:.3em;font-size:1.5em;border-bottom:1px solid #d1d9e0b3;';
       break;
     case 2:
       headingTag = 'h3';
+      inlineStyle = 'margin-top:1.5rem;margin-bottom:1rem;font-weight:600;line-height:1.25;font-size:1.25em;';
       break;
     case 3:
     case 4:
     default:
       headingTag = 'h4';
+      inlineStyle = 'margin-top:1.5rem;margin-bottom:1rem;font-weight:600;line-height:1.25;font-size:1em;';
       break;
   }
 
-  return `<${headingTag}>${he.encode(headingText)}</${headingTag}>`;
+  return `<${headingTag} style="${inlineStyle}">${he.encode(headingText)}</${headingTag}>`;
 }
 
+/**
+ * Renders a repeated group of QuestionnaireResponseItems as an HTML table, applying GitHub-flavored Markdown inline styles.
+ *
+ * @param {QuestionnaireItem} qItem - The repeating group Questionnaire item with child items.
+ * @param {QuestionnaireResponseItem[]} qrItems - Array of repeated response items for the group.
+ * @returns {string} HTML string of the rendered table.
+ */
 function renderRepeatGroupHtml(
   qItem: QuestionnaireItem,
   qrItems: QuestionnaireResponseItem[]
@@ -1306,13 +260,16 @@ function renderRepeatGroupHtml(
   const headers = qItem.item?.map((child) => he.encode(child.text ?? '')) ?? [];
 
   // Render headers
-  let html = `<table><thead><tr>`;
+  let html = `<table style="margin-top:0;margin-bottom:1rem;font-weight:400;border-spacing:0;border-collapse:collapse;display:block;width:max-content;max-width:100%;overflow:auto;font-variant:tabular-nums;">`;
+  html += `<thead><tr style="background-color:#f6f8fa;border-top:1px solid #d1d9e0b3;">`;
+  
   for (const header of headers) {
-    html += `<th>${header}</th>`;
+    html += `<th style="padding:6px 13px;border:1px solid #d1d9e0;font-weight:600;">${header}</th>`;
   }
   html += `</tr></thead>`;
 
   // Render rows for each repeated item
+  html += `<tbody>`;
   for (const qrItemInstance of qrItems) {
     const childQItems = qItem.item ?? [];
     const childQRItems = qrItemInstance.item ?? [];
@@ -1320,19 +277,19 @@ function renderRepeatGroupHtml(
     const indexMap = mapQItemsIndex(qItem);
     const qrItemsByIndex = getQrItemsIndex(childQItems, childQRItems, indexMap);
 
-    html += `<tr>`;
+    html += `<tr style="background-color:#fff;border-top:1px solid #d1d9e0b3;">`;
     for (const [index] of childQItems.entries()) {
       const childQRItem = qrItemsByIndex[index];
 
       // Do not support repeat group nesting for now
       if (Array.isArray(childQRItem)) {
-        html += `<td colspan="${childQRItem.length}">Nested repeat groups not supported in narrative</td>`;
+        html += `<td style="padding:6px 13px;border:1px solid #d1d9e0;" colspan="${childQRItem.length}">Nested repeat groups not supported in narrative</td>`;
         continue;
       }
 
       const answer = childQRItem?.answer?.[0];
       const value = answer ? answerToString(answer) : '';
-      html += `<td>${he.encode(value)}</td>`;
+      html += `<td style="padding:6px 13px;border:1px solid #d1d9e0;">${he.encode(value)}</td>`;
     }
     html += `</tr>`;
   }
@@ -1342,6 +299,12 @@ function renderRepeatGroupHtml(
   return html;
 }
 
+/**
+ * Converts a QuestionnaireResponseItemAnswer into a displayable string value.
+ *
+ * @param {QuestionnaireResponseItemAnswer} answer - The answer object to convert.
+ * @returns {string} A string representation of the answer value.
+ */
 function answerToString(answer: QuestionnaireResponseItemAnswer): string {
   if (answer.valueBoolean !== undefined) {
     return answer.valueBoolean ? 'Yes' : 'No';

--- a/apps/smart-forms-app/src/features/preview/utils/preview.ts
+++ b/apps/smart-forms-app/src/features/preview/utils/preview.ts
@@ -10,7 +10,8 @@ import {
   getQrItemsIndex,
   isSpecificItemControl,
   mapQItemsIndex,
-  parseFhirDateToDisplayDate
+  parseFhirDateToDisplayDate,
+  parseFhirDateTimeToDisplayDateTime
 } from '@aehrc/smart-forms-renderer';
 
 
@@ -320,15 +321,23 @@ function answerToString(answer: QuestionnaireResponseItemAnswer): string {
 
   if (answer.valueDate) {
     const { displayDate, dateParseFail } = parseFhirDateToDisplayDate(answer.valueDate);
+
     if (!dateParseFail) {
       return `${displayDate}`;
     }
 
+    // Fallback to raw valueDate if parsing fails
     return answer.valueDate;
   }
 
   if (answer.valueDateTime) {
-    // TODO date time item - parse to fhirDateTime
+    const { displayDateTime, dateParseFail } = parseFhirDateTimeToDisplayDateTime(answer.valueDateTime);
+
+    if (!dateParseFail) {
+      return `${displayDateTime}`;
+    }
+
+    // Fallback to raw valueDateTime if parsing fails
     return answer.valueDateTime;
   }
 

--- a/apps/smart-forms-app/src/features/preview/utils/preview.ts
+++ b/apps/smart-forms-app/src/features/preview/utils/preview.ts
@@ -1,158 +1,1350 @@
-/*
- * Copyright 2024 Commonwealth Scientific and Industrial Research
- * Organisation (CSIRO) ABN 41 687 119 230.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import type {
   Questionnaire,
+  QuestionnaireItem,
   QuestionnaireResponse,
   QuestionnaireResponseItem,
   QuestionnaireResponseItemAnswer
 } from 'fhir/r4';
 import he from 'he';
-import { parseFhirDateToDisplayDate } from '@aehrc/smart-forms-renderer';
+import {
+  getQrItemsIndex,
+  isSpecificItemControl,
+  mapQItemsIndex,
+  parseFhirDateToDisplayDate
+} from '@aehrc/smart-forms-renderer';
+
+// Inline GitHub Markdown Light CSS for headings, paragraphs, tables, etc.
+const GITHUB_MARKDOWN_INLINE = `
+/* light */
+.markdown-body {
+  color-scheme: light;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  color: #1f2328;
+  background-color: #ffffff;
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
+  font-size: 16px;
+  line-height: 1.5;
+  word-wrap: break-word;
+}
+
+.markdown-body details,
+.markdown-body figcaption,
+.markdown-body figure {
+  display: block;
+}
+
+.markdown-body summary {
+  display: list-item;
+}
+
+.markdown-body [hidden] {
+  display: none !important;
+}
+
+.markdown-body a {
+  background-color: transparent;
+  color: #0969da;
+  text-decoration: none;
+}
+
+.markdown-body abbr[title] {
+  border-bottom: none;
+  -webkit-text-decoration: underline dotted;
+  text-decoration: underline dotted;
+}
+
+.markdown-body b,
+.markdown-body strong {
+  font-weight: 600;
+}
+
+.markdown-body dfn {
+  font-style: italic;
+}
+
+.markdown-body h1 {
+  margin: .67em 0;
+  font-weight: 600;
+  padding-bottom: .3em;
+  font-size: 2em;
+  border-bottom: 1px solid #d1d9e0b3;
+}
+
+.markdown-body mark {
+  background-color: #fff8c5;
+  color: #1f2328;
+}
+
+.markdown-body small {
+  font-size: 90%;
+}
+
+.markdown-body sub,
+.markdown-body sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+.markdown-body sub {
+  bottom: -0.25em;
+}
+
+.markdown-body sup {
+  top: -0.5em;
+}
+
+.markdown-body img {
+  border-style: none;
+  max-width: 100%;
+  box-sizing: content-box;
+}
+
+.markdown-body code,
+.markdown-body kbd,
+.markdown-body pre,
+.markdown-body samp {
+  font-family: monospace;
+  font-size: 1em;
+}
+
+.markdown-body figure {
+  margin: 1em 2.5rem;
+}
+
+.markdown-body hr {
+  box-sizing: content-box;
+  overflow: hidden;
+  background: transparent;
+  border-bottom: 1px solid #d1d9e0b3;
+  height: .25em;
+  padding: 0;
+  margin: 1.5rem 0;
+  background-color: #d1d9e0;
+  border: 0;
+}
+
+.markdown-body input {
+  font: inherit;
+  margin: 0;
+  overflow: visible;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.markdown-body [type=button],
+.markdown-body [type=reset],
+.markdown-body [type=submit] {
+  -webkit-appearance: button;
+  appearance: button;
+}
+
+.markdown-body [type=checkbox],
+.markdown-body [type=radio] {
+  box-sizing: border-box;
+  padding: 0;
+}
+
+.markdown-body [type=number]::-webkit-inner-spin-button,
+.markdown-body [type=number]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+.markdown-body [type=search]::-webkit-search-cancel-button,
+.markdown-body [type=search]::-webkit-search-decoration {
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.markdown-body ::-webkit-input-placeholder {
+  color: inherit;
+  opacity: .54;
+}
+
+.markdown-body ::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  appearance: button;
+  font: inherit;
+}
+
+.markdown-body a:hover {
+  text-decoration: underline;
+}
+
+.markdown-body ::placeholder {
+  color: #59636e;
+  opacity: 1;
+}
+
+.markdown-body hr::before {
+  display: table;
+  content: "";
+}
+
+.markdown-body hr::after {
+  display: table;
+  clear: both;
+  content: "";
+}
+
+.markdown-body table {
+  border-spacing: 0;
+  border-collapse: collapse;
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  overflow: auto;
+  font-variant: tabular-nums;
+}
+
+.markdown-body td,
+.markdown-body th {
+  padding: 0;
+}
+
+.markdown-body details summary {
+  cursor: pointer;
+}
+
+.markdown-body a:focus,
+.markdown-body [role=button]:focus,
+.markdown-body input[type=radio]:focus,
+.markdown-body input[type=checkbox]:focus {
+  outline: 2px solid #0969da;
+  outline-offset: -2px;
+  box-shadow: none;
+}
+
+.markdown-body a:focus:not(:focus-visible),
+.markdown-body [role=button]:focus:not(:focus-visible),
+.markdown-body input[type=radio]:focus:not(:focus-visible),
+.markdown-body input[type=checkbox]:focus:not(:focus-visible) {
+  outline: solid 1px transparent;
+}
+
+.markdown-body a:focus-visible,
+.markdown-body [role=button]:focus-visible,
+.markdown-body input[type=radio]:focus-visible,
+.markdown-body input[type=checkbox]:focus-visible {
+  outline: 2px solid #0969da;
+  outline-offset: -2px;
+  box-shadow: none;
+}
+
+.markdown-body a:not([class]):focus,
+.markdown-body a:not([class]):focus-visible,
+.markdown-body input[type=radio]:focus,
+.markdown-body input[type=radio]:focus-visible,
+.markdown-body input[type=checkbox]:focus,
+.markdown-body input[type=checkbox]:focus-visible {
+  outline-offset: 0;
+}
+
+.markdown-body kbd {
+  display: inline-block;
+  padding: 0.25rem;
+  font: 11px ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
+  line-height: 10px;
+  color: #1f2328;
+  vertical-align: middle;
+  background-color: #f6f8fa;
+  border: solid 1px #d1d9e0b3;
+  border-bottom-color: #d1d9e0b3;
+  border-radius: 6px;
+  box-shadow: inset 0 -1px 0 #d1d9e0b3;
+}
+
+.markdown-body h1,
+.markdown-body h2,
+.markdown-body h3,
+.markdown-body h4,
+.markdown-body h5,
+.markdown-body h6 {
+  margin-top: 1.5rem;
+  margin-bottom: 1rem;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.markdown-body h2 {
+  font-weight: 600;
+  padding-bottom: .3em;
+  font-size: 1.5em;
+  border-bottom: 1px solid #d1d9e0b3;
+}
+
+.markdown-body h3 {
+  font-weight: 600;
+  font-size: 1.25em;
+}
+
+.markdown-body h4 {
+  font-weight: 600;
+  font-size: 1em;
+}
+
+.markdown-body h5 {
+  font-weight: 600;
+  font-size: .875em;
+}
+
+.markdown-body h6 {
+  font-weight: 600;
+  font-size: .85em;
+  color: #59636e;
+}
+
+.markdown-body p {
+  margin-top: 0;
+  margin-bottom: 10px;
+}
+
+.markdown-body blockquote {
+  margin: 0;
+  padding: 0 1em;
+  color: #59636e;
+  border-left: .25em solid #d1d9e0;
+}
+
+.markdown-body ul,
+.markdown-body ol {
+  margin-top: 0;
+  margin-bottom: 0;
+  padding-left: 2em;
+}
+
+.markdown-body ol ol,
+.markdown-body ul ol {
+  list-style-type: lower-roman;
+}
+
+.markdown-body ul ul ol,
+.markdown-body ul ol ol,
+.markdown-body ol ul ol,
+.markdown-body ol ol ol {
+  list-style-type: lower-alpha;
+}
+
+.markdown-body dd {
+  margin-left: 0;
+}
+
+.markdown-body tt,
+.markdown-body code,
+.markdown-body samp {
+  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
+  font-size: 12px;
+}
+
+.markdown-body pre {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
+  font-size: 12px;
+  word-wrap: normal;
+}
+
+.markdown-body .octicon {
+  display: inline-block;
+  overflow: visible !important;
+  vertical-align: text-bottom;
+  fill: currentColor;
+}
+
+.markdown-body input::-webkit-outer-spin-button,
+.markdown-body input::-webkit-inner-spin-button {
+  margin: 0;
+  appearance: none;
+}
+
+.markdown-body .mr-2 {
+  margin-right: 0.5rem !important;
+}
+
+.markdown-body::before {
+  display: table;
+  content: "";
+}
+
+.markdown-body::after {
+  display: table;
+  clear: both;
+  content: "";
+}
+
+.markdown-body>*:first-child {
+  margin-top: 0 !important;
+}
+
+.markdown-body>*:last-child {
+  margin-bottom: 0 !important;
+}
+
+.markdown-body a:not([href]) {
+  color: inherit;
+  text-decoration: none;
+}
+
+.markdown-body .absent {
+  color: #d1242f;
+}
+
+.markdown-body .anchor {
+  float: left;
+  padding-right: 0.25rem;
+  margin-left: -20px;
+  line-height: 1;
+}
+
+.markdown-body .anchor:focus {
+  outline: none;
+}
+
+.markdown-body p,
+.markdown-body blockquote,
+.markdown-body ul,
+.markdown-body ol,
+.markdown-body dl,
+.markdown-body table,
+.markdown-body pre,
+.markdown-body details {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  font-weight: 400;
+}
+
+.markdown-body blockquote>:first-child {
+  margin-top: 0;
+}
+
+.markdown-body blockquote>:last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body h1 .octicon-link,
+.markdown-body h2 .octicon-link,
+.markdown-body h3 .octicon-link,
+.markdown-body h4 .octicon-link,
+.markdown-body h5 .octicon-link,
+.markdown-body h6 .octicon-link {
+  color: #1f2328;
+  vertical-align: middle;
+  visibility: hidden;
+}
+
+.markdown-body h1:hover .anchor,
+.markdown-body h2:hover .anchor,
+.markdown-body h3:hover .anchor,
+.markdown-body h4:hover .anchor,
+.markdown-body h5:hover .anchor,
+.markdown-body h6:hover .anchor {
+  text-decoration: none;
+}
+
+.markdown-body h1:hover .anchor .octicon-link,
+.markdown-body h2:hover .anchor .octicon-link,
+.markdown-body h3:hover .anchor .octicon-link,
+.markdown-body h4:hover .anchor .octicon-link,
+.markdown-body h5:hover .anchor .octicon-link,
+.markdown-body h6:hover .anchor .octicon-link {
+  visibility: visible;
+}
+
+.markdown-body h1 tt,
+.markdown-body h1 code,
+.markdown-body h2 tt,
+.markdown-body h2 code,
+.markdown-body h3 tt,
+.markdown-body h3 code,
+.markdown-body h4 tt,
+.markdown-body h4 code,
+.markdown-body h5 tt,
+.markdown-body h5 code,
+.markdown-body h6 tt,
+.markdown-body h6 code {
+  padding: 0 .2em;
+  font-size: inherit;
+}
+
+.markdown-body summary h1,
+.markdown-body summary h2,
+.markdown-body summary h3,
+.markdown-body summary h4,
+.markdown-body summary h5,
+.markdown-body summary h6 {
+  display: inline-block;
+}
+
+.markdown-body summary h1 .anchor,
+.markdown-body summary h2 .anchor,
+.markdown-body summary h3 .anchor,
+.markdown-body summary h4 .anchor,
+.markdown-body summary h5 .anchor,
+.markdown-body summary h6 .anchor {
+  margin-left: -40px;
+}
+
+.markdown-body summary h1,
+.markdown-body summary h2 {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.markdown-body ul.no-list,
+.markdown-body ol.no-list {
+  padding: 0;
+  list-style-type: none;
+}
+
+.markdown-body ol[type="a s"] {
+  list-style-type: lower-alpha;
+}
+
+.markdown-body ol[type="A s"] {
+  list-style-type: upper-alpha;
+}
+
+.markdown-body ol[type="i s"] {
+  list-style-type: lower-roman;
+}
+
+.markdown-body ol[type="I s"] {
+  list-style-type: upper-roman;
+}
+
+.markdown-body ol[type="1"] {
+  list-style-type: decimal;
+}
+
+.markdown-body div>ol:not([type]) {
+  list-style-type: decimal;
+}
+
+.markdown-body ul ul,
+.markdown-body ul ol,
+.markdown-body ol ol,
+.markdown-body ol ul {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.markdown-body li>p {
+  margin-top: 1rem;
+}
+
+.markdown-body li+li {
+  margin-top: .25em;
+}
+
+.markdown-body dl {
+  padding: 0;
+}
+
+.markdown-body dl dt {
+  padding: 0;
+  margin-top: 1rem;
+  font-size: 1em;
+  font-style: italic;
+  font-weight: 600;
+}
+
+.markdown-body dl dd {
+  padding: 0 1rem;
+  margin-bottom: 1rem;
+}
+
+.markdown-body table th {
+  font-weight: 600;
+}
+
+.markdown-body table th,
+.markdown-body table td {
+  padding: 6px 13px;
+  border: 1px solid #d1d9e0;
+}
+
+.markdown-body table td>:last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body table tr {
+  background-color: #ffffff;
+  border-top: 1px solid #d1d9e0b3;
+}
+
+.markdown-body table tr:nth-child(2n) {
+  background-color: #f6f8fa;
+}
+
+.markdown-body table img {
+  background-color: transparent;
+}
+
+.markdown-body img[align=right] {
+  padding-left: 20px;
+}
+
+.markdown-body img[align=left] {
+  padding-right: 20px;
+}
+
+.markdown-body .emoji {
+  max-width: none;
+  vertical-align: text-top;
+  background-color: transparent;
+}
+
+.markdown-body span.frame {
+  display: block;
+  overflow: hidden;
+}
+
+.markdown-body span.frame>span {
+  display: block;
+  float: left;
+  width: auto;
+  padding: 7px;
+  margin: 13px 0 0;
+  overflow: hidden;
+  border: 1px solid #d1d9e0;
+}
+
+.markdown-body span.frame span img {
+  display: block;
+  float: left;
+}
+
+.markdown-body span.frame span span {
+  display: block;
+  padding: 5px 0 0;
+  clear: both;
+  color: #1f2328;
+}
+
+.markdown-body span.align-center {
+  display: block;
+  overflow: hidden;
+  clear: both;
+}
+
+.markdown-body span.align-center>span {
+  display: block;
+  margin: 13px auto 0;
+  overflow: hidden;
+  text-align: center;
+}
+
+.markdown-body span.align-center span img {
+  margin: 0 auto;
+  text-align: center;
+}
+
+.markdown-body span.align-right {
+  display: block;
+  overflow: hidden;
+  clear: both;
+}
+
+.markdown-body span.align-right>span {
+  display: block;
+  margin: 13px 0 0;
+  overflow: hidden;
+  text-align: right;
+}
+
+.markdown-body span.align-right span img {
+  margin: 0;
+  text-align: right;
+}
+
+.markdown-body span.float-left {
+  display: block;
+  float: left;
+  margin-right: 13px;
+  overflow: hidden;
+}
+
+.markdown-body span.float-left span {
+  margin: 13px 0 0;
+}
+
+.markdown-body span.float-right {
+  display: block;
+  float: right;
+  margin-left: 13px;
+  overflow: hidden;
+}
+
+.markdown-body span.float-right>span {
+  display: block;
+  margin: 13px auto 0;
+  overflow: hidden;
+  text-align: right;
+}
+
+.markdown-body code,
+.markdown-body tt {
+  padding: .2em .4em;
+  margin: 0;
+  font-size: 85%;
+  white-space: break-spaces;
+  background-color: #818b981f;
+  border-radius: 6px;
+}
+
+.markdown-body code br,
+.markdown-body tt br {
+  display: none;
+}
+
+.markdown-body del code {
+  text-decoration: inherit;
+}
+
+.markdown-body samp {
+  font-size: 85%;
+}
+
+.markdown-body pre code {
+  font-size: 100%;
+}
+
+.markdown-body pre>code {
+  padding: 0;
+  margin: 0;
+  word-break: normal;
+  white-space: pre;
+  background: transparent;
+  border: 0;
+}
+
+.markdown-body .highlight {
+  margin-bottom: 1rem;
+}
+
+.markdown-body .highlight pre {
+  margin-bottom: 0;
+  word-break: normal;
+}
+
+.markdown-body .highlight pre,
+.markdown-body pre {
+  padding: 1rem;
+  overflow: auto;
+  font-size: 85%;
+  line-height: 1.45;
+  color: #1f2328;
+  background-color: #f6f8fa;
+  border-radius: 6px;
+}
+
+.markdown-body pre code,
+.markdown-body pre tt {
+  display: inline;
+  max-width: auto;
+  padding: 0;
+  margin: 0;
+  overflow: visible;
+  line-height: inherit;
+  word-wrap: normal;
+  background-color: transparent;
+  border: 0;
+}
+
+.markdown-body .csv-data td,
+.markdown-body .csv-data th {
+  padding: 5px;
+  overflow: hidden;
+  font-size: 12px;
+  line-height: 1;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.markdown-body .csv-data .blob-num {
+  padding: 10px 0.5rem 9px;
+  text-align: right;
+  background: #ffffff;
+  border: 0;
+}
+
+.markdown-body .csv-data tr {
+  border-top: 0;
+}
+
+.markdown-body .csv-data th {
+  font-weight: 600;
+  background: #f6f8fa;
+  border-top: 0;
+}
+
+.markdown-body [data-footnote-ref]::before {
+  content: "[";
+}
+
+.markdown-body [data-footnote-ref]::after {
+  content: "]";
+}
+
+.markdown-body .footnotes {
+  font-size: 12px;
+  color: #59636e;
+  border-top: 1px solid #d1d9e0;
+}
+
+.markdown-body .footnotes ol {
+  padding-left: 1rem;
+}
+
+.markdown-body .footnotes ol ul {
+  display: inline-block;
+  padding-left: 1rem;
+  margin-top: 1rem;
+}
+
+.markdown-body .footnotes li {
+  position: relative;
+}
+
+.markdown-body .footnotes li:target::before {
+  position: absolute;
+  top: calc(0.5rem*-1);
+  right: calc(0.5rem*-1);
+  bottom: calc(0.5rem*-1);
+  left: calc(1.5rem*-1);
+  pointer-events: none;
+  content: "";
+  border: 2px solid #0969da;
+  border-radius: 6px;
+}
+
+.markdown-body .footnotes li:target {
+  color: #1f2328;
+}
+
+.markdown-body .footnotes .data-footnote-backref g-emoji {
+  font-family: monospace;
+}
+
+.markdown-body body:has(:modal) {
+  padding-right: var(--dialog-scrollgutter) !important;
+}
+
+.markdown-body .pl-c {
+  color: #59636e;
+}
+
+.markdown-body .pl-c1,
+.markdown-body .pl-s .pl-v {
+  color: #0550ae;
+}
+
+.markdown-body .pl-e,
+.markdown-body .pl-en {
+  color: #6639ba;
+}
+
+.markdown-body .pl-smi,
+.markdown-body .pl-s .pl-s1 {
+  color: #1f2328;
+}
+
+.markdown-body .pl-ent {
+  color: #0550ae;
+}
+
+.markdown-body .pl-k {
+  color: #cf222e;
+}
+
+.markdown-body .pl-s,
+.markdown-body .pl-pds,
+.markdown-body .pl-s .pl-pse .pl-s1,
+.markdown-body .pl-sr,
+.markdown-body .pl-sr .pl-cce,
+.markdown-body .pl-sr .pl-sre,
+.markdown-body .pl-sr .pl-sra {
+  color: #0a3069;
+}
+
+.markdown-body .pl-v,
+.markdown-body .pl-smw {
+  color: #953800;
+}
+
+.markdown-body .pl-bu {
+  color: #82071e;
+}
+
+.markdown-body .pl-ii {
+  color: #f6f8fa;
+  background-color: #82071e;
+}
+
+.markdown-body .pl-c2 {
+  color: #f6f8fa;
+  background-color: #cf222e;
+}
+
+.markdown-body .pl-sr .pl-cce {
+  font-weight: bold;
+  color: #116329;
+}
+
+.markdown-body .pl-ml {
+  color: #3b2300;
+}
+
+.markdown-body .pl-mh,
+.markdown-body .pl-mh .pl-en,
+.markdown-body .pl-ms {
+  font-weight: bold;
+  color: #0550ae;
+}
+
+.markdown-body .pl-mi {
+  font-style: italic;
+  color: #1f2328;
+}
+
+.markdown-body .pl-mb {
+  font-weight: bold;
+  color: #1f2328;
+}
+
+.markdown-body .pl-md {
+  color: #82071e;
+  background-color: #ffebe9;
+}
+
+.markdown-body .pl-mi1 {
+  color: #116329;
+  background-color: #dafbe1;
+}
+
+.markdown-body .pl-mc {
+  color: #953800;
+  background-color: #ffd8b5;
+}
+
+.markdown-body .pl-mi2 {
+  color: #d1d9e0;
+  background-color: #0550ae;
+}
+
+.markdown-body .pl-mdr {
+  font-weight: bold;
+  color: #8250df;
+}
+
+.markdown-body .pl-ba {
+  color: #59636e;
+}
+
+.markdown-body .pl-sg {
+  color: #818b98;
+}
+
+.markdown-body .pl-corl {
+  text-decoration: underline;
+  color: #0a3069;
+}
+
+.markdown-body [role=button]:focus:not(:focus-visible),
+.markdown-body [role=tabpanel][tabindex="0"]:focus:not(:focus-visible),
+.markdown-body button:focus:not(:focus-visible),
+.markdown-body summary:focus:not(:focus-visible),
+.markdown-body a:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.markdown-body [tabindex="0"]:focus:not(:focus-visible),
+.markdown-body details-dialog:focus:not(:focus-visible) {
+  outline: none;
+}
+
+.markdown-body g-emoji {
+  display: inline-block;
+  min-width: 1ch;
+  font-family: "Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 1em;
+  font-style: normal !important;
+  font-weight: 400;
+  line-height: 1;
+  vertical-align: -0.075em;
+}
+
+.markdown-body g-emoji img {
+  width: 1em;
+  height: 1em;
+}
+
+.markdown-body .task-list-item {
+  list-style-type: none;
+}
+
+.markdown-body .task-list-item label {
+  font-weight: 400;
+}
+
+.markdown-body .task-list-item.enabled label {
+  cursor: pointer;
+}
+
+.markdown-body .task-list-item+.task-list-item {
+  margin-top: 0.25rem;
+}
+
+.markdown-body .task-list-item .handle {
+  display: none;
+}
+
+.markdown-body .task-list-item-checkbox {
+  margin: 0 .2em .25em -1.4em;
+  vertical-align: middle;
+}
+
+.markdown-body ul:dir(rtl) .task-list-item-checkbox {
+  margin: 0 -1.6em .25em .2em;
+}
+
+.markdown-body ol:dir(rtl) .task-list-item-checkbox {
+  margin: 0 -1.6em .25em .2em;
+}
+
+.markdown-body .contains-task-list:hover .task-list-item-convert-container,
+.markdown-body .contains-task-list:focus-within .task-list-item-convert-container {
+  display: block;
+  width: auto;
+  height: 24px;
+  overflow: visible;
+  clip: auto;
+}
+
+.markdown-body ::-webkit-calendar-picker-indicator {
+  filter: invert(50%);
+}
+
+.markdown-body .markdown-alert {
+  padding: 0.5rem 1rem;
+  margin-bottom: 1rem;
+  color: inherit;
+  border-left: .25em solid #d1d9e0;
+}
+
+.markdown-body .markdown-alert>:first-child {
+  margin-top: 0;
+}
+
+.markdown-body .markdown-alert>:last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body .markdown-alert .markdown-alert-title {
+  display: flex;
+  font-weight: 500;
+  align-items: center;
+  line-height: 1;
+}
+
+.markdown-body .markdown-alert.markdown-alert-note {
+  border-left-color: #0969da;
+}
+
+.markdown-body .markdown-alert.markdown-alert-note .markdown-alert-title {
+  color: #0969da;
+}
+
+.markdown-body .markdown-alert.markdown-alert-important {
+  border-left-color: #8250df;
+}
+
+.markdown-body .markdown-alert.markdown-alert-important .markdown-alert-title {
+  color: #8250df;
+}
+
+.markdown-body .markdown-alert.markdown-alert-warning {
+  border-left-color: #9a6700;
+}
+
+.markdown-body .markdown-alert.markdown-alert-warning .markdown-alert-title {
+  color: #9a6700;
+}
+
+.markdown-body .markdown-alert.markdown-alert-tip {
+  border-left-color: #1a7f37;
+}
+
+.markdown-body .markdown-alert.markdown-alert-tip .markdown-alert-title {
+  color: #1a7f37;
+}
+
+.markdown-body .markdown-alert.markdown-alert-caution {
+  border-left-color: #cf222e;
+}
+
+.markdown-body .markdown-alert.markdown-alert-caution .markdown-alert-title {
+  color: #d1242f;
+}
+
+.markdown-body>*:first-child>.heading-element:first-child {
+  margin-top: 0 !important;
+}
+
+.markdown-body .highlight pre:has(+.zeroclipboard-container) {
+  min-height: 52px;
+}
+
+
+`;
 
 export function qrToHTML(
   questionnaire: Questionnaire,
   questionnaireResponse: QuestionnaireResponse
 ): string {
-  if (!questionnaireResponse.item || questionnaireResponse.item.length === 0) return '';
-
-  let QrHtml = `<div style="font-size:20px; font-weight: bold">${questionnaire.title}</div><hr/>`;
-
-  for (const topLevelQRItem of questionnaireResponse.item) {
-    const topLevelQRItemHTML = qrItemToHTML(topLevelQRItem);
-    if (topLevelQRItemHTML) {
-      QrHtml += topLevelQRItemHTML;
-    }
+  if (
+    !questionnaire.item ||
+    questionnaire.item.length === 0 ||
+    !questionnaireResponse.item ||
+    questionnaireResponse.item.length === 0
+  ) {
+    return '';
   }
-  return `<div xmlns="http://www.w3.org/1999/xhtml">${QrHtml}</div>`;
+
+  let html = `<style>${GITHUB_MARKDOWN_INLINE}</style>`;
+  html += `<article class="markdown-body">`;
+
+  // add the map and iterate qItems instead of QRItems
+
+  // Title as h1
+  html += `<h1>${he.encode(questionnaire.title ?? 'Questionnaire Response')}</h1>`;
+
+  // Add Patient/Author/Authored block
+  html += renderMetadataHtml(questionnaireResponse);
+
+  const qItemsIndexMap = mapQItemsIndex(questionnaire);
+  const topLevelQRItemsByIndex = getQrItemsIndex(
+    questionnaire.item,
+    questionnaireResponse.item ?? [],
+    qItemsIndexMap
+  );
+
+  // Render all top-level items
+  for (const [index, topLevelQItem] of questionnaire.item.entries()) {
+    const topLevelQRItemOrItems = topLevelQRItemsByIndex[index] ?? {
+      linkId: topLevelQItem.linkId,
+      text: topLevelQItem.text,
+      item: []
+    };
+
+    const isTabContainer = topLevelQItem
+      ? isSpecificItemControl(topLevelQItem, 'tab-container')
+      : false;
+    const groupNestLevel = isTabContainer ? 0 : 1;
+    html = renderItemHtmlRecursive(topLevelQItem, topLevelQRItemOrItems, groupNestLevel, html);
+  }
+
+  html += `</article>`;
+  return `<div xmlns="http://www.w3.org/1999/xhtml">${html}</div>`;
 }
 
-export function qrItemToHTML(topLevelQRItem: QuestionnaireResponseItem) {
-  let formInHTML = '';
-  if (!topLevelQRItem.item) {
-    return readQuestionnaireResponseItem(undefined, topLevelQRItem, undefined, formInHTML, 0);
+export function renderMetadataHtml(questionnaireResponse: QuestionnaireResponse): string {
+  const lines: string[] = [];
+
+  // Patient (subject.display)
+  if (questionnaireResponse.subject) {
+    const subjectDisplay = questionnaireResponse.subject.display;
+    if (subjectDisplay) {
+      lines.push(`<strong>Patient</strong>: ${he.encode(subjectDisplay)}`);
+    }
   }
 
-  const qrItems = topLevelQRItem.item;
-  for (let i = 0; i < qrItems.length; i++) {
-    formInHTML = readQuestionnaireResponseItem(
-      i === 0 ? undefined : qrItems[i - 1],
-      qrItems[i],
-      qrItems[i + 1],
-      formInHTML,
-      0
+  // Author (author.display)
+  if (questionnaireResponse.author) {
+    const authorDisplay = questionnaireResponse.author.display;
+    if (authorDisplay) {
+      lines.push(`<strong>Author</strong>: ${he.encode(authorDisplay)}`);
+    }
+  }
+
+  // Date Authored
+  if (questionnaireResponse.authored) {
+    const { displayDate, dateParseFail } = parseFhirDateToDisplayDate(
+      questionnaireResponse.authored
     );
+    const authoredDisplay = !dateParseFail ? displayDate : questionnaireResponse.authored;
+
+    lines.push(`<strong>Date Authored</strong>: ${he.encode(authoredDisplay)}`);
   }
 
-  return formInHTML;
+  if (lines.length === 0) {
+    return '';
+  }
+
+  return `<p>${lines.join('<br />')}</p>`;
 }
 
-type RepeatGroupItemStatus = 'first' | 'last' | 'middle' | null;
-function readQuestionnaireResponseItem(
-  prevItem: QuestionnaireResponseItem | undefined,
-  item: QuestionnaireResponseItem,
-  nextItem: QuestionnaireResponseItem | undefined,
-  formInHTML: string,
-  nestedLevel: number
-) {
-  let repeatGroupItemStatus: RepeatGroupItemStatus = null;
-
-  // determine if current item is repeat group item
-  if (prevItem || nextItem) {
-    if (item.linkId !== prevItem?.linkId && item.linkId === nextItem?.linkId) {
-      repeatGroupItemStatus = 'first';
-    } else if (item.linkId === prevItem?.linkId && item.linkId !== nextItem?.linkId) {
-      repeatGroupItemStatus = 'last';
-    } else if (item.linkId === prevItem?.linkId || item.linkId === nextItem?.linkId) {
-      repeatGroupItemStatus = 'middle';
-    }
+function renderItemHtmlRecursive(
+  qItem: QuestionnaireItem,
+  qrItemOrItems: QuestionnaireResponseItem | QuestionnaireResponseItem[] | null,
+  groupNestLevel: number,
+  html: string
+): string {
+  // Render group heading if text exists
+  const qrItemOrItemsIsSingleItem = !Array.isArray(qrItemOrItems) && qrItemOrItems !== null;
+  const qrItemOrItemsIsNonEmptyArray = Array.isArray(qrItemOrItems) && qrItemOrItems.length > 0;
+  if (qItem.type === 'group' && (qrItemOrItemsIsSingleItem || qrItemOrItemsIsNonEmptyArray)) {
+    const groupHeading = getGroupHeading(qItem, groupNestLevel);
+    html += groupHeading;
   }
 
-  const items = item.item;
-  if (items && items.length > 0) {
-    // Render group heading
-    if (repeatGroupItemStatus === 'first') {
-      formInHTML += renderGroupHeadingDiv(item, nestedLevel);
-      formInHTML += renderRepeatGroupItemHeadingDiv();
-    } else if (repeatGroupItemStatus === 'last') {
-      formInHTML += '';
-    } else if (repeatGroupItemStatus === 'middle') {
-      formInHTML += renderRepeatGroupItemHeadingDiv();
-    } else {
-      formInHTML += renderGroupHeadingDiv(item, nestedLevel);
+  // If item.type=group, render children recursively
+  const childQItems = qItem.item;
+  if (childQItems && childQItems.length > 0) {
+    // Map qrItemOrItems into an array of qrItems
+    let childQRItems: QuestionnaireResponseItem[] = [];
+    if (qrItemOrItems) {
+      if (Array.isArray(qrItemOrItems)) {
+        childQRItems = qrItemOrItems;
+      } else {
+        childQRItems = qrItemOrItems.item ?? [];
+      }
     }
 
-    // do compare next object linkId
-    for (let i = 0; i < items.length; i++) {
-      formInHTML = readQuestionnaireResponseItem(
-        i === 0 ? undefined : items[i - 1],
-        items[i],
-        items[i + 1],
-        formInHTML,
-        nestedLevel + 1
+    // Process repeating group items separately - TODO
+    if (qItem.type === 'group' && qItem.repeats && childQRItems.length > 0) {
+      html += renderRepeatGroupHtml(qItem, childQRItems);
+      return html;
+    }
+
+    const indexMap = mapQItemsIndex(qItem);
+    const qrItemsByIndex = getQrItemsIndex(childQItems, childQRItems, indexMap);
+
+    for (const [index, childQItem] of childQItems.entries()) {
+      const childQRItemOrItems = qrItemsByIndex[index];
+
+      html = renderItemHtmlRecursive(
+        childQItem,
+        childQRItemOrItems ?? null,
+        groupNestLevel + 1,
+        html
       );
     }
-    formInHTML += renderGroupBottomMargin(repeatGroupItemStatus);
-  } else {
-    // Render item
-    formInHTML += renderItemDiv(item, nestedLevel);
   }
-  formInHTML += renderGeneralBottomMargin(nestedLevel, nextItem);
 
-  return formInHTML;
-}
+  // At this point qrItemOrItems should be a single qrItem
+  if (Array.isArray(qrItemOrItems)) {
+    return html;
+  }
 
-function renderItemDiv(item: QuestionnaireResponseItem, nestedLevel: number) {
-  if (!item.answer) return '';
+  // Render answers
+  const qrItem = qrItemOrItems;
+  if (qrItem?.answer && qrItem.answer.length > 0) {
+    const label = he.encode(qrItem.text ?? '');
 
-  let qrItemAnswer = '';
-
-  item.answer.forEach((answer) => {
-    const answerValueInString = he.encode(qrItemAnswerValueTypeSwitcher(answer));
-    if (answerValueInString === '') {
-      qrItemAnswer += '<div style="color: red">Undefined answer</div>';
+    if (qItem.repeats && qItem.type !== 'group') {
+      html += `<p><strong>${label}</strong></p>`;
+      html += `<ul>`;
+      for (const a of qrItem.answer) {
+        html += `<li>${he.encode(answerToString(a))}</li>`;
+      }
+      html += `</ul>`;
     } else {
-      qrItemAnswer += `<div>${
-        answerValueInString[0].toUpperCase() + answerValueInString.slice(1)
-      }</div>`;
+      html += qrItem.answer
+        .map((a) => `<p><strong>${label}</strong><br/>${he.encode(answerToString(a))}</p>`)
+        .join('');
     }
-  });
+  }
 
-  const qrItemRender = `<div style="flex:40%">${item.text}</div><div style="flex: 10%"></div><div style="flex: 50%">${qrItemAnswer}</div>`;
-
-  return `<div style="margin-top: ${
-    nestedLevel === 0 ? '20px' : '10px'
-  }; display: flex; flex-wrap: wrap">${qrItemRender}</div>`;
+  return html;
 }
 
-function renderGroupHeadingDiv(item: QuestionnaireResponseItem, nestedLevel: number) {
-  const fontSize = nestedLevel === 0 ? '18px' : '15px';
-  const headingText = he.encode(item.text ?? '');
+function getGroupHeading(qItem: QuestionnaireItem, nestedLevel: number): string {
+  // if item is tab-container, it will only have a nestedLevel of 0, hence do not render a heading
+  // <h1> is really only reserved for the main title of the Questionnaire
+  if (nestedLevel === 0) {
+    return '';
+  }
 
-  return `<div style="font-size: ${fontSize}; font-weight: bold; margin-top: 15px">${headingText}</div>`;
+  const headingText = qItem.text ?? '';
+
+  let headingTag: string;
+  switch (nestedLevel) {
+    case 0:
+      headingTag = 'h1';
+      break;
+    case 1:
+      headingTag = 'h2';
+      break;
+    case 2:
+      headingTag = 'h3';
+      break;
+    case 3:
+    case 4:
+    default:
+      headingTag = 'h4';
+      break;
+  }
+
+  return `<${headingTag}>${he.encode(headingText)}</${headingTag}>`;
 }
 
-function renderRepeatGroupItemHeadingDiv() {
-  return `<div style="margin-top: 15px" />`;
+function renderRepeatGroupHtml(
+  qItem: QuestionnaireItem,
+  qrItems: QuestionnaireResponseItem[]
+): string {
+  if (!Array.isArray(qrItems)) {
+    return '';
+  }
+
+  // Table headers from child questions
+  const headers = qItem.item?.map((child) => he.encode(child.text ?? '')) ?? [];
+
+  // Render headers
+  let html = `<table><thead><tr>`;
+  for (const header of headers) {
+    html += `<th>${header}</th>`;
+  }
+  html += `</tr></thead>`;
+
+  // Render rows for each repeated item
+  for (const qrItemInstance of qrItems) {
+    const childQItems = qItem.item ?? [];
+    const childQRItems = qrItemInstance.item ?? [];
+
+    const indexMap = mapQItemsIndex(qItem);
+    const qrItemsByIndex = getQrItemsIndex(childQItems, childQRItems, indexMap);
+
+    html += `<tr>`;
+    for (const [index] of childQItems.entries()) {
+      const childQRItem = qrItemsByIndex[index];
+
+      // Do not support repeat group nesting for now
+      if (Array.isArray(childQRItem)) {
+        html += `<td colspan="${childQRItem.length}">Nested repeat groups not supported in narrative</td>`;
+        continue;
+      }
+
+      const answer = childQRItem?.answer?.[0];
+      const value = answer ? answerToString(answer) : '';
+      html += `<td>${he.encode(value)}</td>`;
+    }
+    html += `</tr>`;
+  }
+
+  html += `</tbody></table>`;
+
+  return html;
 }
 
-function qrItemAnswerValueTypeSwitcher(answer: QuestionnaireResponseItemAnswer): string {
+function answerToString(answer: QuestionnaireResponseItemAnswer): string {
   if (answer.valueBoolean !== undefined) {
-    return `${answer.valueBoolean}`;
+    return answer.valueBoolean ? 'Yes' : 'No';
   }
 
   if (answer.valueDecimal !== undefined) {
@@ -169,56 +1361,34 @@ function qrItemAnswerValueTypeSwitcher(answer: QuestionnaireResponseItemAnswer):
       return `${displayDate}`;
     }
 
-    return `${answer.valueDate}`;
+    return answer.valueDate;
   }
 
   if (answer.valueDateTime) {
-    // TODO date time item
-    return `${answer.valueDateTime}`;
+    // TODO date time item - parse to fhirDateTime
+    return answer.valueDateTime;
   }
 
   if (answer.valueTime) {
-    return `${answer.valueTime}`;
+    return answer.valueTime;
   }
 
   if (answer.valueString) {
-    return `${answer.valueString}`;
+    return answer.valueString;
+  }
+
+  if (answer.valueCoding?.display) {
+    return answer.valueCoding.display;
   }
 
   if (answer.valueCoding?.code) {
-    return answer.valueCoding?.display ?? `${answer.valueCoding?.code}`;
+    return answer.valueCoding.code;
   }
 
   if (answer.valueQuantity) {
-    return `${answer.valueQuantity}`;
+    const quantity = answer.valueQuantity;
+    return `${quantity.value ?? ''} ${quantity.unit ?? ''}`.trim();
   }
 
   return '';
-}
-
-function renderGroupBottomMargin(repeatGroupItemStatus: RepeatGroupItemStatus) {
-  if (repeatGroupItemStatus === 'first' || repeatGroupItemStatus === 'middle') {
-    return `<div style="height: 1px; width: 100%; background-color: #E5EAF2;margin-top: 15px"></div>`;
-  } else {
-    return `<div style="margin-bottom: 30px;"></div>`;
-  }
-}
-
-function renderGeneralBottomMargin(
-  nestedLevel: number,
-  nextItem: QuestionnaireResponseItem | undefined
-) {
-  const smallMarginDiv = `<div style="margin: 20px 0 20px"></div>`;
-  const largeMarginDiv = `<div style="margin: 55px 0 20px"></div>`;
-
-  if (nestedLevel !== 0) {
-    return '';
-  }
-
-  if (!nextItem) {
-    return smallMarginDiv;
-  }
-
-  const items = nextItem.item;
-  return items && items.length > 0 ? largeMarginDiv : smallMarginDiv;
 }

--- a/apps/smart-forms-app/src/features/renderer/components/RendererLayout.styles.ts
+++ b/apps/smart-forms-app/src/features/renderer/components/RendererLayout.styles.ts
@@ -23,6 +23,7 @@ import {
 
 export const Main = styled(Box)(({ theme }) => ({
   flexGrow: 1,
+  overflow: 'auto',
   minHeight: '100%',
   paddingTop: HEADER_MOBILE_HEIGHT + 16,
   paddingBottom: theme.spacing(4),

--- a/apps/smart-forms-app/src/features/smartAppLaunch/utils/launchContext.ts
+++ b/apps/smart-forms-app/src/features/smartAppLaunch/utils/launchContext.ts
@@ -25,13 +25,19 @@ import type { HumanName } from 'fhir/r4';
 export function constructName(name: HumanName[] | undefined): string {
   if (name?.[0]['text']) {
     return `${name?.[0].text}`;
-  } else {
-    const prefix = name?.[0].prefix?.[0] ?? '';
-    const givenName = name?.[0].given?.[0] ?? '';
-    const familyName = name?.[0].family ?? '';
-
-    return `${prefix} ${givenName} ${familyName}`;
   }
+
+  const prefix = name?.[0].prefix?.[0] ?? '';
+  const givenName = name?.[0].given?.[0] ?? '';
+  const familyName = name?.[0].family ?? '';
+
+  const fullName = `${prefix} ${givenName} ${familyName}`;
+
+  if (fullName.length === 0) {
+    return 'null';
+  }
+
+  return fullName;
 }
 
 export function constructShortName(name: HumanName[] | undefined): string {

--- a/apps/smart-forms-app/src/features/viewer/ResponsePreview.tsx
+++ b/apps/smart-forms-app/src/features/viewer/ResponsePreview.tsx
@@ -39,8 +39,15 @@ function ResponsePreview() {
     return <ViewerInvalid questionnaire={sourceQuestionnaire} />;
   }
 
-  const responseCleaned = removeEmptyAnswersFromResponse(sourceQuestionnaire, sourceResponse);
-  const parsedHTML = parse(qrToHTML(sourceQuestionnaire, responseCleaned));
+  // Use existing narrative HTML if available, otherwise generate it on the fly
+  const responseHtmlDiv = 
+    sourceResponse.text?.div ?? 
+    qrToHTML(
+      sourceQuestionnaire,
+      removeEmptyAnswersFromResponse(sourceQuestionnaire, sourceResponse)
+    );
+
+  const parsedHTML = parse(responseHtmlDiv);
 
   return (
     <>

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@aehrc/sdc-assemble": "^2.0.1",
         "@aehrc/sdc-populate": "^4.4.0",
         "@aehrc/sdc-template-extract": "^1.0.5",
-        "@aehrc/smart-forms-renderer": "^1.0.0-alpha.75",
+        "@aehrc/smart-forms-renderer": "^1.0.0-alpha.76",
         "@dnd-kit/core": "^6.3.1",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
@@ -37622,7 +37622,7 @@
     },
     "packages/smart-forms-renderer": {
       "name": "@aehrc/smart-forms-renderer",
-      "version": "1.0.0-alpha.75",
+      "version": "1.0.0-alpha.76",
       "license": "Apache-2.0",
       "dependencies": {
         "@aehrc/sdc-populate": "^4.4.0",

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/constructResponse.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/constructResponse.ts
@@ -44,6 +44,7 @@ import { getValueSetPromise } from '../api/expandValueset';
 import type { FetchTerminologyCallback, FetchTerminologyRequestConfig } from '../interfaces';
 import { handleFhirPathResult } from './createFhirPathContext';
 import { TERMINOLOGY_SERVER_URL } from '../../globals';
+import { getDisplayName } from './humanName';
 
 /**
  * Constructs a questionnaireResponse recursively from a specified questionnaire, its subject and its initialExpressions
@@ -138,9 +139,16 @@ export async function constructResponse(
 
   // Add user reference to "author" and current dateTime to "authored" if user context present
   if (user && user.id && user.resourceType) {
+    const displayName =
+      user.resourceType === 'Practitioner' ||
+      user.resourceType === 'RelatedPerson' ||
+      user.resourceType === 'Patient'
+        ? getDisplayName(user.name)
+        : undefined;
     questionnaireResponse.author = {
       type: user.resourceType,
-      reference: `${user.resourceType}/${user.id}`
+      reference: `${user.resourceType}/${user.id}`,
+      ...(displayName && { display: displayName })
     };
     questionnaireResponse.authored = new Date().toISOString();
   }

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/humanName.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/humanName.ts
@@ -1,0 +1,19 @@
+import type { HumanName } from 'fhir/r4';
+
+export function getDisplayName(name: HumanName[] | undefined): string {
+  if (name?.[0]?.['text']) {
+    return `${name?.[0].text ?? null}`;
+  }
+
+  const prefix = name?.[0]?.prefix?.[0] ?? '';
+  const givenName = name?.[0]?.given?.[0] ?? '';
+  const familyName = name?.[0]?.family ?? '';
+
+  const fullName = `${prefix} ${givenName} ${familyName}`;
+
+  if (fullName.length === 0) {
+    return 'null';
+  }
+
+  return fullName;
+}

--- a/packages/sdc-populate/src/inAppPopulation/utils/createInputParameters.ts
+++ b/packages/sdc-populate/src/inAppPopulation/utils/createInputParameters.ts
@@ -31,6 +31,7 @@ import type {
   QuestionnaireLevelXFhirQueryVariable,
   SourceQuery
 } from '../interfaces/inAppPopulation.interface';
+import { getDisplayName } from '../../SDCPopulateQuestionnaireOperation/utils/humanName';
 
 export function createPopulateInputParameters(
   questionnaire: Questionnaire,
@@ -125,7 +126,8 @@ function createPatientSubject(questionnaire: Questionnaire, patient: Patient): R
 
   return {
     type: 'Patient',
-    reference: 'Patient/' + patient.id
+    reference: 'Patient/' + patient.id,
+    display: getDisplayName(patient.name)
   };
 }
 

--- a/packages/smart-forms-renderer/package.json
+++ b/packages/smart-forms-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aehrc/smart-forms-renderer",
-  "version": "1.0.0-alpha.75",
+  "version": "1.0.0-alpha.76",
   "description": "FHIR Structured Data Captured (SDC) rendering engine for Smart Forms",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/smart-forms-renderer/src/components/FormComponents/DateTimeItems/index.ts
+++ b/packages/smart-forms-renderer/src/components/FormComponents/DateTimeItems/index.ts
@@ -15,4 +15,4 @@
  * limitations under the License.
  */
 
-export { parseFhirDateToDisplayDate } from './utils';
+export { parseFhirDateToDisplayDate, parseFhirDateTimeToDisplayDateTime } from './utils';

--- a/packages/smart-forms-renderer/src/components/FormComponents/DateTimeItems/utils/index.ts
+++ b/packages/smart-forms-renderer/src/components/FormComponents/DateTimeItems/utils/index.ts
@@ -15,4 +15,5 @@
  * limitations under the License.
  */
 
-export { parseFhirDateToDisplayDate } from './parseDate';
+export { parseFhirDateToDisplayDate, parseFhirDateTimeToDisplayDateTime } from './parseDate';
+

--- a/packages/smart-forms-renderer/src/components/FormComponents/DateTimeItems/utils/parseDate.ts
+++ b/packages/smart-forms-renderer/src/components/FormComponents/DateTimeItems/utils/parseDate.ts
@@ -94,7 +94,7 @@ export function getNumOfSeparators(valueDate: string, seperator: string) {
 }
 
 /**
- * Parse a FHIR date string to a date to be consumed and displayed by the DateItem component.
+ * Parse a FHIR date string to a human-readable display format.
  *
  * @author Sean Fong
  */
@@ -128,6 +128,30 @@ export function parseFhirDateToDisplayDate(fhirDate: string): {
   }
 
   return { displayDate: fhirDate, dateParseFail: true };
+}
+
+/**
+ * Parse a FHIR dateTime string to a human-readable display format.
+ * Supports full and partial FHIR dateTime values.
+ *
+ * @author Sean Fong
+ */
+export function parseFhirDateTimeToDisplayDateTime(fhirDateTime: string): {
+  displayDateTime: string;
+  dateParseFail?: boolean;
+} {
+  if (fhirDateTime.length === 0) {
+    return { displayDateTime: '' };
+  }
+
+  const fullDateTime = dayjs(fhirDateTime);
+  if (fullDateTime.isValid()) {
+    return { displayDateTime: fullDateTime.format('DD/MM/YYYY HH:mm') };
+  }
+
+  const parseFhirDateToDisplayDateResult = parseFhirDateToDisplayDate(fhirDateTime);
+
+  return { displayDateTime: parseFhirDateToDisplayDateResult.displayDate, dateParseFail: parseFhirDateToDisplayDateResult.dateParseFail };
 }
 
 export function parseInputDateToFhirDate(displayDate: string) {

--- a/packages/smart-forms-renderer/src/components/FormComponents/index.ts
+++ b/packages/smart-forms-renderer/src/components/FormComponents/index.ts
@@ -21,7 +21,7 @@ export { RepeatItem } from './RepeatItem';
 export { RepeatGroup } from './RepeatGroup';
 export { GroupTable } from './Tables';
 export { GridGroup } from './GridGroup';
-export { parseFhirDateToDisplayDate } from './DateTimeItems';
+export { parseFhirDateToDisplayDate, parseFhirDateTimeToDisplayDateTime } from './DateTimeItems';
 export { ItemFieldGrid, ItemLabel } from './ItemParts';
 
 // item type components

--- a/packages/smart-forms-renderer/src/components/index.ts
+++ b/packages/smart-forms-renderer/src/components/index.ts
@@ -25,6 +25,7 @@ export {
   GroupTable,
   GridGroup,
   parseFhirDateToDisplayDate,
+  parseFhirDateTimeToDisplayDateTime,
   ItemFieldGrid,
   ItemLabel,
   BooleanField,

--- a/packages/smart-forms-renderer/src/index.ts
+++ b/packages/smart-forms-renderer/src/index.ts
@@ -25,6 +25,7 @@ export {
   GroupTable,
   GridGroup,
   parseFhirDateToDisplayDate,
+  parseFhirDateTimeToDisplayDateTime,
   ItemFieldGrid,
   ItemLabel,
   BooleanField,


### PR DESCRIPTION
Changes:
- Overhauls the narrative generation logic and output. This new narrative is based on GitHub's Markdown styling, which is visually pleasant and straightforward. CSS is lifted from https://github.com/sindresorhus/github-markdown-css/blob/main/github-markdown-light.css.
- In the Response Preview page (after opening an existing in-progress response), instead of re-generating a new narrative on the fly, use the narrative in QuestionnaireResponse.text.div (which was generated previously when the response was saved).

#### Here's how it looks in Response Preview:
<img width="1962" height="1606" alt="image" src="https://github.com/user-attachments/assets/1515a881-719d-4738-976f-71f9c469fb07" />
<img width="1954" height="1714" alt="image" src="https://github.com/user-attachments/assets/1727d1b3-95ca-4906-92d4-35044339eedc" />

#### The QR also looks great when viewed in HAPI. See screenshots below:
<img width="2526" height="1806" alt="image" src="https://github.com/user-attachments/assets/05c04bbd-d865-4267-b73e-c6e818ea86d9" />
<img width="2526" height="1700" alt="image" src="https://github.com/user-attachments/assets/4a2522c7-05a9-4bb0-ac49-c68598f2367b" />
<img width="2528" height="1746" alt="image" src="https://github.com/user-attachments/assets/706f7a0b-8b3b-4b23-8383-f14d6e1d9188" />

