### PR TITLE
Add clone response feature

### DIFF
--- a/apps/smart-forms-app/src/features/dashboard/components/DashboardPages/ResponsesPage/Buttons/CloneResponseButton.tsx
+++ b/apps/smart-forms-app/src/features/dashboard/components/DashboardPages/ResponsesPage/Buttons/CloneResponseButton.tsx
@@ -129,11 +129,10 @@ function CloneResponseButton(props: CloneResponseButtonProps) {
     }
 
     // Create a cloned response - strip id, meta, and authored so it is treated as a new response
-    const { id: _id, meta: _meta, authored: _authored, ...clonedResponse } = selectedResponse;
-    const newResponse: QuestionnaireResponse = {
-      ...clonedResponse,
-      status: 'in-progress'
-    };
+    const newResponse: QuestionnaireResponse = { ...selectedResponse, status: 'in-progress' };
+    delete newResponse.id;
+    delete newResponse.meta;
+    delete newResponse.authored;
 
     // Build form with cloned response content - no pre-population occurs
     await resetAndBuildForm({

--- a/apps/smart-forms-app/src/features/dashboard/components/DashboardPages/ResponsesPage/Buttons/CloneResponseButton.tsx
+++ b/apps/smart-forms-app/src/features/dashboard/components/DashboardPages/ResponsesPage/Buttons/CloneResponseButton.tsx
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2025 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useContext, useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import type { Bundle, Questionnaire, QuestionnaireResponse } from 'fhir/r4';
+import {
+  getFormsServerBundleOrQuestionnairePromise,
+  getReferencedQuestionnaire
+} from '../../../../utils/dashboard.ts';
+import { useNavigate } from 'react-router-dom';
+import { useSnackbar } from 'notistack';
+import { postQuestionnaireToSMARTHealthIT } from '../../../../../../api/saveQr.ts';
+import { assembleIfRequired } from '../../../../../../utils/assemble.ts';
+import { CircularProgress, IconButton, Stack, Typography } from '@mui/material';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import useSmartClient from '../../../../../../hooks/useSmartClient.ts';
+import CloseSnackbar from '../../../../../../components/Snackbar/CloseSnackbar.tsx';
+import { resetAndBuildForm } from '../../../../../../utils/manageForm.ts';
+import { ConfigContext } from '../../../../../configChecker/contexts/ConfigContext.tsx';
+
+interface CloneResponseButtonProps {
+  selectedResponse: QuestionnaireResponse | null;
+}
+
+function CloneResponseButton(props: CloneResponseButtonProps) {
+  const { selectedResponse } = props;
+
+  const { smartClient, patient } = useSmartClient();
+  const { config } = useContext(ConfigContext);
+
+  const [isLoading, setIsLoading] = useState(false);
+
+  const navigate = useNavigate();
+  const { enqueueSnackbar } = useSnackbar();
+
+  // reference could either be a canonical or an id
+  const questionnaireRef = selectedResponse?.questionnaire;
+
+  let queryUrl = '';
+  if (questionnaireRef) {
+    queryUrl += questionnaireRef?.startsWith('http')
+      ? `/Questionnaire?_sort=-date&url=${questionnaireRef}`
+      : `/${questionnaireRef}`;
+  }
+
+  // search referenced questionnaire
+  const { data, error } = useQuery<Bundle | Questionnaire>({
+    queryKey: ['referencedQuestionnaire', queryUrl],
+    queryFn: () => getFormsServerBundleOrQuestionnairePromise(queryUrl, config.formsServerUrl),
+    enabled: !!selectedResponse && !!questionnaireRef
+  });
+
+  if (error) {
+    console.error(error);
+    enqueueSnackbar('There might be an issue with this response', {
+      variant: 'warning',
+      action: <CloseSnackbar variant="warning" />
+    });
+  }
+
+  let referencedQuestionnaire: Questionnaire | null = useMemo(
+    () => getReferencedQuestionnaire(data),
+    [data]
+  );
+
+  async function handleClick() {
+    if (!selectedResponse) {
+      enqueueSnackbar('No response selected.', {
+        variant: 'error',
+        action: <CloseSnackbar variant="error" />
+      });
+      return;
+    }
+
+    if (!referencedQuestionnaire) {
+      enqueueSnackbar('Referenced questionnaire of selected response not found', {
+        variant: 'error',
+        action: <CloseSnackbar variant="error" />
+      });
+      return;
+    }
+
+    if (!smartClient || !patient) {
+      enqueueSnackbar('App not launched via SMART App Launch, unable to clone response', {
+        variant: 'error',
+        action: <CloseSnackbar variant="error" />
+      });
+      return;
+    }
+
+    setIsLoading(true);
+
+    // Assemble questionnaire if selected response is linked to an assemble-root questionnaire
+    referencedQuestionnaire = await assembleIfRequired(
+      referencedQuestionnaire,
+      config.formsServerUrl
+    );
+
+    // Return early if assembly cannot be performed
+    if (!referencedQuestionnaire) {
+      console.error(error);
+      enqueueSnackbar('Referenced questionnaire not found. Unable to clone response', {
+        variant: 'error',
+        action: <CloseSnackbar variant="error" />
+      });
+      setIsLoading(false);
+      return;
+    }
+
+    // Post questionnaire to client if it is SMART Health IT
+    if (smartClient.state.serverUrl.includes('https://launch.smarthealthit.org/v/r4/fhir')) {
+      referencedQuestionnaire.id = referencedQuestionnaire.id + '-SMARTcopy';
+      postQuestionnaireToSMARTHealthIT(smartClient, referencedQuestionnaire);
+    }
+
+    // Create a cloned response - strip id, meta, and authored so it is treated as a new response
+    const { id: _id, meta: _meta, authored: _authored, ...clonedResponse } = selectedResponse;
+    const newResponse: QuestionnaireResponse = {
+      ...clonedResponse,
+      status: 'in-progress'
+    };
+
+    // Build form with cloned response content - no pre-population occurs
+    await resetAndBuildForm({
+      questionnaire: referencedQuestionnaire,
+      questionnaireResponse: newResponse,
+      terminologyServerUrl: config.terminologyServerUrl
+    });
+
+    // Pass isClone flag via router state so RendererLayout skips pre-population
+    navigate('/renderer', { state: { isClone: true } });
+    setIsLoading(false);
+  }
+
+  const buttonIsDisabled = !selectedResponse || !referencedQuestionnaire || isLoading;
+
+  return (
+    <Stack alignItems="center">
+      <IconButton
+        disabled={buttonIsDisabled}
+        color="secondary"
+        onClick={handleClick}
+        data-test="button-clone-response">
+        {isLoading ? (
+          <CircularProgress size={20} color="inherit" sx={{ mb: 0.5 }} />
+        ) : (
+          <ContentCopyIcon />
+        )}
+      </IconButton>
+
+      <Typography
+        fontSize={9}
+        variant="subtitle2"
+        color={buttonIsDisabled ? 'text.disabled' : 'secondary'}
+        textAlign="center"
+        sx={{ mt: -0.5, mb: 0.5 }}>
+        Clone response
+      </Typography>
+    </Stack>
+  );
+}
+
+export default CloneResponseButton;

--- a/apps/smart-forms-app/src/features/dashboard/components/DashboardPages/ResponsesPage/TableComponents/ResponseListToolbarButtons.tsx
+++ b/apps/smart-forms-app/src/features/dashboard/components/DashboardPages/ResponsesPage/TableComponents/ResponseListToolbarButtons.tsx
@@ -19,6 +19,7 @@ import { Box, IconButton, Stack, Typography } from '@mui/material';
 import ClearIcon from '@mui/icons-material/Clear';
 import { constructName } from '../../../../../../utils/humanName.ts';
 import OpenResponseButton from '../Buttons/OpenResponseButton.tsx';
+import CloneResponseButton from '../Buttons/CloneResponseButton.tsx';
 import type { QuestionnaireResponse } from 'fhir/r4';
 import useSmartClient from '../../../../../../hooks/useSmartClient.ts';
 import useSelectedQuestionnaire from '../../../../hooks/useSelectedQuestionnaire.ts';
@@ -44,6 +45,7 @@ function ResponseListToolbarButtons(props: ResponseListToolbarButtonsProps) {
     return (
       <Box display="flex" alignItems="center" columnGap={2}>
         <OpenResponseButton selectedResponse={selectedResponse} />
+        <CloneResponseButton selectedResponse={selectedResponse} />
         <Stack alignItems="center">
           <IconButton onClick={onClearSelection}>
             <ClearIcon />

--- a/apps/smart-forms-app/src/features/renderer/components/ExistingResponses/ExistingResponsesTableToolbarButtons.tsx
+++ b/apps/smart-forms-app/src/features/renderer/components/ExistingResponses/ExistingResponsesTableToolbarButtons.tsx
@@ -20,6 +20,7 @@ import ClearIcon from '@mui/icons-material/Clear';
 import CreateNewResponseButton from '../../../dashboard/components/DashboardPages/QuestionnairePage/Buttons/CreateNewResponseButton.tsx';
 import type { QuestionnaireResponse } from 'fhir/r4';
 import OpenResponseButton from '../../../dashboard/components/DashboardPages/ResponsesPage/Buttons/OpenResponseButton.tsx';
+import CloneResponseButton from '../../../dashboard/components/DashboardPages/ResponsesPage/Buttons/CloneResponseButton.tsx';
 
 interface ExistingResponsesTableToolbarButtonsProps {
   selectedResponse: QuestionnaireResponse | null;
@@ -33,6 +34,7 @@ function ExistingResponsesTableToolbarButtons(props: ExistingResponsesTableToolb
     return (
       <Box display="flex" alignItems="center" columnGap={2}>
         <OpenResponseButton selectedResponse={selectedResponse} />
+        <CloneResponseButton selectedResponse={selectedResponse} />
         <Stack alignItems="center">
           <IconButton onClick={onClearSelection}>
             <ClearIcon />

--- a/apps/smart-forms-app/src/features/renderer/components/RendererLayout.tsx
+++ b/apps/smart-forms-app/src/features/renderer/components/RendererLayout.tsx
@@ -33,6 +33,7 @@ import { useQuestionnaireResponseStore, useResponsive } from '@aehrc/smart-forms
 import useSmartClient from '../../../hooks/useSmartClient.ts';
 import type { RendererSpinner } from '../types/rendererSpinner.ts';
 import RepopulateBackdrop from '../../repopulate/components/RepopulateBackdrop.tsx';
+import { useLocation } from 'react-router-dom';
 
 function RendererLayout() {
   const { smartClient, patient, user } = useSmartClient();
@@ -43,8 +44,11 @@ function RendererLayout() {
   const [desktopNavCollapsed, setDesktopNavCollapsed] = useState(false);
 
   // Init population spinner
+  // Skip pre-population if navigated here via CloneResponseButton (isClone passed via router state)
+  const { state } = useLocation();
+  const isCloneLoad = !!(state as { isClone?: boolean } | null)?.isClone;
   let initialSpinner: RendererSpinner = { isSpinning: false, status: 'prepopulate', message: '' };
-  if (smartClient && patient && user && !sourceResponse.id) {
+  if (smartClient && patient && user && !sourceResponse.id && !isCloneLoad) {
     initialSpinner = {
       isSpinning: true,
       status: 'prepopulate',

--- a/apps/smart-forms-app/src/features/viewer/ViewerNav/ViewerCloneResponseAction.tsx
+++ b/apps/smart-forms-app/src/features/viewer/ViewerNav/ViewerCloneResponseAction.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import {
+  buildForm,
+  useQuestionnaireResponseStore,
+  useQuestionnaireStore,
+  useTerminologyServerStore
+} from '@aehrc/smart-forms-renderer';
+import ViewerOperationItem from './ViewerOperationItem.tsx';
+import type { QuestionnaireResponse } from 'fhir/r4';
+
+function ViewerCloneResponseAction() {
+  const sourceQuestionnaire = useQuestionnaireStore.use.sourceQuestionnaire();
+  const sourceResponse = useQuestionnaireResponseStore.use.sourceResponse();
+  const terminologyServerUrl = useTerminologyServerStore.use.url();
+
+  const [isLoading, setIsLoading] = useState(false);
+
+  const navigate = useNavigate();
+
+  async function handleClone() {
+    setIsLoading(true);
+
+    // Strip id, meta and authored so the response is treated as new when saved
+    const { id: _id, meta: _meta, authored: _authored, ...clonedResponse } = sourceResponse;
+    const newResponse: QuestionnaireResponse = {
+      ...clonedResponse,
+      status: 'in-progress'
+    };
+
+    await buildForm({
+      questionnaire: sourceQuestionnaire,
+      questionnaireResponse: newResponse,
+      terminologyServerUrl
+    });
+
+    // Pass isClone flag via router state so RendererLayout skips pre-population
+    navigate('/renderer', { state: { isClone: true } });
+    setIsLoading(false);
+  }
+
+  return (
+    <ViewerOperationItem
+      title="Clone Response"
+      icon={<ContentCopyIcon />}
+      disabled={isLoading}
+      onClick={handleClone}
+    />
+  );
+}
+
+export default ViewerCloneResponseAction;

--- a/apps/smart-forms-app/src/features/viewer/ViewerNav/ViewerCloneResponseAction.tsx
+++ b/apps/smart-forms-app/src/features/viewer/ViewerNav/ViewerCloneResponseAction.tsx
@@ -40,11 +40,10 @@ function ViewerCloneResponseAction() {
     setIsLoading(true);
 
     // Strip id, meta and authored so the response is treated as new when saved
-    const { id: _id, meta: _meta, authored: _authored, ...clonedResponse } = sourceResponse;
-    const newResponse: QuestionnaireResponse = {
-      ...clonedResponse,
-      status: 'in-progress'
-    };
+    const newResponse: QuestionnaireResponse = { ...sourceResponse, status: 'in-progress' };
+    delete newResponse.id;
+    delete newResponse.meta;
+    delete newResponse.authored;
 
     await buildForm({
       questionnaire: sourceQuestionnaire,

--- a/apps/smart-forms-app/src/features/viewer/ViewerNav/ViewerOperationSection.tsx
+++ b/apps/smart-forms-app/src/features/viewer/ViewerNav/ViewerOperationSection.tsx
@@ -25,6 +25,7 @@ import PrintIcon from '@mui/icons-material/Print';
 import { PrintComponentRefContext } from '../ViewerLayout.tsx';
 import { useReactToPrint } from 'react-to-print';
 import ViewerOperationItem from './ViewerOperationItem.tsx';
+import ViewerCloneResponseAction from './ViewerCloneResponseAction.tsx';
 import {
   NavSectionHeading,
   NavSectionHeadingWrapper,
@@ -94,6 +95,7 @@ function ViewerOperationSection() {
             }}
           />
         ) : null}
+        <ViewerCloneResponseAction />
         <ViewerOperationItem title={'Print Preview'} icon={<PrintIcon />} onClick={handlePrint} />
       </List>
     </NavSectionWrapper>


### PR DESCRIPTION
Adds a "Clone response" action to the dashboard responses table, the in-renderer existing responses table, and the viewer operations bar. Cloning strips id/meta/authored and resets status to in-progress so the clone is saved as a new response. Pre-population is skipped on load via router state.