### PR TITLE
fix: resolve OpenChoice reset functionality issues

### DIFF
--- a/packages/smart-forms-renderer/src/components/FormComponents/OpenChoiceItems/OpenChoiceCheckboxAnswerOptionItem.tsx
+++ b/packages/smart-forms-renderer/src/components/FormComponents/OpenChoiceItems/OpenChoiceCheckboxAnswerOptionItem.tsx
@@ -170,6 +170,7 @@ function OpenChoiceCheckboxAnswerOptionItem(props: OpenChoiceCheckboxAnswerOptio
   function handleClear() {
     onQrItemChange(createEmptyQrItem(qItem, answerKey));
     setOpenLabelChecked(false);
+    setOpenLabelValue('');
   }
 
   if (isTabled) {

--- a/packages/smart-forms-renderer/src/components/FormComponents/OpenChoiceItems/OpenChoiceCheckboxAnswerValueSetItem.tsx
+++ b/packages/smart-forms-renderer/src/components/FormComponents/OpenChoiceItems/OpenChoiceCheckboxAnswerValueSetItem.tsx
@@ -174,6 +174,7 @@ function OpenChoiceCheckboxAnswerValueSetItem(props: OpenChoiceCheckboxAnswerVal
   function handleClear() {
     onQrItemChange(createEmptyQrItem(qItem, answerKey));
     setOpenLabelChecked(false);
+    setOpenLabelValue('');
   }
 
   if (isTabled) {

--- a/packages/smart-forms-renderer/src/components/FormComponents/OpenChoiceItems/OpenChoiceRadioAnswerOptionItem.tsx
+++ b/packages/smart-forms-renderer/src/components/FormComponents/OpenChoiceItems/OpenChoiceRadioAnswerOptionItem.tsx
@@ -144,6 +144,7 @@ function OpenChoiceRadioAnswerOptionItem(props: OpenChoiceRadioAnswerOptionItemP
       // If open label is unchecked, remove it from answers
       if (changedOpenLabelValue === '') {
         onQrItemChange(createEmptyQrItem(qItem, answerKey));
+        setOpenLabelSelected(false);
         return;
       }
 
@@ -159,6 +160,7 @@ function OpenChoiceRadioAnswerOptionItem(props: OpenChoiceRadioAnswerOptionItemP
   function handleClear() {
     onQrItemChange(createEmptyQrItem(qItem, answerKey));
     setOpenLabelSelected(false);
+    setOpenLabelValue('');
   }
 
   return (

--- a/packages/smart-forms-renderer/src/components/FormComponents/OpenChoiceItems/OpenChoiceRadioAnswerValueSetItem.tsx
+++ b/packages/smart-forms-renderer/src/components/FormComponents/OpenChoiceItems/OpenChoiceRadioAnswerValueSetItem.tsx
@@ -148,6 +148,7 @@ function OpenChoiceRadioAnswerValueSetItem(props: OpenChoiceRadioAnswerValueSetI
       // If open label is unchecked, remove it from answers
       if (changedOpenLabelValue === '') {
         onQrItemChange(createEmptyQrItem(qItem, answerKey));
+        setOpenLabelSelected(false);
         return;
       }
 
@@ -163,6 +164,7 @@ function OpenChoiceRadioAnswerValueSetItem(props: OpenChoiceRadioAnswerValueSetI
   function handleClear() {
     onQrItemChange(createEmptyQrItem(qItem, answerKey));
     setOpenLabelSelected(false);
+    setOpenLabelValue('');
   }
 
   return (


### PR DESCRIPTION
- Fix small X (input cleaner) to uncheck radio/checkbox when clearing input text
- Fix big X (right-side cleaner) to clear input text when resetting selection
- Apply fixes to all OpenChoice component variants:
  - OpenChoiceRadioAnswerOptionItem
  - OpenChoiceCheckboxAnswerOptionItem
  - OpenChoiceCheckboxAnswerValueSetItem
  - OpenChoiceRadioAnswerValueSetItem

Both reset methods now properly clear both input text and selection state, providing consistent behavior across all OpenChoice components.

Fixes #1530