### PR TITLE
fix: Time control now produces correct FHIR format (HH:mm:ss)

### DIFF
--- a/packages/smart-forms-renderer/src/components/FormComponents/TimeItem/TimeItem.tsx
+++ b/packages/smart-forms-renderer/src/components/FormComponents/TimeItem/TimeItem.tsx
@@ -49,13 +49,13 @@ function TimeItem(props: BaseItemProps) {
   if (qrItem?.answer && qrItem?.answer[0].valueTime) {
     timeString = qrItem.answer[0].valueTime;
   }
-  const timeDayJs = timeString ? dayjs(timeString) : null;
+  const timeDayJs = timeString ? dayjs(timeString, 'HH:mm:ss') : null;
 
   // Event handlers
   function handleTimeChange(newValue: Dayjs | null) {
     const emptyQrItem = createEmptyQrItem(qItem, answerKey);
     if (newValue) {
-      onQrItemChange({ ...emptyQrItem, answer: [{ id: answerKey, valueTime: newValue.format() }] });
+      onQrItemChange({ ...emptyQrItem, answer: [{ id: answerKey, valueTime: newValue.format('HH:mm:ss') }] });
     } else {
       onQrItemChange(emptyQrItem);
     }


### PR DESCRIPTION
- Fix TimeItem.tsx to format time output as HH:mm:ss instead of full datetime
- Fix time parsing to properly handle time-only strings with dayjs format
- Resolves issue where time input '11:00 am' was producing '2025-09-04T11:00:00+03:00'
- Now correctly produces '11:00:00' as expected by FHIR specification

Resolves #1532