### PR TITLE
Issue/1926

### DIFF
--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/addDisplayToCodings.test.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/addDisplayToCodings.test.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { getCodeSystemLookupPromise } from '../api/lookupCodeSystem';
 import { resolveLookupPromises } from '../utils/resolveLookupPromises';
 import { addDisplayToQuestionnaireResponseCodings } from '../utils/addDisplayToCodings';

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/answerOption.test.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/answerOption.test.ts
@@ -31,6 +31,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import { describe, expect, it } from '@jest/globals';
 import { findInAnswerOptions } from '../utils/answerOption';
 
 describe('findInAnswerOptions', () => {

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/createQuestionnaireReference.test.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/createQuestionnaireReference.test.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { describe, expect, it } from '@jest/globals';
 import type { Questionnaire } from 'fhir/r4';
 import { createQuestionnaireReference } from '../utils/createQuestionnaireReference';
 

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/expandValueSet.test.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/expandValueSet.test.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import type { QuestionnaireItem } from 'fhir/r4';
 import { defaultTerminologyRequest } from '../api/defaultTerminologyRequest';
 import { getValueSetPromise } from '../api/expandValueSet';

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/fetchQuestionnaire.test.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/fetchQuestionnaire.test.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { describe, expect, it, jest, test } from '@jest/globals';
 import type { Bundle, OperationOutcome, Questionnaire } from 'fhir/r4';
 import { fetchQuestionnaire, safeReplaceCanonicalVersion } from '../api/fetchQuestionnaire';
 import type { InputParameters } from '../interfaces'; // Adjust FHIR version if needed

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/lookupCodeSystem.test.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/lookupCodeSystem.test.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { defaultTerminologyRequest } from '../api/defaultTerminologyRequest';
 import type { Coding } from 'fhir/r4';
 import { getCodeSystemLookupPromise, lookupResponseIsValid } from '../api/lookupCodeSystem';

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/parse.test.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/parse.test.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { describe, expect, it } from '@jest/globals';
 import type { QuestionnaireItem, QuestionnaireItemInitial } from 'fhir/r4';
 import { parseItemInitialToAnswer, parseValueToAnswer } from '../utils/parse';
 import { checkIsDateTime, checkIsTime, convertDateTimeToDate } from '../utils/constructResponse';

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/populate.test.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/populate.test.ts
@@ -1,4 +1,4 @@
-import { describe } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 import type { Bundle, Patient, QuestionnaireResponse } from 'fhir/r4';
 import { patRepop } from '../../test-data-shared/patRepop';
 import { bundleObsBodyHeight } from '../../test-data-shared/CalculatedExpressionBMICalculatorPrepop/bundleObsBodyHeight';
@@ -38,7 +38,7 @@ function prepareContextForFhirpathV4(ctx: Record<string, any>): Record<string, a
 jest.mock('../utils/createFhirPathContext', () => {
   const actual = jest.requireActual('../utils/createFhirPathContext');
   return {
-    ...actual,
+    ...(actual as object),
     createFhirPathContext: jest.fn() // only createReferenceContextTuple is mocked
   };
 });
@@ -46,18 +46,66 @@ jest.mock('../utils/createFhirPathContext', () => {
 // Mock resolveLookupPromises function
 jest.mock('../utils/resolveLookupPromises');
 
-const mockFetchResourceCallback = jest.fn();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockFetchResourceCallback = jest.fn() as any;
 const mockFetchResourceCallbackConfig = {
   sourceServerUrl: 'https://example.com/fhir'
 };
 
-const mockTerminologyCallback = jest.fn();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockTerminologyCallback = jest.fn() as any;
 const mockTerminologyCallbackConfig = {
   terminologyServerUrl: 'https://example.com/terminology/fhir'
 };
 
 // Launch context resources
 const mockPatient: Patient = patRepop;
+
+const SDC_INITIAL_EXPR =
+  'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression';
+const SDC_ITEM_POP_CTX =
+  'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-itemPopulationContext';
+
+// Minimal questionnaire with a repeat group whose children use toString() on a context variable.
+// This pattern previously caused false-positive issues when 2+ resources were in the collection.
+const qRepeatGroupWithToString = {
+  resourceType: 'Questionnaire',
+  id: 'repeat-group-tostring-test',
+  status: 'active',
+  item: [
+    {
+      linkId: 'conditions-group',
+      type: 'group',
+      repeats: true,
+      extension: [
+        {
+          url: SDC_ITEM_POP_CTX,
+          valueExpression: {
+            name: 'ConditionRepeat',
+            language: 'text/fhirpath',
+            expression: '%ConditionInput.entry.resource'
+          }
+        }
+      ],
+      item: [
+        {
+          linkId: 'condition-onset',
+          type: 'date',
+          extension: [
+            {
+              url: SDC_INITIAL_EXPR,
+              valueExpression: {
+                language: 'text/fhirpath',
+                expression:
+                  '%ConditionRepeat.onset.ofType(dateTime).toString().substring(0,10).toDate()'
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
 
 describe('populate', () => {
   beforeAll(() => {
@@ -161,8 +209,67 @@ describe('populate', () => {
 
     const resultContext = resultAsOutputParameters.parameter.find(
       (param) => param.name === 'contextResult-custom'
-    ).valueAttachment.data as string;
+    )?.valueAttachment?.data as string;
     const decodedResultContext = JSON.parse(Base64.decode(resultContext));
     expect(decodedResultContext).toStrictEqual(mockContext);
+  });
+});
+
+describe('populate - repeat group with toString()', () => {
+  it('should populate 2 repeat instances without issues when 2 resources are in the collection', async () => {
+    const mockContext = {
+      resource: { resourceType: 'QuestionnaireResponse', status: 'in-progress' },
+      rootResource: { resourceType: 'QuestionnaireResponse', status: 'in-progress' },
+      patient: { resourceType: 'Patient', id: 'test-patient' },
+      ConditionInput: {
+        resourceType: 'Bundle',
+        type: 'searchset',
+        entry: [
+          { resource: { resourceType: 'Condition', id: 'cond-1', onsetDateTime: '2023-06-15' } },
+          { resource: { resourceType: 'Condition', id: 'cond-2', onsetDateTime: '2022-03-20' } }
+        ]
+      }
+    };
+
+    (createFhirPathContext as jest.Mock).mockImplementation(async () => mockContext);
+    (resolveLookupPromises as jest.Mock).mockImplementation(async () => ({}));
+
+    const inputParameters: InputParameters = {
+      resourceType: 'Parameters',
+      parameter: [
+        { name: 'questionnaire', resource: qRepeatGroupWithToString as any },
+        { name: 'subject', valueReference: { type: 'Patient', reference: 'Patient/test-patient' } }
+      ]
+    };
+
+    const result = await populate(
+      inputParameters,
+      mockFetchResourceCallback,
+      mockFetchResourceCallbackConfig,
+      mockTerminologyCallback,
+      mockTerminologyCallbackConfig
+    );
+
+    const resultAsOutputParameters = result as OutputParameters;
+    expect(resultAsOutputParameters.resourceType).toBe('Parameters');
+
+    // No issues should be reported — before the fix, toString() on a multi-item collection
+    // triggered a false-positive OperationOutcomeIssue warning
+    const issuesParam = resultAsOutputParameters.parameter.find((p) => p.name === 'issues');
+    expect(issuesParam).toBeUndefined();
+
+    // Both conditions should appear as separate repeat group instances
+    const response = resultAsOutputParameters.parameter.find((p) => p.name === 'response')
+      ?.resource as QuestionnaireResponse;
+    expect(response).toBeDefined();
+
+    const repeatInstances = response.item?.filter((item) => item.linkId === 'conditions-group');
+    expect(repeatInstances).toHaveLength(2);
+
+    for (const instance of repeatInstances!) {
+      const onsetItem = instance.item?.find((item) => item.linkId === 'condition-onset');
+      expect(onsetItem).toBeDefined();
+      expect(onsetItem?.answer?.length).toBeGreaterThan(0);
+    }
   });
 });

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/readPopulationExpressions.test.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/readPopulationExpressions.test.ts
@@ -15,9 +15,15 @@
  * limitations under the License.
  */
 
+import { describe, expect, it } from '@jest/globals';
 import type { Questionnaire } from 'fhir/r4';
 import { readPopulationExpressions } from '../utils/readPopulationExpressions';
 import { QTestFhirContext } from './resources/QTestFhirContext';
+
+const SDC_INITIAL_EXPR =
+  'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression';
+const SDC_ITEM_POP_CTX =
+  'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-itemPopulationContext';
 
 describe('readPopulationExpressions', () => {
   const questionnaire = QTestFhirContext as Questionnaire;
@@ -25,5 +31,87 @@ describe('readPopulationExpressions', () => {
 
   it('should extract x-fhir-query variables ObsBodyHeight and ObsBodyWeight', () => {
     expect(initialExpressions.q1.expression).toEqual('%ObsBodyHeight.toString()');
+  });
+});
+
+describe('readPopulationExpressions - itemPopulationContext', () => {
+  const questionnaire: Questionnaire = {
+    resourceType: 'Questionnaire',
+    status: 'active',
+    item: [
+      {
+        linkId: 'non-repeat-field',
+        type: 'string',
+        extension: [
+          {
+            url: SDC_INITIAL_EXPR,
+            valueExpression: { language: 'text/fhirpath', expression: '%patient.name.family' }
+          }
+        ]
+      },
+      {
+        linkId: 'repeat-group',
+        type: 'group',
+        repeats: true,
+        extension: [
+          {
+            url: SDC_ITEM_POP_CTX,
+            valueExpression: {
+              name: 'ConditionRepeat',
+              language: 'text/fhirpath',
+              expression: '%Condition.entry.resource'
+            }
+          }
+        ],
+        item: [
+          {
+            linkId: 'condition-onset',
+            type: 'date',
+            extension: [
+              {
+                url: SDC_INITIAL_EXPR,
+                valueExpression: {
+                  language: 'text/fhirpath',
+                  expression:
+                    "%ConditionRepeat.onset.ofType(dateTime).toString().substring(0,10).toDate()"
+                }
+              }
+            ]
+          },
+          {
+            linkId: 'condition-code',
+            type: 'open-choice',
+            extension: [
+              {
+                url: SDC_INITIAL_EXPR,
+                valueExpression: {
+                  language: 'text/fhirpath',
+                  expression: '%ConditionRepeat.code.coding'
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  };
+
+  const { initialExpressions, itemPopulationContexts } = readPopulationExpressions(questionnaire);
+
+  it('should include initialExpression for non-repeat items', () => {
+    expect(initialExpressions['non-repeat-field']).toBeDefined();
+    expect(initialExpressions['non-repeat-field'].expression).toEqual('%patient.name.family');
+  });
+
+  it('should not include initialExpressions for children of an itemPopulationContext group', () => {
+    expect(initialExpressions['condition-onset']).toBeUndefined();
+    expect(initialExpressions['condition-code']).toBeUndefined();
+  });
+
+  it('should still register the itemPopulationContext', () => {
+    expect(itemPopulationContexts['ConditionRepeat']).toBeDefined();
+    expect(itemPopulationContexts['ConditionRepeat'].expression).toEqual(
+      '%Condition.entry.resource'
+    );
   });
 });

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/readPopulationExpressions.test.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/readPopulationExpressions.test.ts
@@ -73,7 +73,7 @@ describe('readPopulationExpressions - itemPopulationContext', () => {
                 valueExpression: {
                   language: 'text/fhirpath',
                   expression:
-                    "%ConditionRepeat.onset.ofType(dateTime).toString().substring(0,10).toDate()"
+                    '%ConditionRepeat.onset.ofType(dateTime).toString().substring(0,10).toDate()'
                 }
               }
             ]

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/resolveLookupPromises.test.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/resolveLookupPromises.test.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { lookupResponseIsValid } from '../api/lookupCodeSystem';
 import { resolveLookupPromises } from '../utils/resolveLookupPromises'; // Mock getCodeSystemLookupPromise function
 

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/constructResponse.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/constructResponse.ts
@@ -38,7 +38,7 @@ import dayjs from 'dayjs';
 import fhirpath from 'fhirpath';
 // Need to specifically import from 'index.js' to get it working with ts
 import fhirpath_r4_model from 'fhirpath/fhir-context/r4/index.js';
-import { getItemPopulationContextName } from './readPopulationExpressions';
+import { getInitialExpression, getItemPopulationContextName } from './readPopulationExpressions';
 import { createQuestionnaireReference } from './createQuestionnaireReference';
 import { parseItemInitialToAnswer, parseValueToAnswer } from './parse';
 import { getValueSetPromise } from '../api/expandValueSet';
@@ -571,11 +571,11 @@ async function constructRepeatGroupInstances(
   const terminologyServerUrl = fetchTerminologyRequestConfig?.terminologyServerUrl ?? null;
   const fhirServerUrl = fetchResourceRequestConfig?.sourceServerUrl ?? null;
 
-  // Look in initialExpressions of each of the child items to relate back to the itemPopulationContext its using
+  // Look in child items to relate back to the itemPopulationContext being used
   let itemPopulationContextExpression: string | undefined;
   let itemPopulationContext: ItemPopulationContext | undefined;
   for (const childItem of qRepeatGroupParent.item) {
-    const expression = initialExpressions[childItem.linkId]?.expression;
+    const expression = getInitialExpression(childItem)?.expression;
     if (!expression) continue;
 
     const contextName = getItemPopulationContextName(expression);
@@ -623,9 +623,10 @@ async function constructRepeatGroupInstances(
     };
 
     for (const childItem of qRepeatGroupParent.item) {
-      // Populate answers from initialExpressions
-      const initialExpression = initialExpressions[childItem.linkId];
-      if (initialExpression) {
+      // Populate answers from initialExpression — read directly from the questionnaire item
+      // so that expressions are evaluated per-item against the scoped context, not the global one
+      const childInitialExpression = getInitialExpression(childItem);
+      if (childInitialExpression?.expression) {
         // Allow child items consuming itemPopulationContext to access renderer-wide variables via fhirPathContext
         const fhirPathContextWithItemPopulationContext = {
           ...fhirPathContext,
@@ -635,7 +636,7 @@ async function constructRepeatGroupInstances(
         try {
           const fhirPathResult = fhirpath.evaluate(
             {},
-            initialExpression.expression,
+            childInitialExpression.expression,
             fhirPathContextWithItemPopulationContext,
             fhirpath_r4_model,
             {
@@ -670,7 +671,7 @@ async function constructRepeatGroupInstances(
         } catch (e) {
           // e is not thrown as an Error type in fhirpath.js, so we can't use `if (e instanceof Error)` here
           console.warn(
-            `SDC-Populate Error: fhirpath evaluation for ItemPopulationContext child for expression ${initialExpression.expression} failed. Details below:` +
+            `SDC-Populate Error: fhirpath evaluation for ItemPopulationContext child for expression ${childInitialExpression.expression} failed. Details below:` +
               e
           );
         }

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/readPopulationExpressions.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/readPopulationExpressions.ts
@@ -38,13 +38,16 @@ export function readPopulationExpressions(questionnaire: Questionnaire): Populat
 }
 
 /**
- * Recursively read a single questionnaire item/group and save its initialExpression into the object if present
+ * Recursively read a single questionnaire item/group and save its initialExpression into the object if present.
+ * initialExpressions belonging to children of an itemPopulationContext group are excluded from the global map —
+ * they are evaluated per-item in constructRepeatGroupInstances and must not be pre-evaluated against the full collection.
  *
  * @author Sean Fong
  */
 function readQuestionnaireItemRecursive(
   item: QuestionnaireItem,
-  populationExpressions: PopulationExpressions
+  populationExpressions: PopulationExpressions,
+  underItemPopulationContext = false
 ): PopulationExpressions {
   const items = item.item;
   if (items && items.length > 0) {
@@ -59,7 +62,28 @@ function readQuestionnaireItemRecursive(
       };
     }
 
-    // Read initial expression of group item
+    // Read initial expression of group item — skipped when under an itemPopulationContext
+    if (!underItemPopulationContext) {
+      const initialExpression = getInitialExpression(item);
+      if (initialExpression && initialExpression.expression) {
+        populationExpressions.initialExpressions[item.linkId] = {
+          expression: initialExpression.expression,
+          value: undefined
+        };
+      }
+    }
+
+    // Children of an itemPopulationContext group are evaluated per-item, not globally
+    const childrenUnderContext = underItemPopulationContext || !!itemPopulationContext;
+    items.forEach((item) => {
+      readQuestionnaireItemRecursive(item, populationExpressions, childrenUnderContext);
+    });
+
+    return populationExpressions;
+  }
+
+  // Read initial expression of qItem — skipped when under an itemPopulationContext
+  if (!underItemPopulationContext) {
     const initialExpression = getInitialExpression(item);
     if (initialExpression && initialExpression.expression) {
       populationExpressions.initialExpressions[item.linkId] = {
@@ -67,22 +91,6 @@ function readQuestionnaireItemRecursive(
         value: undefined
       };
     }
-
-    // iterate through items of item recursively
-    items.forEach((item) => {
-      readQuestionnaireItemRecursive(item, populationExpressions);
-    });
-
-    return populationExpressions;
-  }
-
-  // Read initial expression of qItem
-  const initialExpression = getInitialExpression(item);
-  if (initialExpression && initialExpression.expression) {
-    populationExpressions.initialExpressions[item.linkId] = {
-      expression: initialExpression.expression,
-      value: undefined
-    };
   }
 
   return populationExpressions;

--- a/packages/sdc-populate/src/inAppPopulation/test/createInputParameters.test.ts
+++ b/packages/sdc-populate/src/inAppPopulation/test/createInputParameters.test.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { constructPopulateInputParameters } from '../utils/inputParameters';
 import { resolveFhirContextReferences } from '../utils/resolveFhirContexts';
 import type { Encounter, Endpoint, Patient, Practitioner, Questionnaire } from 'fhir/r4';

--- a/packages/sdc-populate/src/inAppPopulation/test/populateQuestionnaire.test.ts
+++ b/packages/sdc-populate/src/inAppPopulation/test/populateQuestionnaire.test.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { describe, expect, it, jest } from '@jest/globals';
 import type {
   Bundle,
   Encounter,

--- a/packages/sdc-populate/src/inAppPopulation/test/resolveFhirContexts.test.ts
+++ b/packages/sdc-populate/src/inAppPopulation/test/resolveFhirContexts.test.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { resolveFhirContextReferences } from '../utils/resolveFhirContexts';
 
 const mockFetchResource = jest.fn();


### PR DESCRIPTION
## Summary

- `readPopulationExpressions` was adding children of `itemPopulationContext` repeat groups to the global `initialExpressions` map, causing `generateExpressionValues` to pre-evaluate them against the full resource collection. FHIRPath functions like `toString()` that require a single-item input would then throw, producing a spurious `OperationOutcomeIssue` warning. Population itself was never broken — the per-item evaluation in `constructRepeatGroupInstances` always worked correctly and never used the pre-computed value.
- Fix: exclude repeat group children from the global map in `readPopulationExpressions`, and read expressions directly from the questionnaire item in `constructRepeatGroupInstances` so they are always evaluated against the correctly scoped per-item context.
- Also adds explicit `@jest/globals` imports to all `sdc-populate` test files to resolve IDE type errors (matches the pattern already used in `smart-forms-renderer`).

