### PR TITLE
Explicitly set hapi.fhir.server_address in EHR launcher deployment

### DIFF
--- a/deployment/ehr-proxy/ehr-proxy-app/lib/ehr-proxy-app-stack.ts
+++ b/deployment/ehr-proxy/ehr-proxy-app/lib/ehr-proxy-app-stack.ts
@@ -35,7 +35,8 @@ export class EhrProxyAppStack extends cdk.Stack {
     });
 
     const certificate = new Certificate(this, 'EhrProxyCertificate', {
-      // This must match the fhirServerBaseUrl in services/ehr-proxy/smart-proxy/lib/index.ts - 'proxy.smartforms.io' + '/fhir'
+      // This must match `fhirServerBaseUrl` in: ../smart-proxy/lib/index.ts - 'https://proxy.smartforms.io/fhir'
+      // This must match `fhirServerBaseUrl` in: ../hapi-endpoint/lib/index.ts - 'https://proxy.smartforms.io/fhir'
       domainName: 'proxy.smartforms.io',
       validation: CertificateValidation.fromDns(hostedZone)
     });
@@ -54,52 +55,6 @@ export class EhrProxyAppStack extends cdk.Stack {
 
     const hapi = new HapiEndpoint(this, 'EhrProxyHapi', { cluster });
     const smartProxy = new SmartProxy(this, 'EhrProxySmartProxy', { cluster });
-
-    // === DECOMMISSIONED as of 1 July 2025 ===
-    // See: https://github.com/aehrc/smart-forms/issues/1337
-    // This block was previously used to configure $extract and $transform routes.
-    // It is now left here for reference only and should be removed in future cleanup.
-
-    /*
-    const extractTarget = extract.service.loadBalancerTarget({
-      containerName: extract.containerName,
-      containerPort: extract.containerPort
-    });
-    const extractTargetGroup = new ApplicationTargetGroup(this, 'EhrProxyExtractTargetGroup', {
-      vpc,
-      port: extract.containerPort,
-      protocol: ApplicationProtocol.HTTP,
-      targets: [extractTarget],
-      healthCheck: { path: '/fhir/QuestionnaireResponse/$extract' }
-    });
-    listener.addAction('EhrProxyExtractAction', {
-      action: ListenerAction.forward([extractTargetGroup]),
-      priority: 1,
-      conditions: [
-        ListenerCondition.pathPatterns([
-          '/fhir/QuestionnaireResponse/$extract',
-          '/fhir/StructureMap/$convert'
-        ])
-      ]
-    });
-
-    const transformTarget = transform.service.loadBalancerTarget({
-      containerName: transform.containerName,
-      containerPort: transform.containerPort
-    });
-    const transformTargetGroup = new ApplicationTargetGroup(this, 'EhrProxyTransformTargetGroup', {
-      vpc,
-      port: transform.containerPort,
-      protocol: ApplicationProtocol.HTTP,
-      targets: [transformTarget],
-      healthCheck: { path: '/StructureMap' }
-    });
-    listener.addAction('EhrProxyTransformAction', {
-      action: ListenerAction.forward([transformTargetGroup]),
-      priority: 2,
-      conditions: [ListenerCondition.pathPatterns(['/fhir/StructureMap/$transform'])]
-    });
-    */
 
     // Create a target for the HAPI FHIR API service
     const hapiTarget = hapi.service.loadBalancerTarget({

--- a/deployment/ehr-proxy/hapi-endpoint/lib/index.ts
+++ b/deployment/ehr-proxy/hapi-endpoint/lib/index.ts
@@ -33,6 +33,10 @@ export class HapiEndpoint extends Construct {
       memoryMiB: '2048'
     });
 
+    // This must match `Certificate.domainName` in ../ehr-proxy-app/lib/ehr-proxy-app-stack.ts - 'proxy.smartforms.io'
+    // This must match `fhirServerBaseUrl` in: ../smart-proxy/lib/index.ts - 'https://proxy.smartforms.io/fhir'
+    const fhirServerBaseUrl = 'https://proxy.smartforms.io/fhir';
+
     // Create the cache container.
     taskDefinition.addContainer('EhrProxyHapiContainer', {
       containerName: this.containerName,
@@ -44,7 +48,8 @@ export class HapiEndpoint extends Construct {
       }),
       environment: {
         use_apache_address_strategy: 'true',
-        'hapi.fhir.openapi_enabled': 'false'
+        'hapi.fhir.openapi_enabled': 'false',
+        'hapi.fhir.server_address': fhirServerBaseUrl,
       }
     });
 

--- a/deployment/ehr-proxy/smart-proxy/lib/index.ts
+++ b/deployment/ehr-proxy/smart-proxy/lib/index.ts
@@ -1,10 +1,4 @@
-import {
-  Cluster,
-  Compatibility,
-  ContainerImage,
-  FargateService,
-  TaskDefinition
-} from 'aws-cdk-lib/aws-ecs';
+import { Cluster, Compatibility, ContainerImage, FargateService, TaskDefinition } from 'aws-cdk-lib/aws-ecs';
 import { Construct } from 'constructs';
 
 export interface SmartProxyProps {
@@ -28,7 +22,8 @@ export class SmartProxy extends Construct {
       memoryMiB: '512'
     });
 
-    // This must match the domainName in services/ehr-proxy/ehr-proxy-app/lib/ehr-proxy-app-stack.ts - 'proxy.smartforms.io'
+    // This must match `Certificate.domainName` in ../ehr-proxy-app/lib/ehr-proxy-app-stack.ts - 'proxy.smartforms.io'
+    // This must match `fhirServerBaseUrl` in: ../hapi-endpoint/lib/index.ts - 'https://proxy.smartforms.io/fhir'
     const fhirServerBaseUrl = 'https://proxy.smartforms.io/fhir';
 
     // Create the cache container.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14941,9 +14941,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1020.2",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1020.2.tgz",
-      "integrity": "sha512-yWdt3dJh4aPm1VNyEgfG3lozGrvddw0i7avt+Cl9KOYixmisQtAg39/aZqzVVqjzVZVEanXmz+tlhzzh75Z69A==",
+      "version": "2.1026.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1026.0.tgz",
+      "integrity": "sha512-JdXR20s9gMHY3niweK5/D9tILLG8u2FOyJjWgSaNZGJ+pq9u0sBFxufXPO4VxJzDitGFOIW5VvQThXP+Y2VrVA==",
       "license": "Apache-2.0",
       "bin": {
         "cdk": "bin/cdk"


### PR DESCRIPTION
This addresses the problem where its not passing the "HTTPS protocol" along in the URL.
 
For context, refer https://proxy.smartforms.io/fhir/metadata and notice `implemention.url` is http://proxy.smartforms.io/fhir (HTTP instead of HTTPS). So when Inferno tries to use the next pagination link (https://proxy.smartforms.io/v/r4/fhir/Observation `link[1].url`), it tries to hit the HTTP link which doesn't exist, resulting in a timeout.