### PR TITLE
feat: Associate instruction text with input fields using aria-describ…

### DIFF
--- a/packages/smart-forms-renderer/src/components/FormComponents/DisplayItem/DisplayInstructions.tsx
+++ b/packages/smart-forms-renderer/src/components/FormComponents/DisplayItem/DisplayInstructions.tsx
@@ -21,15 +21,16 @@ import Typography from '@mui/material/Typography';
 import { DisplayInstructionsWrapper } from './DisplayInstructions.styles';
 
 interface DisplayInstructionsProps {
+  id?: string;
   readOnly: boolean;
   children?: ReactNode;
 }
 
 const DisplayInstructions = memo(function DisplayInstructions(props: DisplayInstructionsProps) {
-  const { readOnly, children } = props;
+  const { id, readOnly, children } = props;
 
   return children ? (
-    <DisplayInstructionsWrapper>
+    <DisplayInstructionsWrapper id={id}>
       <Typography
         component="span"
         variant="caption"

--- a/packages/smart-forms-renderer/src/components/FormComponents/ItemParts/ItemFieldGrid.tsx
+++ b/packages/smart-forms-renderer/src/components/FormComponents/ItemParts/ItemFieldGrid.tsx
@@ -33,6 +33,63 @@ interface ItemFieldGridProps {
   timeFeedback?: string;
 }
 
+/**
+ * Helper function to generate instruction ID if instructions exist and there's no feedback
+ */
+export function getInstructionsId(
+  qItem: QuestionnaireItem,
+  displayInstructions: string,
+  hasFeedback: boolean
+): string | undefined {
+  return displayInstructions && !hasFeedback ? `instructions-${qItem.linkId}` : undefined;
+}
+
+/**
+ * Recursively add aria-describedby to input/textarea elements and radio/checkbox groups in the React tree
+ */
+function addAriaDescribedBy(children: ReactNode, instructionsId: string): ReactNode {
+  return React.Children.map(children, (child) => {
+    if (!React.isValidElement(child)) {
+      return child;
+    }
+
+    const element = child as React.ReactElement<any>;
+
+    // Add aria-describedby to input elements
+    if (element.type === 'input' || element.type === 'textarea') {
+      const existingDescribedBy = element.props['aria-describedby'];
+      const newDescribedBy = existingDescribedBy
+        ? `${existingDescribedBy} ${instructionsId}`
+        : instructionsId;
+
+      return React.cloneElement(element, {
+        'aria-describedby': newDescribedBy
+      });
+    }
+
+    // Add aria-describedby to RadioGroup and FormGroup (for radio buttons and checkboxes)
+    if (element.type && typeof element.type === 'object' && 'render' in element.type) {
+      const existingDescribedBy = element.props['aria-describedby'];
+      const newDescribedBy = existingDescribedBy
+        ? `${existingDescribedBy} ${instructionsId}`
+        : instructionsId;
+
+      return React.cloneElement(element, {
+        'aria-describedby': newDescribedBy
+      });
+    }
+
+    // Recursively process children
+    if (element.props && element.props.children) {
+      return React.cloneElement(element, {
+        children: addAriaDescribedBy(element.props.children, instructionsId)
+      });
+    }
+
+    return child;
+  });
+}
+
 function ItemFieldGrid(props: ItemFieldGridProps) {
   const { qItem, readOnly, labelChildren, fieldChildren } = props;
 
@@ -41,6 +98,18 @@ function ItemFieldGrid(props: ItemFieldGridProps) {
 
   const { displayInstructions } = useRenderingExtensions(qItem);
 
+  // Generate instruction ID if instructions exist
+  const instructionsId =
+    displayInstructions && !props.feedback && !props.dateFeedback && !props.timeFeedback
+      ? `instructions-${qItem.linkId}`
+      : undefined;
+
+  // Add aria-describedby to field children if instructions exist
+  const enhancedFieldChildren =
+    instructionsId && fieldChildren
+      ? addAriaDescribedBy(fieldChildren, instructionsId)
+      : fieldChildren;
+
   return (
     <Grid container columnSpacing={columnGapPixels + 'px'} rowGap={rowGapPixels + 'px'}>
       {/* NOTE: Boolean checkboxes now have labels which uses <SrOnly/>, similar to tailwind's sr-only class  */}
@@ -48,10 +117,12 @@ function ItemFieldGrid(props: ItemFieldGridProps) {
         <>{labelChildren}</>
       </Grid>
       <Grid size={{ ...fieldBreakpoints }}>
-        <>{fieldChildren}</>
+        <>{enhancedFieldChildren}</>
         {/* Only show display instructions if there is no feedback of any type */}
-        {!props.feedback && !props.dateFeedback && !props.timeFeedback && (
-          <DisplayInstructions readOnly={readOnly}>{displayInstructions}</DisplayInstructions>
+        {instructionsId && (
+          <DisplayInstructions id={instructionsId} readOnly={readOnly}>
+            {displayInstructions}
+          </DisplayInstructions>
         )}
       </Grid>
     </Grid>

--- a/packages/smart-forms-renderer/src/stories/itemTypes/Boolean.stories.tsx
+++ b/packages/smart-forms-renderer/src/stories/itemTypes/Boolean.stories.tsx
@@ -27,7 +27,7 @@ import {
   questionnaireFactory,
   questionnaireResponseFactory
 } from '../testUtils';
-import { expect, fireEvent } from 'storybook/test';
+import { expect, fireEvent, within } from 'storybook/test';
 import { createStory } from '../storybookWrappers/createStory';
 
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
@@ -163,5 +163,58 @@ export const BooleanCheckboxResponse: Story = createStory({
     const input = element.querySelector('input');
 
     expect(input).toBeChecked();
+  }
+}) as Story;
+
+/* Boolean with instructions for accessibility testing */
+const qBooleanAccessibility = questionnaireFactory([
+  {
+    linkId: 'consent',
+    type: 'boolean',
+    repeats: false,
+    text: 'I agree to the terms and conditions',
+    item: [
+      {
+        linkId: 'consent-instructions',
+        type: 'display',
+        text: 'Please read the terms carefully before agreeing',
+        extension: [
+          {
+            url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-displayCategory',
+            valueCodeableConcept: {
+              coding: [
+                {
+                  system: 'http://hl7.org/fhir/questionnaire-display-category',
+                  code: 'instructions'
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  }
+]);
+
+export const BooleanInstructionsAccessibility: Story = createStory({
+  args: {
+    questionnaire: qBooleanAccessibility
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const inputField = canvas.getByTestId('q-item-boolean-field');
+    const radioGroup = inputField.querySelector('[role="radiogroup"]');
+    const ariaDescribedBy = radioGroup?.getAttribute('aria-describedby');
+
+    // Check that aria-describedby is present and references the instructions
+    expect(ariaDescribedBy).toBeTruthy();
+    expect(ariaDescribedBy).toContain('instructions-consent');
+
+    // Check that the instructions element exists with the correct ID
+    const instructionsElement = document.getElementById('instructions-consent');
+    expect(instructionsElement).toBeTruthy();
+    expect(instructionsElement?.textContent).toContain(
+      'Please read the terms carefully before agreeing'
+    );
   }
 }) as Story;

--- a/packages/smart-forms-renderer/src/stories/itemTypes/String.stories.tsx
+++ b/packages/smart-forms-renderer/src/stories/itemTypes/String.stories.tsx
@@ -25,7 +25,7 @@ import {
   questionnaireFactory,
   questionnaireResponseFactory
 } from '../testUtils';
-import { expect, fireEvent } from 'storybook/test';
+import { expect, fireEvent, within } from 'storybook/test';
 import { createStory } from '../storybookWrappers/createStory';
 
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
@@ -100,5 +100,56 @@ export const StringBasicResponse: Story = createStory({
     const inputText = await getInputText(canvasElement, targetLinkId);
 
     expect(inputText).toBe(targetInput);
+  }
+}) as Story;
+
+/* String with instructions for accessibility testing */
+const qStringAccessibility = questionnaireFactory([
+  {
+    linkId: 'email',
+    type: 'string',
+    repeats: false,
+    text: 'Email Address',
+    item: [
+      {
+        linkId: 'email-instructions',
+        type: 'display',
+        text: 'Please enter your work email address',
+        extension: [
+          {
+            url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-displayCategory',
+            valueCodeableConcept: {
+              coding: [
+                {
+                  system: 'http://hl7.org/fhir/questionnaire-display-category',
+                  code: 'instructions'
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  }
+]);
+
+export const StringInstructionsAccessibility: Story = createStory({
+  args: {
+    questionnaire: qStringAccessibility
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const inputField = canvas.getByTestId('q-item-string-field');
+    const textarea = inputField.querySelector('textarea');
+    const ariaDescribedBy = textarea?.getAttribute('aria-describedby');
+
+    // Check that aria-describedby is present and references the instructions
+    expect(ariaDescribedBy).toBeTruthy();
+    expect(ariaDescribedBy).toContain('instructions-email');
+
+    // Check that the instructions element exists with the correct ID
+    const instructionsElement = document.getElementById('instructions-email');
+    expect(instructionsElement).toBeTruthy();
+    expect(instructionsElement?.textContent).toContain('Please enter your work email address');
   }
 }) as Story;

--- a/packages/smart-forms-renderer/src/stories/itemTypes/Text.stories.tsx
+++ b/packages/smart-forms-renderer/src/stories/itemTypes/Text.stories.tsx
@@ -25,7 +25,7 @@ import {
   questionnaireFactory,
   questionnaireResponseFactory
 } from '../testUtils';
-import { expect, fireEvent } from 'storybook/test';
+import { expect, fireEvent, within } from 'storybook/test';
 import { createStory } from '../storybookWrappers/createStory';
 
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
@@ -98,5 +98,58 @@ export const TextBasicResponse: Story = createStory({
     const inputText = await getInputText(canvasElement, targetLinkId);
 
     expect(inputText).toBe(targetInput);
+  }
+}) as Story;
+
+/* Text with instructions for accessibility testing */
+const qTextAccessibility = questionnaireFactory([
+  {
+    linkId: 'comments',
+    type: 'text',
+    repeats: false,
+    text: 'Additional Comments',
+    item: [
+      {
+        linkId: 'comments-instructions',
+        type: 'display',
+        text: 'Please provide any additional information you think is relevant',
+        extension: [
+          {
+            url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-displayCategory',
+            valueCodeableConcept: {
+              coding: [
+                {
+                  system: 'http://hl7.org/fhir/questionnaire-display-category',
+                  code: 'instructions'
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  }
+]);
+
+export const TextInstructionsAccessibility: Story = createStory({
+  args: {
+    questionnaire: qTextAccessibility
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const inputField = canvas.getByTestId('q-item-text-field');
+    const textarea = inputField.querySelector('textarea');
+    const ariaDescribedBy = textarea?.getAttribute('aria-describedby');
+
+    // Check that aria-describedby is present and references the instructions
+    expect(ariaDescribedBy).toBeTruthy();
+    expect(ariaDescribedBy).toContain('instructions-comments');
+
+    // Check that the instructions element exists with the correct ID
+    const instructionsElement = document.getElementById('instructions-comments');
+    expect(instructionsElement).toBeTruthy();
+    expect(instructionsElement?.textContent).toContain(
+      'Please provide any additional information you think is relevant'
+    );
   }
 }) as Story;


### PR DESCRIPTION
…edby (#1640)

This commit implements accessibility improvements by associating instructional text with their parent form fields using the aria-describedby attribute.

Changes:
- Modified ItemFieldGrid to recursively add aria-describedby to input/textarea elements and radio/checkbox groups when instructions are present
- Added getInstructionsId helper function to generate instruction IDs
- Updated DisplayInstructions component to accept an optional id prop
- Added Storybook tests for String, Boolean, and Text items to verify aria-describedby functionality with instruction text

Screen readers will now announce instructional text when a field receives focus, improving the accessibility experience for users with visual impairments.

Fixes #1640