### PR TITLE
fix: Time prepopulation now works correctly with valueTime format

### DIFF
--- a/packages/smart-forms-renderer/src/components/FormComponents/TimeItem/TimeItem.tsx
+++ b/packages/smart-forms-renderer/src/components/FormComponents/TimeItem/TimeItem.tsx
@@ -49,7 +49,7 @@ function TimeItem(props: BaseItemProps) {
   if (qrItem?.answer && qrItem?.answer[0].valueTime) {
     timeString = qrItem.answer[0].valueTime;
   }
-  const timeDayJs = timeString ? dayjs(timeString) : null;
+  const timeDayJs = timeString ? dayjs(timeString, 'HH:mm:ss') : null;
 
   // Event handlers
   function handleTimeChange(newValue: Dayjs | null) {


### PR DESCRIPTION
- Fix TimeItem.tsx to properly parse time-only strings with dayjs format
- Resolves issue where QR with valueTime: '11:00:00' was not prepopulating correctly
- Now correctly displays '11:00 am' when prepopulating from '11:00:00' valueTime
- Ensures proper parsing of HH:mm:ss format for time prepopulation

Resolves #1531