### PR TITLE
feat: implement GroupHideAddItemButton extension for issue #1428

### DIFF
--- a/CHANGELOG.alpha.md
+++ b/CHANGELOG.alpha.md
@@ -8,6 +8,10 @@ This changelog only includes changes from version 1.0.0-alpha.1 onwards. For sta
 
 WARNING: Alpha releases are not stable and may contain breaking changes. Changes are also most likely to be undocumented.
 
+## [1.0.0-alpha.89] - 2025-08-04
+#### Added
+- Add support for custom `https://smartforms.csiro.au/ig/StructureDefinition/GroupHideAddItemButton` extension to hide the "Add Item" button in a repeating group or group table item.
+  This extension is used when you want to prevent users from adding items to a group, but still want to allow them to edit existing items.
 
 ## [1.0.0-alpha.88] - 2025-08-01
 #### Fixed

--- a/apps/smart-forms-app/package.json
+++ b/apps/smart-forms-app/package.json
@@ -27,7 +27,7 @@
     "@aehrc/sdc-assemble": "^2.0.1",
     "@aehrc/sdc-populate": "^4.5.0",
     "@aehrc/sdc-template-extract": "^1.0.6",
-    "@aehrc/smart-forms-renderer": "^1.0.0-alpha.88",
+    "@aehrc/smart-forms-renderer": "^1.0.0-alpha.89",
     "@dnd-kit/core": "^6.3.1",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@aehrc/sdc-assemble": "^2.0.1",
         "@aehrc/sdc-populate": "^4.5.0",
         "@aehrc/sdc-template-extract": "^1.0.6",
-        "@aehrc/smart-forms-renderer": "^1.0.0-alpha.88",
+        "@aehrc/smart-forms-renderer": "^1.0.0-alpha.89",
         "@dnd-kit/core": "^6.3.1",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
@@ -38884,7 +38884,7 @@
     },
     "packages/smart-forms-renderer": {
       "name": "@aehrc/smart-forms-renderer",
-      "version": "1.0.0-alpha.88",
+      "version": "1.0.0-alpha.89",
       "license": "Apache-2.0",
       "dependencies": {
         "@aehrc/sdc-populate": "^4.6.0",

--- a/packages/smart-forms-renderer/.npmignore
+++ b/packages/smart-forms-renderer/.npmignore
@@ -10,3 +10,6 @@ storybook-static
 storybook.log
 doctor-storybook.log
 build-storybook.log
+
+# Ignore tests and test data
+src/tests

--- a/packages/smart-forms-renderer/package.json
+++ b/packages/smart-forms-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aehrc/smart-forms-renderer",
-  "version": "1.0.0-alpha.88",
+  "version": "1.0.0-alpha.89",
   "description": "FHIR Structured Data Captured (SDC) rendering engine for Smart Forms",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/smart-forms-renderer/src/components/FormComponents/RepeatGroup/RepeatGroupView.tsx
+++ b/packages/smart-forms-renderer/src/components/FormComponents/RepeatGroup/RepeatGroupView.tsx
@@ -42,6 +42,7 @@ import GroupHeading from '../GroupItem/GroupHeading';
 import { appendRepeatIndexToLastSegment } from '../../../utils/itemPath';
 import type { ItemPath } from '../../../interfaces/itemPath.interface';
 import { getItemTextToDisplay } from '../../../utils/itemTextToDisplay';
+import { isGroupAddItemButtonHidden } from '../../../utils/extensions';
 
 interface RepeatGroupViewProps
   extends PropsWithItemPathAttribute,
@@ -135,7 +136,9 @@ function RepeatGroupView(props: RepeatGroupViewProps) {
             })}
           </TransitionGroup>
 
-          <AddItemButton repeatGroups={repeatGroups} readOnly={readOnly} onAddItem={onAddItem} />
+          {!isGroupAddItemButtonHidden(qItem) && (
+            <AddItemButton repeatGroups={repeatGroups} readOnly={readOnly} onAddItem={onAddItem} />
+          )}
         </AccordionDetails>
       </GroupAccordion>
     );
@@ -186,7 +189,9 @@ function RepeatGroupView(props: RepeatGroupViewProps) {
           })}
         </TransitionGroup>
 
-        <AddItemButton repeatGroups={repeatGroups} readOnly={readOnly} onAddItem={onAddItem} />
+        {!isGroupAddItemButtonHidden(qItem) && (
+          <AddItemButton repeatGroups={repeatGroups} readOnly={readOnly} onAddItem={onAddItem} />
+        )}
       </Card>
     </QGroupContainerBox>
   );

--- a/packages/smart-forms-renderer/src/components/FormComponents/Tables/GroupTableView.tsx
+++ b/packages/smart-forms-renderer/src/components/FormComponents/Tables/GroupTableView.tsx
@@ -46,6 +46,7 @@ import { StandardCheckbox } from '../../Checkbox.styles';
 import type { ItemPath } from '../../../interfaces/itemPath.interface';
 import { Box } from '@mui/material';
 import { getItemTextToDisplay } from '../../../utils/itemTextToDisplay';
+import { isGroupAddItemButtonHidden } from '../../../utils/extensions';
 
 interface GroupTableViewProps
   extends PropsWithIsRepeatedAttribute,
@@ -130,7 +131,7 @@ function GroupTableView(props: GroupTableViewProps) {
           {itemTextToDisplay ? <Divider sx={{ mb: 1.5, opacity: 0.6 }} /> : null}
           <TableContainer component={Paper} elevation={groupCardElevation}>
             <Table>
-              {showExtraGTableInteractions ? (
+              {showExtraGTableInteractions && !isGroupAddItemButtonHidden(qItem) ? (
                 <caption>
                   <AddRowButton repeatGroups={tableRows} readOnly={readOnly} onAddItem={onAddRow} />
                 </caption>
@@ -209,7 +210,7 @@ function GroupTableView(props: GroupTableViewProps) {
       ) : null}
       <TableContainer component={Paper} elevation={groupCardElevation}>
         <Table>
-          {showExtraGTableInteractions ? (
+          {showExtraGTableInteractions && !isGroupAddItemButtonHidden(qItem) ? (
             <caption>
               <AddRowButton repeatGroups={tableRows} readOnly={readOnly} onAddItem={onAddRow} />
             </caption>

--- a/packages/smart-forms-renderer/src/stories/assets/questionnaires/QGroupHideAddItemButton.ts
+++ b/packages/smart-forms-renderer/src/stories/assets/questionnaires/QGroupHideAddItemButton.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2025 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Questionnaire } from 'fhir/r4';
+
+export const qGroupHideAddItemButton: Questionnaire = {
+  resourceType: 'Questionnaire',
+  id: 'GroupHideAddItemButton',
+  name: 'GroupHideAddItemButton',
+  title: 'Group Hide Add Item Button Extension Demo',
+  version: '0.1.0',
+  status: 'draft',
+  publisher: 'AEHRC CSIRO',
+  date: '2025-08-01',
+  url: 'https://smartforms.csiro.au/docs/custom-extension/group-hide-add-item-button',
+  item: [
+    {
+      linkId: 'normal-repeat-group',
+      type: 'group',
+      text: 'Normal Repeating Group (Add Item button visible)',
+      repeats: true,
+      item: [
+        {
+          linkId: 'normal-name',
+          type: 'string',
+          text: 'Name',
+          required: true
+        },
+        {
+          linkId: 'normal-age',
+          type: 'integer',
+          text: 'Age'
+        }
+      ]
+    },
+    {
+      linkId: 'hidden-add-repeat-group',
+      type: 'group',
+      text: 'Repeating Group with Hidden Add Item Button',
+      repeats: true,
+      extension: [
+        {
+          url: 'https://smartforms.csiro.au/ig/StructureDefinition/GroupHideAddItemButton',
+          valueBoolean: true
+        }
+      ],
+      item: [
+        {
+          linkId: 'hidden-name',
+          type: 'string',
+          text: 'Name',
+          required: true
+        },
+        {
+          linkId: 'hidden-title',
+          type: 'string',
+          text: 'Title'
+        }
+      ]
+    },
+    {
+      linkId: 'normal-group-table',
+      type: 'group',
+      text: 'Normal Group Table (Add Row button visible)',
+      repeats: true,
+      extension: [
+        {
+          url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl',
+          valueCodeableConcept: {
+            coding: [
+              {
+                system: 'http://hl7.org/fhir/questionnaire-item-control',
+                code: 'gtable'
+              }
+            ]
+          }
+        }
+      ],
+      item: [
+        {
+          linkId: 'table-product',
+          type: 'string',
+          text: 'Product',
+          required: true
+        },
+        {
+          linkId: 'table-quantity',
+          type: 'integer',
+          text: 'Quantity'
+        },
+        {
+          linkId: 'table-price',
+          type: 'decimal',
+          text: 'Price'
+        }
+      ]
+    },
+    {
+      linkId: 'hidden-add-group-table',
+      type: 'group',
+      text: 'Group Table with Hidden Add Row Button',
+      repeats: true,
+      extension: [
+        {
+          url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl',
+          valueCodeableConcept: {
+            coding: [
+              {
+                system: 'http://hl7.org/fhir/questionnaire-item-control',
+                code: 'gtable'
+              }
+            ]
+          }
+        },
+        {
+          url: 'https://smartforms.csiro.au/ig/StructureDefinition/GroupHideAddItemButton',
+          valueBoolean: true
+        }
+      ],
+      item: [
+        {
+          linkId: 'static-item',
+          type: 'string',
+          text: 'Static Item',
+          required: true
+        },
+        {
+          linkId: 'static-value',
+          type: 'string',
+          text: 'Value'
+        }
+      ]
+    }
+  ]
+};

--- a/packages/smart-forms-renderer/src/stories/assets/questionnaires/index.ts
+++ b/packages/smart-forms-renderer/src/stories/assets/questionnaires/index.ts
@@ -41,3 +41,4 @@ export * from './QItemControlDisplay';
 export * from './QItemControlGroup';
 export * from './QItemControlQuestion';
 export * from './QTerminologyControl';
+export * from './QGroupHideAddItemButton';

--- a/packages/smart-forms-renderer/src/stories/sdc/GroupHideAddItemButton.stories.tsx
+++ b/packages/smart-forms-renderer/src/stories/sdc/GroupHideAddItemButton.stories.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import BuildFormWrapperForStorybook from '../storybookWrappers/BuildFormWrapperForStorybook';
+import { qGroupHideAddItemButton } from '../assets/questionnaires';
+
+// More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+const meta = {
+  title: 'SDC/Group Hide Add Item Button Extension',
+  component: BuildFormWrapperForStorybook,
+  parameters: {
+    docs: {
+      description: {
+        component: `
+This story demonstrates the custom GroupHideAddItemButton extension that allows hiding the "Add Item" button for repeating groups and group tables.
+
+**Extension URL:** \`https://smartforms.csiro.au/ig/StructureDefinition/GroupHideAddItemButton\`
+
+**Usage:**
+- When \`valueBoolean: true\`, the Add Item/Add Row button is hidden
+- When \`valueBoolean: false\` or extension is not present, the button is visible
+
+**Benefits:**
+- Prevents users from adding new rows/items to a Repeating Group or Group Table when not appropriate
+- Supports use cases with static tables where users shouldn't be allowed to add new rows
+
+This form shows four different scenarios:
+1. Normal Repeating Group - Add Item button is visible
+2. Repeating Group with Extension - Add Item button is hidden
+3. Normal Group Table - Add Row button is visible  
+4. Group Table with Extension - Add Row button is hidden
+        `
+      }
+    }
+  },
+  tags: ['autodocs']
+} satisfies Meta<typeof BuildFormWrapperForStorybook>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
+
+export const GroupHideAddItemButtonDemo: Story = {
+  args: {
+    questionnaire: qGroupHideAddItemButton
+  }
+}; 

--- a/packages/smart-forms-renderer/src/tests/extensions.test.ts
+++ b/packages/smart-forms-renderer/src/tests/extensions.test.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2025 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { QuestionnaireItem } from 'fhir/r4';
+import { isGroupAddItemButtonHidden } from '../utils/extensions';
+
+describe('isGroupAddItemButtonHidden', () => {
+  it('should return false when extension is not present', () => {
+    const qItem: QuestionnaireItem = {
+      linkId: 'test-group',
+      type: 'group',
+      repeats: true,
+      text: 'Test Group'
+    };
+
+    expect(isGroupAddItemButtonHidden(qItem)).toBe(false);
+  });
+
+  it('should return false when extension is present but different URL', () => {
+    const qItem: QuestionnaireItem = {
+      linkId: 'test-group',
+      type: 'group',
+      repeats: true,
+      text: 'Test Group',
+      extension: [
+        {
+          url: 'http://other-extension-url',
+          valueBoolean: true
+        }
+      ]
+    };
+
+    expect(isGroupAddItemButtonHidden(qItem)).toBe(false);
+  });
+
+  it('should return true when GroupHideAddItemButton extension is present and true', () => {
+    const qItem: QuestionnaireItem = {
+      linkId: 'test-group',
+      type: 'group',
+      repeats: true,
+      text: 'Test Group',
+      extension: [
+        {
+          url: 'https://smartforms.csiro.au/ig/StructureDefinition/GroupHideAddItemButton',
+          valueBoolean: true
+        }
+      ]
+    };
+
+    expect(isGroupAddItemButtonHidden(qItem)).toBe(true);
+  });
+
+  it('should return false when GroupHideAddItemButton extension is present but false', () => {
+    const qItem: QuestionnaireItem = {
+      linkId: 'test-group',
+      type: 'group',
+      repeats: true,
+      text: 'Test Group',
+      extension: [
+        {
+          url: 'https://smartforms.csiro.au/ig/StructureDefinition/GroupHideAddItemButton',
+          valueBoolean: false
+        }
+      ]
+    };
+
+    expect(isGroupAddItemButtonHidden(qItem)).toBe(false);
+  });
+
+  it('should return false when GroupHideAddItemButton extension is present but valueBoolean is undefined', () => {
+    const qItem: QuestionnaireItem = {
+      linkId: 'test-group',
+      type: 'group',
+      repeats: true,
+      text: 'Test Group',
+      extension: [
+        {
+          url: 'https://smartforms.csiro.au/ig/StructureDefinition/GroupHideAddItemButton'
+        }
+      ]
+    };
+
+    expect(isGroupAddItemButtonHidden(qItem)).toBe(false);
+  });
+
+  it('should handle multiple extensions and find the correct one', () => {
+    const qItem: QuestionnaireItem = {
+      linkId: 'test-group',
+      type: 'group',
+      repeats: true,
+      text: 'Test Group',
+      extension: [
+        {
+          url: 'http://other-extension-url',
+          valueString: 'some value'
+        },
+        {
+          url: 'https://smartforms.csiro.au/ig/StructureDefinition/GroupHideAddItemButton',
+          valueBoolean: true
+        },
+        {
+          url: 'http://another-extension-url',
+          valueInteger: 42
+        }
+      ]
+    };
+
+    expect(isGroupAddItemButtonHidden(qItem)).toBe(true);
+  });
+});

--- a/packages/smart-forms-renderer/src/utils/extensions.ts
+++ b/packages/smart-forms-renderer/src/utils/extensions.ts
@@ -556,3 +556,18 @@ export function isItemTextHidden(qItem: QuestionnaireItem): boolean {
 
   return !!extension?.valueBoolean;
 }
+
+/**
+ * Check if the QuestionnaireItem has a 'GroupHideAddItemButton' extension to hide the Add Item button for group tables.
+ *
+ * @param {QuestionnaireItem} qItem - The QuestionnaireItem to check.
+ * @returns {boolean} True if the Add Item button should be hidden, otherwise false.
+ */
+export function isGroupAddItemButtonHidden(qItem: QuestionnaireItem): boolean {
+  const extension = qItem.extension?.find(
+    (extension: Extension) =>
+      extension.url === 'https://smartforms.csiro.au/ig/StructureDefinition/GroupHideAddItemButton'
+  );
+
+  return !!extension?.valueBoolean;
+}


### PR DESCRIPTION
- Add isGroupAddItemButtonHidden function to extensions.ts
- Update RepeatGroupView to conditionally render Add Item button
- Update GroupTableView to conditionally render Add Row button
- Add comprehensive tests for the new extension function
- Create sample questionnaire demonstrating all use cases
- Add Storybook story for interactive testing and documentation

This implements the custom extension:
https://smartforms.csiro.au/ig/StructureDefinition/GroupHideAddItemButton

Benefits:
- Prevents users from adding new rows/items when not appropriate
- Supports static table use cases where adding rows should be disabled
- Works for both repeating groups and group tables

Resolves #1428