### PR TITLE
Add enableColorScheme at ScopedCssBaseline for native light/dark alignment with parent app

### DIFF
--- a/CHANGELOG.alpha.md
+++ b/CHANGELOG.alpha.md
@@ -7,6 +7,10 @@ This changelog only includes changes from version 1.0.0-alpha.1 onwards. For sta
 
 WARNING: Alpha releases are not stable and may contain breaking changes. Changes are also most likely to be undocumented.
 
+## [1.0.0-alpha.94] - 2025-08-20
+#### Fixed
+- Add enableColorScheme at ScopedCssBaseline for native light/dark alignment with parent app i.e. native scrollbars, native focus rings, etc.
+  Note that this doesn't provide you with dark mode. for that, you need to wrap `<BaseRenderer>` with your own light/dark-mode enabled `<ThemeProvider>`. See https://mui.com/material-ui/customization/theming/ for more details.
 
 ## [1.0.0-alpha.93] - 2025-08-19
 #### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -39348,7 +39348,7 @@
     },
     "packages/smart-forms-renderer": {
       "name": "@aehrc/smart-forms-renderer",
-      "version": "1.0.0-alpha.93",
+      "version": "1.0.0-alpha.94",
       "license": "Apache-2.0",
       "dependencies": {
         "@aehrc/sdc-populate": "^4.6.2",

--- a/packages/smart-forms-renderer/package.json
+++ b/packages/smart-forms-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aehrc/smart-forms-renderer",
-  "version": "1.0.0-alpha.93",
+  "version": "1.0.0-alpha.94",
   "description": "FHIR Structured Data Captured (SDC) rendering engine for Smart Forms",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/smart-forms-renderer/src/theme/RendererThemeProvider.tsx
+++ b/packages/smart-forms-renderer/src/theme/RendererThemeProvider.tsx
@@ -39,7 +39,7 @@ export function RendererThemeProvider({ children }: { children: ReactNode }) {
   return (
     <StyledEngineProvider injectFirst>
       <MUIThemeProvider theme={theme}>
-        <ScopedCssBaseline>{children}</ScopedCssBaseline>
+        <ScopedCssBaseline enableColorScheme>{children}</ScopedCssBaseline>
       </MUIThemeProvider>
     </StyledEngineProvider>
   );


### PR DESCRIPTION
Resolves #1492.