### PR TITLE
Increase populate timeout to 30s

### DIFF
--- a/apps/smart-forms-app/src/features/prepopulate/hooks/usePopulate.tsx
+++ b/apps/smart-forms-app/src/features/prepopulate/hooks/usePopulate.tsx
@@ -96,8 +96,7 @@ function usePopulate(spinner: RendererSpinner, onStopSpinner: () => void): void 
     fetchTerminologyCallback: fetchTerminologyCallback,
     fetchTerminologyRequestConfig: {
       terminologyServerUrl: defaultTerminologyServerUrl
-    },
-    timeoutMs: 30000
+    }
   })
     .then(async (populateRes) => {
       if (!populateRes) {

--- a/apps/smart-forms-app/src/features/prepopulate/hooks/usePopulate.tsx
+++ b/apps/smart-forms-app/src/features/prepopulate/hooks/usePopulate.tsx
@@ -81,7 +81,7 @@ function usePopulate(spinner: RendererSpinner, onStopSpinner: () => void): void 
 
   setIsPopulated(true);
 
-  const populateParams = {
+  populateQuestionnaire({
     questionnaire: sourceQuestionnaire,
     fetchResourceCallback: fetchResourceCallback,
     fetchResourceRequestConfig: {
@@ -96,17 +96,9 @@ function usePopulate(spinner: RendererSpinner, onStopSpinner: () => void): void 
     fetchTerminologyCallback: fetchTerminologyCallback,
     fetchTerminologyRequestConfig: {
       terminologyServerUrl: defaultTerminologyServerUrl
-    }
-  };
-
-  populateQuestionnaire(populateParams)
-    .then((populateRes) => {
-      // Retry once if the first attempt fails - handles transient server slowness on first use
-      if (!populateRes?.populateSuccess || !populateRes?.populateResult) {
-        return populateQuestionnaire(populateParams);
-      }
-      return populateRes;
-    })
+    },
+    timeoutMs: 30000
+  })
     .then(async (populateRes) => {
       if (!populateRes) {
         onStopSpinner();

--- a/apps/smart-forms-app/src/features/prepopulate/hooks/usePopulate.tsx
+++ b/apps/smart-forms-app/src/features/prepopulate/hooks/usePopulate.tsx
@@ -80,7 +80,8 @@ function usePopulate(spinner: RendererSpinner, onStopSpinner: () => void): void 
   }
 
   setIsPopulated(true);
-  populateQuestionnaire({
+
+  const populateParams = {
     questionnaire: sourceQuestionnaire,
     fetchResourceCallback: fetchResourceCallback,
     fetchResourceRequestConfig: {
@@ -96,7 +97,16 @@ function usePopulate(spinner: RendererSpinner, onStopSpinner: () => void): void 
     fetchTerminologyRequestConfig: {
       terminologyServerUrl: defaultTerminologyServerUrl
     }
-  })
+  };
+
+  populateQuestionnaire(populateParams)
+    .then((populateRes) => {
+      // Retry once if the first attempt fails - handles transient server slowness on first use
+      if (!populateRes?.populateSuccess || !populateRes?.populateResult) {
+        return populateQuestionnaire(populateParams);
+      }
+      return populateRes;
+    })
     .then(async (populateRes) => {
       if (!populateRes) {
         onStopSpinner();

--- a/apps/smart-forms-app/src/features/prepopulate/test/usePopulate.test.tsx
+++ b/apps/smart-forms-app/src/features/prepopulate/test/usePopulate.test.tsx
@@ -549,6 +549,43 @@ describe('usePopulate', () => {
       });
     });
 
+    it('should retry once and succeed if first attempt fails', async () => {
+      const spinner = createSpinner(true, 'prepopulate');
+      mockPopulateQuestionnaire
+        .mockResolvedValueOnce({ populateSuccess: false, populateResult: null })
+        .mockResolvedValueOnce({
+          populateSuccess: true,
+          populateResult: { populatedResponse: mockResponse }
+        });
+
+      renderHook(() => usePopulate(spinner, mockOnStopSpinner));
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(mockPopulateQuestionnaire).toHaveBeenCalledTimes(2);
+      expect(mockBuildForm).toHaveBeenCalled();
+      expect(mockEnqueueSnackbar).toHaveBeenCalledWith('Form populated', {
+        preventDuplicate: true,
+        action: expect.anything()
+      });
+    });
+
+    it('should show failure message if both attempts fail', async () => {
+      const spinner = createSpinner(true, 'prepopulate');
+      mockPopulateQuestionnaire.mockResolvedValue({ populateSuccess: false, populateResult: null });
+
+      renderHook(() => usePopulate(spinner, mockOnStopSpinner));
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(mockPopulateQuestionnaire).toHaveBeenCalledTimes(2);
+      expect(mockBuildForm).not.toHaveBeenCalled();
+      expect(mockEnqueueSnackbar).toHaveBeenCalledWith('Form not populated', {
+        variant: 'warning',
+        action: expect.anything()
+      });
+    });
+
     it('should handle missing populate result', async () => {
       const spinner = createSpinner(true, 'prepopulate');
       mockPopulateQuestionnaire.mockResolvedValue({

--- a/apps/smart-forms-app/src/features/prepopulate/test/usePopulate.test.tsx
+++ b/apps/smart-forms-app/src/features/prepopulate/test/usePopulate.test.tsx
@@ -317,8 +317,7 @@ describe('usePopulate', () => {
         fetchTerminologyCallback: expect.any(Function),
         fetchTerminologyRequestConfig: {
           terminologyServerUrl: 'https://test-terminology-server.com'
-        },
-        timeoutMs: 30000
+        }
       });
     });
 

--- a/apps/smart-forms-app/src/features/prepopulate/test/usePopulate.test.tsx
+++ b/apps/smart-forms-app/src/features/prepopulate/test/usePopulate.test.tsx
@@ -317,7 +317,8 @@ describe('usePopulate', () => {
         fetchTerminologyCallback: expect.any(Function),
         fetchTerminologyRequestConfig: {
           terminologyServerUrl: 'https://test-terminology-server.com'
-        }
+        },
+        timeoutMs: 30000
       });
     });
 
@@ -543,43 +544,6 @@ describe('usePopulate', () => {
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       expect(mockOnStopSpinner).toHaveBeenCalled();
-      expect(mockEnqueueSnackbar).toHaveBeenCalledWith('Form not populated', {
-        variant: 'warning',
-        action: expect.anything()
-      });
-    });
-
-    it('should retry once and succeed if first attempt fails', async () => {
-      const spinner = createSpinner(true, 'prepopulate');
-      mockPopulateQuestionnaire
-        .mockResolvedValueOnce({ populateSuccess: false, populateResult: null })
-        .mockResolvedValueOnce({
-          populateSuccess: true,
-          populateResult: { populatedResponse: mockResponse }
-        });
-
-      renderHook(() => usePopulate(spinner, mockOnStopSpinner));
-
-      await new Promise((resolve) => setTimeout(resolve, 10));
-
-      expect(mockPopulateQuestionnaire).toHaveBeenCalledTimes(2);
-      expect(mockBuildForm).toHaveBeenCalled();
-      expect(mockEnqueueSnackbar).toHaveBeenCalledWith('Form populated', {
-        preventDuplicate: true,
-        action: expect.anything()
-      });
-    });
-
-    it('should show failure message if both attempts fail', async () => {
-      const spinner = createSpinner(true, 'prepopulate');
-      mockPopulateQuestionnaire.mockResolvedValue({ populateSuccess: false, populateResult: null });
-
-      renderHook(() => usePopulate(spinner, mockOnStopSpinner));
-
-      await new Promise((resolve) => setTimeout(resolve, 10));
-
-      expect(mockPopulateQuestionnaire).toHaveBeenCalledTimes(2);
-      expect(mockBuildForm).not.toHaveBeenCalled();
       expect(mockEnqueueSnackbar).toHaveBeenCalledWith('Form not populated', {
         variant: 'warning',
         action: expect.anything()

--- a/packages/sdc-populate/src/inAppPopulation/utils/populateQuestionnaire.ts
+++ b/packages/sdc-populate/src/inAppPopulation/utils/populateQuestionnaire.ts
@@ -60,7 +60,7 @@ export interface PopulateResult {
  * @property fhirContext - An array of contextual resources within a launch. See https://build.fhir.org/ig/HL7/smart-app-launch/scopes-and-launch-context.html#fhircontext-exp
  * @property fetchTerminologyCallback - A callback function to fetch terminology resources, optional
  * @property fetchTerminologyRequestConfig - Any request configuration to be passed to the fetchTerminologyCallback i.e. headers, auth etc., optional
- * @property timeoutMs - Timeout in milliseconds for the $populate operation, default is 10000ms (10 seconds)
+ * @property timeoutMs - Timeout in milliseconds for the $populate operation, default is 30000ms (30 seconds)
  *
  * @author Sean Fong
  */
@@ -103,7 +103,7 @@ export async function populateQuestionnaire(params: PopulateQuestionnaireParams)
     fhirContext,
     fetchTerminologyCallback,
     fetchTerminologyRequestConfig,
-    timeoutMs = 10000
+    timeoutMs = 30000
   } = params;
 
   const { inputParameters } = await initialiseInputParameters(


### PR DESCRIPTION
Handles transient server slowness (e.g. cold HAPI caches on first use of the day) by automatically retrying a failed populate rather than immediately showing "Form not populated" to the user.