### PR TITLE
feat(#1927): block save-as-final when form has validation errors; fix targetConstraint

### DIFF
--- a/apps/smart-forms-app/src/features/renderer/components/RendererActions/SaveAsFinalAction.tsx
+++ b/apps/smart-forms-app/src/features/renderer/components/RendererActions/SaveAsFinalAction.tsx
@@ -32,6 +32,10 @@ import RendererSaveAsFinalOnlyDialog from './RendererSaveAsFinalOnlyDialog.tsx';
 import RendererSaveAsFinalWriteBackDialog from './RendererSaveAsFinalWriteBackDialog.tsx';
 import { populateQuestionnaire } from '@aehrc/sdc-populate';
 import { fetchResourceCallback } from '../../../prepopulate/utils/callback.ts';
+import { useSnackbar } from 'notistack';
+import CloseSnackbar from '../../../../components/Snackbar/CloseSnackbar.tsx';
+import { formHasErrorsMessage } from '../../../../interfaces/snackbar.interface.ts';
+import { findFirstErrorTabIndex } from '../../utils/tabNavigation.ts';
 
 interface SaveAsFinalActionProps extends SpeedDialActionProps {
   isSpeedDial?: boolean;
@@ -48,12 +52,45 @@ function SaveAsFinalAction(props: SaveAsFinalActionProps) {
   const [extractedBundle, setExtractedBundle] = useState<Bundle | null>(null);
 
   const sourceQuestionnaire = useQuestionnaireStore.use.sourceQuestionnaire();
+  const tabs = useQuestionnaireStore.use.tabs();
+  const switchTab = useQuestionnaireStore.use.switchTab();
+
   const sourceResponse = useQuestionnaireResponseStore.use.sourceResponse();
   const updatableResponse = useQuestionnaireResponseStore.use.updatableResponse();
   const formChangesHistory = useQuestionnaireResponseStore.use.formChangesHistory();
+  const responseHasErrors = useQuestionnaireResponseStore.use.responseHasErrors();
+  const invalidItems = useQuestionnaireResponseStore.use.invalidItems();
+  const highlightRequiredItems = useQuestionnaireResponseStore.use.highlightRequiredItems();
+
+  const { enqueueSnackbar } = useSnackbar();
 
   // freeze state of response status so dialog content doesn't change during the save process
   const [responseStatus] = useState(sourceResponse.status);
+
+  // Returns true if save should be aborted due to validation errors
+  function handleValidationErrors(): boolean {
+    if (!responseHasErrors) return false;
+
+    highlightRequiredItems();
+
+    if (Object.keys(tabs).length > 0) {
+      const firstErrorTabIndex = findFirstErrorTabIndex(
+        Object.keys(invalidItems),
+        sourceQuestionnaire.item ?? [],
+        tabs
+      );
+      if (firstErrorTabIndex !== null) {
+        switchTab(firstErrorTabIndex);
+      }
+    }
+
+    enqueueSnackbar(formHasErrorsMessage, {
+      variant: 'error',
+      action: <CloseSnackbar variant="error" />
+    });
+
+    return true;
+  }
 
   // Events handlers
   async function handleTemplateExtract() {
@@ -179,6 +216,8 @@ function SaveAsFinalAction(props: SaveAsFinalActionProps) {
           isAmendment={isAmendment}
           writeBackEnabled={writeBackEnabled}
           onSaveAsFinalActionClick={async () => {
+            if (handleValidationErrors()) return;
+
             if (extractMechanism === 'template-based') {
               await handleTemplateExtract();
             }
@@ -220,7 +259,10 @@ function SaveAsFinalAction(props: SaveAsFinalActionProps) {
         isDisabled={buttonIsDisabled}
         isAmendment={isAmendment}
         writeBackEnabled={writeBackEnabled}
-        onSaveAsFinalActionClick={handleOpenDialog}
+        onSaveAsFinalActionClick={() => {
+          if (handleValidationErrors()) return;
+          handleOpenDialog();
+        }}
         {...speedDialActionProps}
       />
       <RendererSaveAsFinalOnlyDialog

--- a/apps/smart-forms-app/src/features/renderer/utils/tabNavigation.ts
+++ b/apps/smart-forms-app/src/features/renderer/utils/tabNavigation.ts
@@ -1,0 +1,55 @@
+import type { QuestionnaireItem } from 'fhir/r4';
+import type { Tabs } from '@aehrc/smart-forms-renderer';
+
+/**
+ * Finds the tab index of the first visible tab (by tab order) that contains any of the given linkIds.
+ * Returns null if no matching visible tab is found or if there are no tabs.
+ */
+export function findFirstErrorTabIndex(
+  invalidLinkIds: string[],
+  questionnaireItems: QuestionnaireItem[],
+  tabs: Tabs
+): number | null {
+  let minTabIndex: number | null = null;
+
+  for (const linkId of invalidLinkIds) {
+    const tabIndex = findTabIndexForLinkId(linkId, questionnaireItems, tabs);
+    if (tabIndex !== null && (minTabIndex === null || tabIndex < minTabIndex)) {
+      minTabIndex = tabIndex;
+    }
+  }
+
+  return minTabIndex;
+}
+
+function findTabIndexForLinkId(
+  targetLinkId: string,
+  items: QuestionnaireItem[],
+  tabs: Tabs
+): number | null {
+  for (const item of items) {
+    const tab = tabs[item.linkId];
+    if (tab !== undefined) {
+      // This item is a tab — skip hidden tabs, otherwise check if it contains the target
+      if (
+        !tab.isHidden &&
+        (item.linkId === targetLinkId || containsLinkId(targetLinkId, item.item ?? []))
+      ) {
+        return tab.tabIndex;
+      }
+    } else if (item.item) {
+      // Not a tab — recurse into children
+      const found = findTabIndexForLinkId(targetLinkId, item.item, tabs);
+      if (found !== null) return found;
+    }
+  }
+  return null;
+}
+
+function containsLinkId(targetLinkId: string, items: QuestionnaireItem[]): boolean {
+  for (const item of items) {
+    if (item.linkId === targetLinkId) return true;
+    if (item.item && containsLinkId(targetLinkId, item.item)) return true;
+  }
+  return false;
+}

--- a/apps/smart-forms-app/src/features/viewer/ViewerNav/SaveAsFinal/ViewerSaveAsFinal.tsx
+++ b/apps/smart-forms-app/src/features/viewer/ViewerNav/SaveAsFinal/ViewerSaveAsFinal.tsx
@@ -20,9 +20,16 @@ import { useState } from 'react';
 import ViewerOperationItem from '../ViewerOperationItem.tsx';
 import ViewerSaveAsFinalDialog from './ViewerSaveAsFinalDialog.tsx';
 import useSmartClient from '../../../../hooks/useSmartClient.ts';
+import { useQuestionnaireResponseStore } from '@aehrc/smart-forms-renderer';
+import { useSnackbar } from 'notistack';
+import CloseSnackbar from '../../../../components/Snackbar/CloseSnackbar.tsx';
+import { formHasErrorsViewerMessage } from '../../../../interfaces/snackbar.interface.ts';
 
 function ViewerSaveAsFinal() {
   const { smartClient } = useSmartClient();
+  const responseHasErrors = useQuestionnaireResponseStore.use.responseHasErrors();
+  const highlightRequiredItems = useQuestionnaireResponseStore.use.highlightRequiredItems();
+  const { enqueueSnackbar } = useSnackbar();
 
   const [dialogOpen, setDialogOpen] = useState(false);
 
@@ -32,9 +39,18 @@ function ViewerSaveAsFinal() {
         title="Save as Final"
         icon={<TaskAltIcon />}
         onClick={() => {
-          if (smartClient) {
-            setDialogOpen(true);
+          if (!smartClient) return;
+
+          if (responseHasErrors) {
+            highlightRequiredItems();
+            enqueueSnackbar(formHasErrorsViewerMessage, {
+              variant: 'error',
+              action: <CloseSnackbar variant="error" />
+            });
+            return;
           }
+
+          setDialogOpen(true);
         }}
       />
       <ViewerSaveAsFinalDialog open={dialogOpen} closeDialog={() => setDialogOpen(false)} />

--- a/apps/smart-forms-app/src/interfaces/snackbar.interface.ts
+++ b/apps/smart-forms-app/src/interfaces/snackbar.interface.ts
@@ -17,6 +17,9 @@
 
 export const saveErrorMessage = 'An error occurred while saving.';
 
+export const formHasErrorsMessage =
+  'The form has errors that must be fixed before saving as final.';
+
 export const saveSuccessMessage = 'Response saved';
 export const saveAsFinalSuccessMessage = 'Response saved as final';
 export const saveAmendmentSuccessMessage = 'Response saved as amendment';

--- a/apps/smart-forms-app/src/interfaces/snackbar.interface.ts
+++ b/apps/smart-forms-app/src/interfaces/snackbar.interface.ts
@@ -20,6 +20,9 @@ export const saveErrorMessage = 'An error occurred while saving.';
 export const formHasErrorsMessage =
   'The form has errors that must be fixed before saving as final.';
 
+export const formHasErrorsViewerMessage =
+  'This response has errors. Edit the response to view and fix them before saving as final.';
+
 export const saveSuccessMessage = 'Response saved';
 export const saveAsFinalSuccessMessage = 'Response saved as final';
 export const saveAmendmentSuccessMessage = 'Response saved as amendment';

--- a/apps/smart-forms-app/src/test/tabNavigation.test.ts
+++ b/apps/smart-forms-app/src/test/tabNavigation.test.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2025 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { findFirstErrorTabIndex } from '../features/renderer/utils/tabNavigation';
+import type { QuestionnaireItem } from 'fhir/r4';
+import type { Tabs } from '@aehrc/smart-forms-renderer';
+
+// Structure: tab-container (non-tab group) → tab-a, tab-b, tab-c (tabs)
+// tab-a contains: field-1, group-nested (which contains field-nested)
+// tab-b contains: field-2
+// tab-c contains: field-3
+const questionnaireItems: QuestionnaireItem[] = [
+  {
+    linkId: 'tab-container',
+    type: 'group',
+    item: [
+      {
+        linkId: 'tab-a',
+        type: 'group',
+        item: [
+          { linkId: 'field-1', type: 'string' },
+          {
+            linkId: 'group-nested',
+            type: 'group',
+            item: [{ linkId: 'field-nested', type: 'string' }]
+          }
+        ]
+      },
+      {
+        linkId: 'tab-b',
+        type: 'group',
+        item: [{ linkId: 'field-2', type: 'string' }]
+      },
+      {
+        linkId: 'tab-c',
+        type: 'group',
+        item: [{ linkId: 'field-3', type: 'string' }]
+      }
+    ]
+  }
+];
+
+const tabs: Tabs = {
+  'tab-a': { tabIndex: 0, isComplete: false, isHidden: false },
+  'tab-b': { tabIndex: 1, isComplete: false, isHidden: false },
+  'tab-c': { tabIndex: 2, isComplete: false, isHidden: false }
+};
+
+const tabsWithHiddenC: Tabs = {
+  ...tabs,
+  'tab-c': { tabIndex: 2, isComplete: false, isHidden: true }
+};
+
+describe('findFirstErrorTabIndex', () => {
+  it('should return null when tabs is empty', () => {
+    expect(findFirstErrorTabIndex(['field-1'], questionnaireItems, {})).toBeNull();
+  });
+
+  it('should return null when invalidLinkIds is empty', () => {
+    expect(findFirstErrorTabIndex([], questionnaireItems, tabs)).toBeNull();
+  });
+
+  it('should return null when no invalid linkId is found in any tab', () => {
+    expect(findFirstErrorTabIndex(['unknown-field'], questionnaireItems, tabs)).toBeNull();
+  });
+
+  it('should return null when the linkId matches a non-tab container item', () => {
+    expect(findFirstErrorTabIndex(['tab-container'], questionnaireItems, tabs)).toBeNull();
+  });
+
+  it('should return the tabIndex when the invalid linkId is the tab item itself', () => {
+    expect(findFirstErrorTabIndex(['tab-a'], questionnaireItems, tabs)).toBe(0);
+    expect(findFirstErrorTabIndex(['tab-b'], questionnaireItems, tabs)).toBe(1);
+  });
+
+  it('should return the tabIndex when the invalid linkId is a direct child of a tab', () => {
+    expect(findFirstErrorTabIndex(['field-1'], questionnaireItems, tabs)).toBe(0);
+    expect(findFirstErrorTabIndex(['field-2'], questionnaireItems, tabs)).toBe(1);
+    expect(findFirstErrorTabIndex(['field-3'], questionnaireItems, tabs)).toBe(2);
+  });
+
+  it('should return the tabIndex when the invalid linkId is deeply nested within a tab', () => {
+    expect(findFirstErrorTabIndex(['field-nested'], questionnaireItems, tabs)).toBe(0);
+  });
+
+  it('should return the lowest tabIndex when invalid items span multiple tabs', () => {
+    expect(findFirstErrorTabIndex(['field-2', 'field-1'], questionnaireItems, tabs)).toBe(0);
+    expect(findFirstErrorTabIndex(['field-3', 'field-2'], questionnaireItems, tabs)).toBe(1);
+  });
+
+  it('should return the tabIndex when multiple invalid items are in the same tab', () => {
+    expect(findFirstErrorTabIndex(['field-1', 'field-nested'], questionnaireItems, tabs)).toBe(0);
+  });
+
+  // In practice, hidden tabs won't have entries in invalidItems because validateItemRecursive
+  // skips hidden items upstream. The isHidden guard here is defensive — it covers the
+  // questionnaire-hidden extension case. enableWhen-hidden tabs have tab.isHidden === false
+  // but also won't appear in invalidItems for the same reason.
+  it('should return null when the matching tab is hidden', () => {
+    expect(findFirstErrorTabIndex(['field-3'], questionnaireItems, tabsWithHiddenC)).toBeNull();
+  });
+
+  it('should skip hidden tabs and return the next visible tab', () => {
+    expect(
+      findFirstErrorTabIndex(['field-3', 'field-2'], questionnaireItems, tabsWithHiddenC)
+    ).toBe(1);
+  });
+
+  it('should return null when all matching tabs are hidden', () => {
+    const allHidden: Tabs = {
+      'tab-a': { tabIndex: 0, isComplete: false, isHidden: true },
+      'tab-b': { tabIndex: 1, isComplete: false, isHidden: true },
+      'tab-c': { tabIndex: 2, isComplete: false, isHidden: true }
+    };
+    expect(
+      findFirstErrorTabIndex(['field-1', 'field-2'], questionnaireItems, allHidden)
+    ).toBeNull();
+  });
+});

--- a/documentation/docs/api/sdc-populate/interfaces/PopulateQuestionnaireParams.md
+++ b/documentation/docs/api/sdc-populate/interfaces/PopulateQuestionnaireParams.md
@@ -70,7 +70,7 @@ Questionnaire to populate
 
 > `optional` **timeoutMs**: `number`
 
-Timeout in milliseconds for the $populate operation, default is 10000ms (10 seconds)
+Timeout in milliseconds for the $populate operation, default is 30000ms (30 seconds)
 
 ***
 

--- a/documentation/docs/api/smart-forms-renderer/functions/QuestionnaireTitleText.md
+++ b/documentation/docs/api/smart-forms-renderer/functions/QuestionnaireTitleText.md
@@ -1,0 +1,36 @@
+# Function: QuestionnaireTitleText()
+
+> **QuestionnaireTitleText**(`props`): `Element`
+
+Renders `Questionnaire.title` with support for optional `Questionnaire._title` rendering
+extensions (xhtml, markdown, style).
+
+This component is rendered automatically by the renderer at the top of the form unless
+`hideQuestionnaireTitle` is set to `true` in the renderer config (via `setRendererConfig`).
+Set `hideQuestionnaireTitle: true` when your consuming app already displays the questionnaire
+title in its own header, to avoid rendering it twice.
+
+The component is also exported so consuming apps can render the styled title independently
+in a custom location (e.g. a page header or sidebar).
+
+## Parameters
+
+| Parameter | Type |
+| ------ | ------ |
+| `props` | `QuestionnaireTitleTextProps` |
+
+## Returns
+
+`Element`
+
+## Example
+
+```ts
+// Render title in a custom location
+import { QuestionnaireTitleText } from '@aehrc/smart-forms-renderer';
+<QuestionnaireTitleText questionnaire={questionnaire} />
+```
+
+## See
+
+QuestionnaireTitleTextProps

--- a/documentation/docs/api/smart-forms-renderer/functions/useDisplayCqfAndCalculatedExpression.md
+++ b/documentation/docs/api/smart-forms-renderer/functions/useDisplayCqfAndCalculatedExpression.md
@@ -13,7 +13,7 @@ Returns the value of a cqf-expression, calculatedExpression or ItemTextAriaLabel
 | Parameter | Type | Description |
 | ------ | ------ | ------ |
 | `qItem` | `QuestionnaireItem` | The questionnaire item. |
-| `from` | `"item"` \| `"item._text"` \| `"item._text.aria-label"` \| `"item._answerValueSet"` | The expression source. Should be a one of 'item._text' or 'item._text.aria-label' |
+| `from` | `"item"` \| `"item._text"` \| `"item._text.aria-label"` \| `"item._prefix"` \| `"item._answerValueSet"` | The expression source (e.g. 'item._text', 'item._text.aria-label', 'item._prefix') |
 
 ## Returns
 

--- a/documentation/docs/api/smart-forms-renderer/index.md
+++ b/documentation/docs/api/smart-forms-renderer/index.md
@@ -87,6 +87,7 @@
 | [parseDecimalStringWithPrecision](functions/parseDecimalStringWithPrecision.md) | - |
 | [parseFhirDateTimeToDisplayDateTime](functions/parseFhirDateTimeToDisplayDateTime.md) | Parse a FHIR dateTime string to a human-readable display format. Supports full and partial FHIR dateTime values. |
 | [parseFhirDateToDisplayDate](functions/parseFhirDateToDisplayDate.md) | Parse a FHIR date string to a human-readable display format. |
+| [QuestionnaireTitleText](functions/QuestionnaireTitleText.md) | Renders `Questionnaire.title` with support for optional `Questionnaire._title` rendering extensions (xhtml, markdown, style). |
 | [removeEmptyAnswersFromResponse](functions/removeEmptyAnswersFromResponse.md) | Remove all empty/hidden answers from the filled QuestionnaireResponse. This takes into account enableWhens, enableWhenExpressions, items without item.answer, empty item.answer arrays and empty strings. This does not remove items that are hidden by the http://hl7.org/fhir/StructureDefinition/questionnaire-hidden extension. |
 | [removeInternalIdsFromResponse](functions/removeInternalIdsFromResponse.md) | Remove all instances of item.answer.id from the filled QuestionnaireResponse. These IDs are used internally for rendering repeating items, and can be safely left out of the final response. |
 | [rendererThemeComponentOverrides](functions/rendererThemeComponentOverrides.md) | - |

--- a/documentation/docs/api/smart-forms-renderer/interfaces/CalculatedExpression.md
+++ b/documentation/docs/api/smart-forms-renderer/interfaces/CalculatedExpression.md
@@ -14,9 +14,9 @@ CalculatedExpression FHIRPath expression
 
 ### from
 
-> **from**: `"item"` \| `"item._text"` \| `"item._text.aria-label"` \| `"item._answerValueSet"`
+> **from**: `"item"` \| `"item._text"` \| `"item._text.aria-label"` \| `"item._prefix"` \| `"item._answerValueSet"`
 
-Whether the expressions is for the item itself, for item._text or item._answerValueSet
+Whether the expressions is for the item itself, for item._text, item._prefix or item._answerValueSet
 
 ***
 

--- a/documentation/docs/api/smart-forms-renderer/interfaces/QuestionnaireResponseStoreType.md
+++ b/documentation/docs/api/smart-forms-renderer/interfaces/QuestionnaireResponseStoreType.md
@@ -80,6 +80,12 @@ Required items are not highlighted by default (to provide a less-jarring UX), bu
 
 ***
 
+### responseHasErrors
+
+> **responseHasErrors**: `boolean`
+
+***
+
 ### responseIsValid
 
 > **responseIsValid**: `boolean`

--- a/documentation/docs/api/smart-forms-renderer/interfaces/RendererConfig.md
+++ b/documentation/docs/api/smart-forms-renderer/interfaces/RendererConfig.md
@@ -69,6 +69,16 @@ If `true`, hides the quantity comparator field.
 
 ***
 
+### hideQuestionnaireTitle?
+
+> `optional` **hideQuestionnaireTitle**: `boolean`
+
+If `true`, suppresses the renderer's built-in rendering of `Questionnaire.title`.
+  Set this to `true` when the consuming app already renders the title in its own header to avoid displaying it twice.
+  - Default: `false`
+
+***
+
 ### inputsFlexGrow?
 
 > `optional` **inputsFlexGrow**: `boolean`
@@ -137,6 +147,16 @@ If `true`, swaps "Yes" and "No" options for boolean fields.
 
 Defines when the form should switch to a tabbed layout based on screen size.
   - Default: `{ query: 'up', start: 'md' }`
+
+***
+
+### tabListStickyTop?
+
+> `optional` **tabListStickyTop**: `number`
+
+The pixel offset from the top of the viewport at which the tab list becomes sticky.
+  Set this to the height of any sticky header in the consuming app so the tab list sticks immediately below it.
+  - Default: `0`
 
 ***
 

--- a/documentation/docs/api/smart-forms-renderer/interfaces/RendererConfigStoreType.md
+++ b/documentation/docs/api/smart-forms-renderer/interfaces/RendererConfigStoreType.md
@@ -46,6 +46,12 @@ RendererConfigStore properties and methods
 
 ***
 
+### hideQuestionnaireTitle
+
+> **hideQuestionnaireTitle**: `boolean`
+
+***
+
 ### inputsFlexGrow
 
 > **inputsFlexGrow**: `boolean`
@@ -111,6 +117,12 @@ RendererConfigStore properties and methods
 ### showTabbedFormAt
 
 > **showTabbedFormAt**: [`UseResponsiveProps`](UseResponsiveProps.md)
+
+***
+
+### tabListStickyTop
+
+> **tabListStickyTop**: `number`
 
 ***
 

--- a/documentation/docs/api/smart-forms-renderer/typedoc-sidebar.cjs
+++ b/documentation/docs/api/smart-forms-renderer/typedoc-sidebar.cjs
@@ -366,6 +366,11 @@ const typedocSidebar = {
         },
         {
           type: "doc",
+          id: "api/smart-forms-renderer/functions/QuestionnaireTitleText",
+          label: "QuestionnaireTitleText"
+        },
+        {
+          type: "doc",
           id: "api/smart-forms-renderer/functions/removeEmptyAnswersFromResponse",
           label: "removeEmptyAnswersFromResponse"
         },

--- a/documentation/docs/api/smart-forms-renderer/variables/useQuestionnaireResponseStore.md
+++ b/documentation/docs/api/smart-forms-renderer/variables/useQuestionnaireResponseStore.md
@@ -85,6 +85,14 @@ This is the React version of the store which can be used as React hooks in React
 
 `boolean`
 
+#### use.responseHasErrors()
+
+> **responseHasErrors**: () => `boolean`
+
+##### Returns
+
+`boolean`
+
 #### use.responseIsValid()
 
 > **responseIsValid**: () => `boolean`

--- a/documentation/docs/api/smart-forms-renderer/variables/useRendererConfigStore.md
+++ b/documentation/docs/api/smart-forms-renderer/variables/useRendererConfigStore.md
@@ -64,6 +64,14 @@
 
 `boolean`
 
+#### use.hideQuestionnaireTitle()
+
+> **hideQuestionnaireTitle**: () => `boolean`
+
+##### Returns
+
+`boolean`
+
 #### use.inputsFlexGrow()
 
 > **inputsFlexGrow**: () => `boolean`
@@ -145,6 +153,14 @@
 ##### Returns
 
 [`UseResponsiveProps`](../interfaces/UseResponsiveProps.md)
+
+#### use.tabListStickyTop()
+
+> **tabListStickyTop**: () => `number`
+
+##### Returns
+
+`number`
 
 #### use.tabListWidthOrResponsive()
 

--- a/documentation/docs/sdc/advanced/constraint.mdx
+++ b/documentation/docs/sdc/advanced/constraint.mdx
@@ -157,3 +157,12 @@ This extension allows you to specify human-readable error messages when the cons
   storyId="sdc-10-1-4-behavior-other-control--target-constraint-multi"
   initialHeight={170}
 />
+
+#### Item-Level Constraint Usage
+
+Constraints can also be defined directly on individual items instead of at the questionnaire root level. When no `location` is specified, the constraint applies to the item it is defined on.
+
+<IframeContainer
+  storyId="sdc-10-1-4-behavior-other-control--target-constraint-item-level"
+  initialHeight={220}
+/>

--- a/packages/smart-forms-renderer/src/components/FormComponents/ChoiceItems/ChoiceSelectAnswerOptionFields.tsx
+++ b/packages/smart-forms-renderer/src/components/FormComponents/ChoiceItems/ChoiceSelectAnswerOptionFields.tsx
@@ -17,6 +17,8 @@
 
 import React from 'react';
 import Autocomplete from '@mui/material/Autocomplete';
+import FormControl from '@mui/material/FormControl';
+import FormHelperText from '@mui/material/FormHelperText';
 import type { QuestionnaireItem, QuestionnaireItemAnswerOption } from 'fhir/r4';
 import type {
   PropsWithIsTabledAttribute,
@@ -25,11 +27,11 @@ import type {
 import { useRendererConfigStore } from '../../../stores';
 import { compareAnswerOptionValue, isOptionDisabled } from '../../../utils/choice';
 import { getAnswerOptionLabel } from '../../../utils/openChoice';
-import { StyledRequiredTypography } from '../Item.styles';
 import DisplayUnitText from '../ItemParts/DisplayUnitText';
 import ExpressionUpdateFadingIcon from '../ItemParts/ExpressionUpdateFadingIcon';
 import { StandardTextField } from '../Textfield.styles';
 import StyledText from '../ItemParts/StyledText';
+import AccessibleFeedback from '../ItemParts/AccessibleFeedback';
 
 interface ChoiceSelectAnswerOptionFieldsProps
   extends PropsWithIsTabledAttribute,
@@ -72,7 +74,14 @@ function ChoiceSelectAnswerOptionFields(props: ChoiceSelectAnswerOptionFieldsPro
     React.useState<QuestionnaireItemAnswerOption | null>(valueSelect);
 
   return (
-    <>
+    <FormControl
+      error={!!feedback}
+      sx={{
+        width: '100%',
+        maxWidth: !isTabled ? textFieldWidth : 3000,
+        minWidth: 160,
+        flexGrow: 1
+      }}>
       <Autocomplete
         id={qItem.type + '-' + qItem.linkId}
         value={valueSelect ?? null}
@@ -110,15 +119,9 @@ function ChoiceSelectAnswerOptionFields(props: ChoiceSelectAnswerOptionFieldsPro
             }
           }
         }}
+        fullWidth
         autoHighlight
-        sx={{
-          maxWidth: !isTabled ? textFieldWidth : 3000,
-          minWidth: 160,
-          flexGrow: 1,
-          '& .MuiAutocomplete-tag': {
-            mx: 0
-          }
-        }}
+        sx={{ '& .MuiAutocomplete-tag': { mx: 0 } }}
         size="small"
         disabled={readOnly && readOnlyVisualStyle === 'disabled'}
         readOnly={readOnly && readOnlyVisualStyle === 'readonly'}
@@ -133,6 +136,7 @@ function ChoiceSelectAnswerOptionFields(props: ChoiceSelectAnswerOptionFieldsPro
             <StandardTextField
               textFieldWidth={textFieldWidth}
               isTabled={isTabled}
+              error={!!feedback}
               placeholder={valueSelect ? undefined : entryFormat || displayPrompt}
               {...params}
               slotProps={{
@@ -200,8 +204,12 @@ function ChoiceSelectAnswerOptionFields(props: ChoiceSelectAnswerOptionFieldsPro
         }}
       />
 
-      {feedback ? <StyledRequiredTypography>{feedback}</StyledRequiredTypography> : null}
-    </>
+      {feedback ? (
+        <FormHelperText>
+          <AccessibleFeedback>{feedback}</AccessibleFeedback>
+        </FormHelperText>
+      ) : null}
+    </FormControl>
   );
 }
 

--- a/packages/smart-forms-renderer/src/components/FormComponents/ChoiceItems/ChoiceSelectAnswerValueSetFields.tsx
+++ b/packages/smart-forms-renderer/src/components/FormComponents/ChoiceItems/ChoiceSelectAnswerValueSetFields.tsx
@@ -18,6 +18,8 @@
 import { useState } from 'react';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import Autocomplete from '@mui/material/Autocomplete';
+import FormControl from '@mui/material/FormControl';
+import FormHelperText from '@mui/material/FormHelperText';
 import Typography from '@mui/material/Typography';
 import type { Coding, QuestionnaireItem } from 'fhir/r4';
 import type { TerminologyError } from '../../../hooks/useValueSetCodings';
@@ -29,9 +31,9 @@ import { useRendererConfigStore } from '../../../stores';
 import { isCodingDisabled } from '../../../utils/choice';
 import ExpressionUpdateFadingIcon from '../ItemParts/ExpressionUpdateFadingIcon';
 import { StyledAlert } from '../../Alert.styles';
-import { StyledRequiredTypography } from '../Item.styles';
 import DisplayUnitText from '../ItemParts/DisplayUnitText';
 import { StandardTextField } from '../Textfield.styles';
+import AccessibleFeedback from '../ItemParts/AccessibleFeedback';
 
 interface ChoiceSelectAnswerValueSetFieldsProps
   extends PropsWithIsTabledAttribute,
@@ -81,7 +83,14 @@ function ChoiceSelectAnswerValueSetFields(props: ChoiceSelectAnswerValueSetField
 
   if (codings.length > 0) {
     return (
-      <>
+      <FormControl
+        error={!!feedback}
+        sx={{
+          width: '100%',
+          maxWidth: !isTabled ? textFieldWidth : 3000,
+          minWidth: 160,
+          flexGrow: 1
+        }}>
         <Autocomplete
           {...(!isTabled && { id: `${qItem.type}-${qItem.linkId}` })}
           options={codings}
@@ -91,11 +100,11 @@ function ChoiceSelectAnswerValueSetFields(props: ChoiceSelectAnswerValueSetField
           getOptionLabel={(option) => option.display ?? `${option.code}`}
           value={valueCoding ?? null}
           onChange={(_, newValue) => onSelectChange(newValue)}
+          fullWidth
           autoHighlight
           open={open}
           onOpen={() => setOpen(true)}
           onClose={() => setOpen(false)}
-          sx={{ maxWidth: !isTabled ? textFieldWidth : 3000, minWidth: 160, flexGrow: 1 }}
           size="small"
           disabled={readOnly && readOnlyVisualStyle === 'disabled'}
           readOnly={readOnly && readOnlyVisualStyle === 'readonly'}
@@ -104,6 +113,7 @@ function ChoiceSelectAnswerValueSetFields(props: ChoiceSelectAnswerValueSetField
               multiline
               textFieldWidth={textFieldWidth}
               isTabled={isTabled}
+              error={!!feedback}
               placeholder={valueCoding ? undefined : entryFormat || displayPrompt}
               onFocus={handleFocus}
               {...params}
@@ -135,8 +145,12 @@ function ChoiceSelectAnswerValueSetFields(props: ChoiceSelectAnswerValueSetField
           )}
         />
 
-        {feedback ? <StyledRequiredTypography>{feedback}</StyledRequiredTypography> : null}
-      </>
+        {feedback ? (
+          <FormHelperText>
+            <AccessibleFeedback>{feedback}</AccessibleFeedback>
+          </FormHelperText>
+        ) : null}
+      </FormControl>
     );
   }
 

--- a/packages/smart-forms-renderer/src/components/FormComponents/DateTimeItems/CustomDateItem/CustomDateItem.tsx
+++ b/packages/smart-forms-renderer/src/components/FormComponents/DateTimeItems/CustomDateItem/CustomDateItem.tsx
@@ -69,7 +69,8 @@ function CustomDateItem(props: BaseItemProps) {
   // Perform validation checks
   // Constraint and required feedback takes priority; fall back to date format feedback.
   const validationFeedback = useValidationFeedback(qItem, undefined);
-  const feedback = validationFeedback || useDateValidation(input, dateParseFail);
+  const dateValidationFeedback = useDateValidation(input, dateParseFail);
+  const feedback = validationFeedback || dateValidationFeedback;
 
   // Generate instruction ID if instructions exist and there's no feedback
   const instructionsId =

--- a/packages/smart-forms-renderer/src/components/FormComponents/DateTimeItems/CustomDateItem/CustomDateItem.tsx
+++ b/packages/smart-forms-renderer/src/components/FormComponents/DateTimeItems/CustomDateItem/CustomDateItem.tsx
@@ -18,6 +18,7 @@
 import { useState } from 'react';
 import useDateValidation from '../../../../hooks/useDateValidation';
 import useReadOnly from '../../../../hooks/useReadOnly';
+import useValidationFeedback from '../../../../hooks/useValidationFeedback';
 import type { BaseItemProps } from '../../../../interfaces/renderProps.interface';
 import { useQuestionnaireStore } from '../../../../stores';
 import { createEmptyQrItem, getQRItemId } from '../../../../utils/qrItem';
@@ -66,7 +67,9 @@ function CustomDateItem(props: BaseItemProps) {
   const [focused, setFocused] = useState(false);
 
   // Perform validation checks
-  const feedback = useDateValidation(input, dateParseFail);
+  // Constraint and required feedback takes priority; fall back to date format feedback.
+  const validationFeedback = useValidationFeedback(qItem, undefined);
+  const feedback = validationFeedback || useDateValidation(input, dateParseFail);
 
   // Generate instruction ID if instructions exist and there's no feedback
   const instructionsId =

--- a/packages/smart-forms-renderer/src/components/FormComponents/DateTimeItems/CustomDateTimeItem/CustomDateTimeItem.tsx
+++ b/packages/smart-forms-renderer/src/components/FormComponents/DateTimeItems/CustomDateTimeItem/CustomDateTimeItem.tsx
@@ -23,6 +23,7 @@ import useDateNonEmptyValidation from '../../../../hooks/useDateTimeNonEmpty';
 import useDateValidation from '../../../../hooks/useDateValidation';
 import useReadOnly from '../../../../hooks/useReadOnly';
 import useTimeValidation from '../../../../hooks/useTimeValidation';
+import useValidationFeedback from '../../../../hooks/useValidationFeedback';
 import type { BaseItemProps } from '../../../../interfaces/renderProps.interface';
 import { useQuestionnaireStore } from '../../../../stores';
 import { createEmptyQrItem, getQRItemId } from '../../../../utils/qrItem';
@@ -95,6 +96,8 @@ function CustomDateTimeItem(props: BaseItemProps) {
   const [dateFocused, setDateFocused] = useState(false);
 
   // Perform validation checks
+  // Constraint and required feedback takes priority; fall back to date/time format feedback.
+  const validationFeedback = useValidationFeedback(qItem, undefined);
   let dateFeedback = useDateValidation(dateInput, dateParseFail);
   const { timeFeedback, is24HourNotation } = useTimeValidation(
     timeInput,
@@ -103,6 +106,7 @@ function CustomDateTimeItem(props: BaseItemProps) {
   );
 
   dateFeedback = useDateNonEmptyValidation(dateInput, timeInput, dateFeedback, timeFeedback);
+  dateFeedback = validationFeedback || dateFeedback;
 
   // Generate instruction ID if instructions exist and there's no feedback
   const instructionsId =

--- a/packages/smart-forms-renderer/src/components/FormComponents/OpenChoiceItems/OpenChoiceSelectAnswerOptionField.tsx
+++ b/packages/smart-forms-renderer/src/components/FormComponents/OpenChoiceItems/OpenChoiceSelectAnswerOptionField.tsx
@@ -20,6 +20,8 @@ import { getAnswerOptionLabel } from '../../../utils/openChoice';
 import { StandardTextField } from '../Textfield.styles';
 import type { AutocompleteChangeReason } from '@mui/material/Autocomplete';
 import Autocomplete from '@mui/material/Autocomplete';
+import FormControl from '@mui/material/FormControl';
+import FormHelperText from '@mui/material/FormHelperText';
 import type { QuestionnaireItem, QuestionnaireItemAnswerOption } from 'fhir/r4';
 import type {
   PropsWithIsTabledAttribute,
@@ -27,10 +29,10 @@ import type {
   PropsWithRenderingExtensionsAttribute
 } from '../../../interfaces/renderProps.interface';
 import { useRendererConfigStore } from '../../../stores';
-import { StyledRequiredTypography } from '../Item.styles';
 import DisplayUnitText from '../ItemParts/DisplayUnitText';
 import ExpressionUpdateFadingIcon from '../ItemParts/ExpressionUpdateFadingIcon';
 import StyledText from '../ItemParts/StyledText';
+import AccessibleFeedback from '../ItemParts/AccessibleFeedback';
 
 interface OpenChoiceSelectAnswerOptionFieldProps
   extends PropsWithIsTabledAttribute,
@@ -71,7 +73,14 @@ function OpenChoiceSelectAnswerOptionField(props: OpenChoiceSelectAnswerOptionFi
   const [inputValue, setInputValue] = React.useState('');
 
   return (
-    <>
+    <FormControl
+      error={!!feedback}
+      sx={{
+        width: '100%',
+        maxWidth: !isTabled ? textFieldWidth : 3000,
+        minWidth: 160,
+        flexGrow: 1
+      }}>
       <Autocomplete
         id={qItem.type + '-' + qItem.linkId}
         value={valueSelect ?? null}
@@ -104,16 +113,10 @@ function OpenChoiceSelectAnswerOptionField(props: OpenChoiceSelectAnswerOptionFi
             }
           }
         }}
+        fullWidth
         freeSolo
         autoHighlight
-        sx={{
-          maxWidth: !isTabled ? textFieldWidth : 3000,
-          minWidth: 160,
-          flexGrow: 1,
-          '& .MuiAutocomplete-tag': {
-            mx: 0
-          }
-        }}
+        sx={{ '& .MuiAutocomplete-tag': { mx: 0 } }}
         disabled={readOnly && readOnlyVisualStyle === 'disabled'}
         readOnly={readOnly && readOnlyVisualStyle === 'readonly'}
         size="small"
@@ -122,6 +125,7 @@ function OpenChoiceSelectAnswerOptionField(props: OpenChoiceSelectAnswerOptionFi
             multiline
             textFieldWidth={textFieldWidth}
             isTabled={isTabled}
+            error={!!feedback}
             placeholder={valueSelect ? undefined : entryFormat || displayPrompt}
             {...params}
             slotProps={{
@@ -192,8 +196,12 @@ function OpenChoiceSelectAnswerOptionField(props: OpenChoiceSelectAnswerOptionFi
         }}
       />
 
-      {feedback ? <StyledRequiredTypography>{feedback}</StyledRequiredTypography> : null}
-    </>
+      {feedback ? (
+        <FormHelperText>
+          <AccessibleFeedback>{feedback}</AccessibleFeedback>
+        </FormHelperText>
+      ) : null}
+    </FormControl>
   );
 }
 

--- a/packages/smart-forms-renderer/src/components/FormComponents/OpenChoiceItems/OpenChoiceSelectAnswerValueSetField.tsx
+++ b/packages/smart-forms-renderer/src/components/FormComponents/OpenChoiceItems/OpenChoiceSelectAnswerValueSetField.tsx
@@ -18,6 +18,8 @@
 import React from 'react';
 import type { AutocompleteChangeReason } from '@mui/material/Autocomplete';
 import Autocomplete from '@mui/material/Autocomplete';
+import FormControl from '@mui/material/FormControl';
+import FormHelperText from '@mui/material/FormHelperText';
 import { StandardTextField } from '../Textfield.styles';
 import Typography from '@mui/material/Typography';
 import type {
@@ -28,9 +30,9 @@ import type {
 import type { Coding, QuestionnaireItem } from 'fhir/r4';
 import type { TerminologyError } from '../../../hooks/useValueSetCodings';
 import { useRendererConfigStore } from '../../../stores';
-import { StyledRequiredTypography } from '../Item.styles';
 import DisplayUnitText from '../ItemParts/DisplayUnitText';
 import ExpressionUpdateFadingIcon from '../ItemParts/ExpressionUpdateFadingIcon';
+import AccessibleFeedback from '../ItemParts/AccessibleFeedback';
 
 interface OpenChoiceSelectAnswerValueSetFieldProps
   extends PropsWithIsTabledAttribute,
@@ -71,7 +73,14 @@ function OpenChoiceSelectAnswerValueSetField(props: OpenChoiceSelectAnswerValueS
   const { displayUnit, displayPrompt, entryFormat } = renderingExtensions;
 
   return (
-    <>
+    <FormControl
+      error={!!feedback}
+      sx={{
+        width: '100%',
+        maxWidth: !isTabled ? textFieldWidth : 3000,
+        minWidth: 160,
+        flexGrow: 1
+      }}>
       <Autocomplete
         id={qItem.type + '-' + qItem.linkId}
         value={valueSelect ?? null}
@@ -81,9 +90,9 @@ function OpenChoiceSelectAnswerValueSetField(props: OpenChoiceSelectAnswerValueS
         }
         onChange={(_, newValue, reason) => onValueChange(newValue, reason)}
         onInputChange={(_, newValue, reason) => onValueChange(newValue, reason)}
+        fullWidth
         freeSolo
         autoHighlight
-        sx={{ maxWidth: !isTabled ? textFieldWidth : 3000, minWidth: 160, flexGrow: 1 }}
         disabled={readOnly && readOnlyVisualStyle === 'disabled'}
         readOnly={readOnly && readOnlyVisualStyle === 'readonly'}
         size="small"
@@ -92,6 +101,7 @@ function OpenChoiceSelectAnswerValueSetField(props: OpenChoiceSelectAnswerValueS
             multiline
             textFieldWidth={textFieldWidth}
             isTabled={isTabled}
+            error={!!feedback}
             placeholder={entryFormat || displayPrompt}
             {...params}
             slotProps={{
@@ -124,8 +134,12 @@ function OpenChoiceSelectAnswerValueSetField(props: OpenChoiceSelectAnswerValueS
         </Typography>
       ) : null}
 
-      {feedback ? <StyledRequiredTypography>{feedback}</StyledRequiredTypography> : null}
-    </>
+      {feedback ? (
+        <FormHelperText>
+          <AccessibleFeedback>{feedback}</AccessibleFeedback>
+        </FormHelperText>
+      ) : null}
+    </FormControl>
   );
 }
 

--- a/packages/smart-forms-renderer/src/stores/questionnaireResponseStore.ts
+++ b/packages/smart-forms-renderer/src/stores/questionnaireResponseStore.ts
@@ -31,6 +31,12 @@ import { questionnaireStore } from './questionnaireStore';
 import { createQuestionnaireResponseItemMap } from '../utils/questionnaireResponseStoreUtils/updatableResponseItems';
 import { generateUniqueId } from '../utils/extractObservation';
 
+function hasErrors(invalidItems: Record<string, OperationOutcome>): boolean {
+  return Object.values(invalidItems).some((outcome) =>
+    outcome.issue.some((issue) => issue.severity === 'error' || issue.severity === 'fatal')
+  );
+}
+
 /**
  * QuestionnaireResponseStore properties and methods
  * Properties can be accessed for fine-grain details.
@@ -63,6 +69,7 @@ export interface QuestionnaireResponseStoreType {
   invalidItems: Record<string, OperationOutcome>;
   requiredItemsIsHighlighted: boolean;
   responseIsValid: boolean;
+  responseHasErrors: boolean;
   validateResponse: (questionnaire: Questionnaire, updatedResponse: QuestionnaireResponse) => void;
   buildSourceResponse: (response: QuestionnaireResponse) => void;
   updateResponse: (updatedResponse: QuestionnaireResponse, isInitialUpdate: boolean) => void;
@@ -89,12 +96,14 @@ export const questionnaireResponseStore = createStore<QuestionnaireResponseStore
     invalidItems: {},
     requiredItemsIsHighlighted: false,
     responseIsValid: true,
+    responseHasErrors: false,
     validateResponse: (questionnaire: Questionnaire, updatedResponse: QuestionnaireResponse) => {
       const updatedInvalidItems = validateForm(questionnaire, updatedResponse);
 
       set(() => ({
         invalidItems: updatedInvalidItems,
-        responseIsValid: Object.keys(updatedInvalidItems).length === 0
+        responseIsValid: Object.keys(updatedInvalidItems).length === 0,
+        responseHasErrors: hasErrors(updatedInvalidItems)
       }));
     },
     buildSourceResponse: (questionnaireResponse: QuestionnaireResponse) => {
@@ -111,7 +120,8 @@ export const questionnaireResponseStore = createStore<QuestionnaireResponseStore
         ),
         invalidItems: initialInvalidItems,
         requiredItemsIsHighlighted: false,
-        responseIsValid: Object.keys(initialInvalidItems).length === 0
+        responseIsValid: Object.keys(initialInvalidItems).length === 0,
+        responseHasErrors: hasErrors(initialInvalidItems)
       }));
     },
     updateResponse: (updatedResponse: QuestionnaireResponse, isInitialUpdate: boolean) => {
@@ -126,7 +136,8 @@ export const questionnaireResponseStore = createStore<QuestionnaireResponseStore
             updatedResponse
           ),
           invalidItems: updatedInvalidItems,
-          responseIsValid: Object.keys(updatedInvalidItems).length === 0
+          responseIsValid: Object.keys(updatedInvalidItems).length === 0,
+          responseHasErrors: hasErrors(updatedInvalidItems)
         };
 
         // If this is the initial update, skip updating the form changes
@@ -156,7 +167,8 @@ export const questionnaireResponseStore = createStore<QuestionnaireResponseStore
         ),
         formChangesHistory: [],
         invalidItems: updatedInvalidItems,
-        responseIsValid: Object.keys(updatedInvalidItems).length === 0
+        responseIsValid: Object.keys(updatedInvalidItems).length === 0,
+        responseHasErrors: hasErrors(updatedInvalidItems)
       }));
     },
     setUpdatableResponseAsEmpty: (clearedResponse: QuestionnaireResponse) => {
@@ -172,7 +184,8 @@ export const questionnaireResponseStore = createStore<QuestionnaireResponseStore
         formChangesHistory: [],
         invalidItems: updatedInvalidItems,
         requiredItemsIsHighlighted: false,
-        responseIsValid: Object.keys(updatedInvalidItems).length === 0
+        responseIsValid: Object.keys(updatedInvalidItems).length === 0,
+        responseHasErrors: hasErrors(updatedInvalidItems)
       }));
     },
     destroySourceResponse: () => {
@@ -188,7 +201,8 @@ export const questionnaireResponseStore = createStore<QuestionnaireResponseStore
         formChangesHistory: [],
         invalidItems: {},
         requiredItemsIsHighlighted: false,
-        responseIsValid: true
+        responseIsValid: true,
+        responseHasErrors: false
       }));
     },
     highlightRequiredItems: () =>

--- a/packages/smart-forms-renderer/src/stories/assets/questionnaires/QBehaviorOtherControl.ts
+++ b/packages/smart-forms-renderer/src/stories/assets/questionnaires/QBehaviorOtherControl.ts
@@ -1170,7 +1170,7 @@ export const qTargetConstraintSimple: Questionnaire = {
           valueExpression: {
             language: 'text/fhirpath',
             expression:
-              "%resource.item.where(linkId='1.1').answer.value < %resource.item.where(linkId='1.2').answer.value"
+              "%resource.item.where(linkId='1.1').answer.value >= %resource.item.where(linkId='1.2').answer.value"
           }
         },
         {
@@ -1237,7 +1237,7 @@ export const qTargetConstraintMultiple: Questionnaire = {
           valueExpression: {
             language: 'text/fhirpath',
             expression:
-              "%resource.item.where(linkId='aus-contact').answer.valueString.matches('^[0-9 ]+$').not()"
+              "%resource.item.where(linkId='aus-contact').answer.valueString.matches('^[0-9 ]+$')"
           }
         },
         {
@@ -1271,7 +1271,7 @@ export const qTargetConstraintMultiple: Questionnaire = {
           valueExpression: {
             language: 'text/fhirpath',
             expression:
-              "%resource.item.where(linkId='aus-contact').answer.value.matches('^(?!02|03|07|08|1300|1900|1800|04).+$')"
+              "%resource.item.where(linkId='aus-contact').answer.value.matches('^(02|03|04|07|08|1300|1800|1900)[0-9 ]+$')"
           }
         },
         {
@@ -1317,6 +1317,49 @@ export const qTargetConstraintMultiple: Questionnaire = {
           linkId: 'aus-contact-instructions',
           text: 'Include an area code for landlines',
           type: 'display'
+        }
+      ]
+    }
+  ]
+};
+
+// Demonstrates item-level targetConstraint (constraint defined directly on the item, no location
+// extension needed). The error surfaces on the "Last name" field when "First name" is filled
+// but "Last name" is empty.
+export const qTargetConstraintItemLevel: Questionnaire = {
+  resourceType: 'Questionnaire',
+  status: 'draft',
+  item: [
+    {
+      linkId: 'instructions',
+      text: 'Enter a first name, then leave last name blank to trigger a constraint error on the last name field.',
+      type: 'display'
+    },
+    {
+      linkId: 'firstName',
+      text: 'First name',
+      type: 'string'
+    },
+    {
+      linkId: 'lastName',
+      text: 'Last name',
+      type: 'string',
+      extension: [
+        {
+          url: 'http://hl7.org/fhir/StructureDefinition/targetConstraint',
+          extension: [
+            { url: 'key', valueId: 'last-name-required' },
+            { url: 'severity', valueCode: 'error' },
+            {
+              url: 'expression',
+              valueExpression: {
+                language: 'text/fhirpath',
+                expression:
+                  "%resource.item.where(linkId='firstName').answer.value.exists() implies %resource.item.where(linkId='lastName').answer.value.exists()"
+              }
+            },
+            { url: 'human', valueString: 'Last name is required when first name is provided' }
+          ]
         }
       ]
     }

--- a/packages/smart-forms-renderer/src/stories/sdc/BehaviorOtherControl.stories.tsx
+++ b/packages/smart-forms-renderer/src/stories/sdc/BehaviorOtherControl.stories.tsx
@@ -26,6 +26,7 @@ import {
   qEnableWhenMultiCheckbox,
   qInitialRepeats,
   qInitialSingle,
+  qTargetConstraintItemLevel,
   qTargetConstraintMultiple,
   qTargetConstraintSimple,
   qText
@@ -102,6 +103,12 @@ export const TargetConstraintSimple: Story = createStory({
 export const TargetConstraintMulti: Story = createStory({
   args: {
     questionnaire: qTargetConstraintMultiple
+  }
+}) as Story;
+
+export const TargetConstraintItemLevel: Story = createStory({
+  args: {
+    questionnaire: qTargetConstraintItemLevel
   }
 }) as Story;
 

--- a/packages/smart-forms-renderer/src/test/extractTargetConstraint.test.ts
+++ b/packages/smart-forms-renderer/src/test/extractTargetConstraint.test.ts
@@ -493,5 +493,185 @@ describe('extractTargetConstraint - Phase 5', () => {
 
       expect(result).toEqual({});
     });
+
+    it('should extract target constraints from item-level extensions', () => {
+      const questionnaire: Questionnaire = {
+        resourceType: 'Questionnaire',
+        status: 'active',
+        item: [
+          {
+            linkId: 'field-a',
+            text: 'Field A',
+            type: 'string',
+            extension: [
+              {
+                url: 'http://hl7.org/fhir/StructureDefinition/targetConstraint',
+                extension: [
+                  { url: 'key', valueId: 'item-constraint' },
+                  { url: 'severity', valueCode: 'error' },
+                  {
+                    url: 'expression',
+                    valueExpression: {
+                      expression: 'field.exists() implies other.exists()',
+                      language: 'text/fhirpath'
+                    }
+                  },
+                  { url: 'human', valueString: 'Other is required when field is set' }
+                ]
+              }
+            ]
+          }
+        ]
+      };
+
+      const result = extractTargetConstraints(questionnaire);
+
+      expect(result['item-constraint']).toMatchObject({
+        key: 'item-constraint',
+        severityCode: 'error',
+        human: 'Other is required when field is set',
+        linkId: 'field-a'
+      });
+    });
+
+    it('should set linkId on item-level constraints but not on questionnaire-level constraints', () => {
+      const questionnaire: Questionnaire = {
+        resourceType: 'Questionnaire',
+        status: 'active',
+        extension: [
+          {
+            url: 'http://hl7.org/fhir/StructureDefinition/targetConstraint',
+            extension: [
+              { url: 'key', valueId: 'q-level-constraint' },
+              { url: 'severity', valueCode: 'warning' },
+              {
+                url: 'expression',
+                valueExpression: { expression: 'true', language: 'text/fhirpath' }
+              },
+              { url: 'human', valueString: 'Questionnaire-level constraint' }
+            ]
+          }
+        ],
+        item: [
+          {
+            linkId: 'my-item',
+            text: 'My Item',
+            type: 'string',
+            extension: [
+              {
+                url: 'http://hl7.org/fhir/StructureDefinition/targetConstraint',
+                extension: [
+                  { url: 'key', valueId: 'item-level-constraint' },
+                  { url: 'severity', valueCode: 'error' },
+                  {
+                    url: 'expression',
+                    valueExpression: { expression: 'value.exists()', language: 'text/fhirpath' }
+                  },
+                  { url: 'human', valueString: 'Item-level constraint' }
+                ]
+              }
+            ]
+          }
+        ]
+      };
+
+      const result = extractTargetConstraints(questionnaire);
+
+      // Questionnaire-level constraint has no linkId (set later by readTargetConstraintLocationLinkIds if it has a location)
+      expect(result['q-level-constraint'].linkId).toBeUndefined();
+      // Item-level constraint has linkId set from the item during extraction
+      expect(result['item-level-constraint'].linkId).toBe('my-item');
+    });
+
+    it('should extract target constraints from nested item extensions', () => {
+      const questionnaire: Questionnaire = {
+        resourceType: 'Questionnaire',
+        status: 'active',
+        item: [
+          {
+            linkId: 'group',
+            text: 'Group',
+            type: 'group',
+            item: [
+              {
+                linkId: 'nested-field',
+                text: 'Nested Field',
+                type: 'string',
+                extension: [
+                  {
+                    url: 'http://hl7.org/fhir/StructureDefinition/targetConstraint',
+                    extension: [
+                      { url: 'key', valueId: 'nested-constraint' },
+                      { url: 'severity', valueCode: 'error' },
+                      {
+                        url: 'expression',
+                        valueExpression: { expression: 'value.exists()', language: 'text/fhirpath' }
+                      },
+                      { url: 'human', valueString: 'Nested constraint' }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      };
+
+      const result = extractTargetConstraints(questionnaire);
+
+      expect(result['nested-constraint']).toMatchObject({
+        key: 'nested-constraint',
+        linkId: 'nested-field'
+      });
+    });
+
+    it('should extract both questionnaire-level and item-level constraints together', () => {
+      const questionnaire: Questionnaire = {
+        resourceType: 'Questionnaire',
+        status: 'active',
+        extension: [
+          {
+            url: 'http://hl7.org/fhir/StructureDefinition/targetConstraint',
+            extension: [
+              { url: 'key', valueId: 'q-constraint' },
+              { url: 'severity', valueCode: 'warning' },
+              {
+                url: 'expression',
+                valueExpression: { expression: 'true', language: 'text/fhirpath' }
+              },
+              { url: 'human', valueString: 'Questionnaire constraint' }
+            ]
+          }
+        ],
+        item: [
+          {
+            linkId: 'item-1',
+            text: 'Item 1',
+            type: 'string',
+            extension: [
+              {
+                url: 'http://hl7.org/fhir/StructureDefinition/targetConstraint',
+                extension: [
+                  { url: 'key', valueId: 'item-constraint' },
+                  { url: 'severity', valueCode: 'error' },
+                  {
+                    url: 'expression',
+                    valueExpression: { expression: 'value.exists()', language: 'text/fhirpath' }
+                  },
+                  { url: 'human', valueString: 'Item constraint' }
+                ]
+              }
+            ]
+          }
+        ]
+      };
+
+      const result = extractTargetConstraints(questionnaire);
+
+      expect(Object.keys(result)).toHaveLength(2);
+      expect(result['q-constraint']).toBeDefined();
+      expect(result['item-constraint']).toBeDefined();
+      expect(result['item-constraint'].linkId).toBe('item-1');
+    });
   });
 });

--- a/packages/smart-forms-renderer/src/test/stores/questionnaireResponseStore.test.ts
+++ b/packages/smart-forms-renderer/src/test/stores/questionnaireResponseStore.test.ts
@@ -100,6 +100,7 @@ describe('questionnaireResponseStore', () => {
       expect(state.invalidItems).toEqual({});
       expect(state.requiredItemsIsHighlighted).toBe(false);
       expect(state.responseIsValid).toBe(true);
+      expect(state.responseHasErrors).toBe(false);
     });
   });
 
@@ -316,6 +317,64 @@ describe('questionnaireResponseStore', () => {
       expect(state.invalidItems).toEqual({});
       expect(state.requiredItemsIsHighlighted).toBe(false);
       expect(state.responseIsValid).toBe(true);
+    });
+  });
+
+  describe('responseHasErrors', () => {
+    it('should be false when there are no invalid items', () => {
+      mockValidateForm.mockReturnValue({});
+      questionnaireResponseStore
+        .getState()
+        .validateResponse(mockQuestionnaire, mockQuestionnaireResponse);
+
+      expect(questionnaireResponseStore.getState().responseHasErrors).toBe(false);
+    });
+
+    it('should be true when an invalid item has an error-severity issue', () => {
+      mockValidateForm.mockReturnValue({
+        'test-item': {
+          resourceType: 'OperationOutcome' as const,
+          issue: [{ severity: 'error', code: 'business-rule' }]
+        }
+      });
+      questionnaireResponseStore
+        .getState()
+        .validateResponse(mockQuestionnaire, mockQuestionnaireResponse);
+
+      expect(questionnaireResponseStore.getState().responseHasErrors).toBe(true);
+    });
+
+    it('should be false when invalid items contain only warning-severity issues', () => {
+      mockValidateForm.mockReturnValue({
+        'test-item': {
+          resourceType: 'OperationOutcome' as const,
+          issue: [{ severity: 'warning', code: 'business-rule' }]
+        }
+      });
+      questionnaireResponseStore
+        .getState()
+        .validateResponse(mockQuestionnaire, mockQuestionnaireResponse);
+
+      // responseIsValid is false (there are invalid items) but responseHasErrors is false (no errors, only warnings)
+      expect(questionnaireResponseStore.getState().responseIsValid).toBe(false);
+      expect(questionnaireResponseStore.getState().responseHasErrors).toBe(false);
+    });
+
+    it('should be true when at least one issue is error-severity alongside warnings', () => {
+      mockValidateForm.mockReturnValue({
+        'test-item': {
+          resourceType: 'OperationOutcome' as const,
+          issue: [
+            { severity: 'warning', code: 'business-rule' },
+            { severity: 'error', code: 'business-rule' }
+          ]
+        }
+      });
+      questionnaireResponseStore
+        .getState()
+        .validateResponse(mockQuestionnaire, mockQuestionnaireResponse);
+
+      expect(questionnaireResponseStore.getState().responseHasErrors).toBe(true);
     });
   });
 

--- a/packages/smart-forms-renderer/src/test/targetConstraint.test.ts
+++ b/packages/smart-forms-renderer/src/test/targetConstraint.test.ts
@@ -81,7 +81,10 @@ describe('targetConstraint', () => {
   });
 
   describe('evaluateInitialTargetConstraints', () => {
-    it('should evaluate initial target constraints with valid expressions', async () => {
+    it('should set isInvalid=false when expression returns true (constraint met)', async () => {
+      // Per FHIR spec, expressions return true when the constraint is MET (valid).
+      // constraint-1: expression returns [true] → constraint met → isInvalid should be false
+      // constraint-2: expression returns [false] → constraint violated → isInvalid should be true
       const mockInitialResponse: QuestionnaireResponse = {
         resourceType: 'QuestionnaireResponse',
         status: 'in-progress',
@@ -91,11 +94,11 @@ describe('targetConstraint', () => {
       const mockInitialResponseItemMap: Record<string, QuestionnaireResponseItem[]> = {};
 
       const mockTargetConstraints: Record<string, TargetConstraint> = {
-        'constraint-1': createMockTargetConstraint('constraint-1', 'true', false),
+        'constraint-1': createMockTargetConstraint('constraint-1', 'age >= 0', false),
         'constraint-2': createMockTargetConstraint(
           'constraint-2',
           '%context.item.where(linkId="test").answer.value',
-          true
+          false
         )
       };
 
@@ -118,18 +121,17 @@ describe('targetConstraint', () => {
         terminologyServerUrl
       };
 
-      // Mock createFhirPathContext
       mockCreateFhirPathContext.mockResolvedValue({
         fhirPathContext: { updated: 'context' },
         fhirPathTerminologyCache: {}
       });
 
-      // Mock fhirpath evaluate calls
+      // constraint-1: expression returns true → constraint MET → isInvalid = false (no change from initial)
+      // constraint-2: expression returns false → constraint VIOLATED → isInvalid = true
       mockFhirpathEvaluate
-        .mockReturnValueOnce(Promise.resolve([true])) // First constraint returns true
-        .mockReturnValueOnce([false]); // Second constraint returns false (sync)
+        .mockReturnValueOnce(Promise.resolve([true]))
+        .mockReturnValueOnce([false]);
 
-      // Mock handleFhirPathResult
       mockHandleFhirPathResult.mockResolvedValueOnce([true]).mockResolvedValueOnce([false]);
 
       const result = await evaluateInitialTargetConstraints(params);
@@ -146,8 +148,8 @@ describe('targetConstraint', () => {
       expect(mockFhirpathEvaluate).toHaveBeenCalledTimes(2);
       expect(mockHandleFhirPathResult).toHaveBeenCalledTimes(2);
 
-      expect(result.initialTargetConstraints['constraint-1'].isInvalid).toBe(true);
-      expect(result.initialTargetConstraints['constraint-2'].isInvalid).toBe(false);
+      expect(result.initialTargetConstraints['constraint-1'].isInvalid).toBe(false);
+      expect(result.initialTargetConstraints['constraint-2'].isInvalid).toBe(true);
       expect(result.updatedFhirPathContext).toEqual({ updated: 'context' });
     });
 
@@ -219,7 +221,7 @@ describe('targetConstraint', () => {
       expect(result.initialTargetConstraints).toEqual(mockTargetConstraints);
     });
 
-    it('should handle empty results by setting isInvalid to false', async () => {
+    it('should set isInvalid=false when expression returns empty (safe default)', async () => {
       const mockTargetConstraints: Record<string, TargetConstraint> = {
         'constraint-empty': createMockTargetConstraint('constraint-empty', 'empty.result', true)
       };
@@ -247,12 +249,14 @@ describe('targetConstraint', () => {
       expect(result.initialTargetConstraints['constraint-empty'].isInvalid).toBe(false);
     });
 
-    it('should handle intersect expressions with empty results', async () => {
+    it('should set isInvalid=true when intersect expression returns empty (constraint violated)', async () => {
+      // fhirpath.js returns [] when an intersect() expression evaluates to false.
+      // This means the constraint IS violated, so isInvalid should be true.
       const mockTargetConstraints: Record<string, TargetConstraint> = {
         'constraint-intersect': createMockTargetConstraint(
           'constraint-intersect',
           'item.intersect(empty)',
-          true
+          false // starts valid
         )
       };
 
@@ -276,7 +280,7 @@ describe('targetConstraint', () => {
 
       const result = await evaluateInitialTargetConstraints(params);
 
-      expect(result.initialTargetConstraints['constraint-intersect'].isInvalid).toBe(false);
+      expect(result.initialTargetConstraints['constraint-intersect'].isInvalid).toBe(true);
     });
 
     it('should cache async terminology results', async () => {
@@ -350,9 +354,15 @@ describe('targetConstraint', () => {
       expect(result.initialTargetConstraints['constraint-error'].isInvalid).toBe(false); // Should remain unchanged
     });
 
-    it('should not update isInvalid when value is the same to prevent infinite loops', async () => {
+    it('should not update isInvalid when expression returns correct spec-compliant value (prevents infinite loops)', async () => {
+      // constraint already correctly marked as valid (isInvalid=false), and expression returns true
+      // (constraint met) → !true = false → same as existing → no update
       const mockTargetConstraints: Record<string, TargetConstraint> = {
-        'constraint-same': createMockTargetConstraint('constraint-same', 'true', true)
+        'constraint-already-valid': createMockTargetConstraint(
+          'constraint-already-valid',
+          'age >= 0',
+          false // already correct
+        )
       };
 
       const params = {
@@ -375,7 +385,7 @@ describe('targetConstraint', () => {
 
       const result = await evaluateInitialTargetConstraints(params);
 
-      expect(result.initialTargetConstraints['constraint-same'].isInvalid).toBe(true); // Unchanged
+      expect(result.initialTargetConstraints['constraint-already-valid'].isInvalid).toBe(false);
     });
 
     it('should handle non-boolean results', async () => {
@@ -412,9 +422,34 @@ describe('targetConstraint', () => {
   });
 
   describe('evaluateTargetConstraints', () => {
-    it('should evaluate target constraints and return update status', async () => {
+    it('should set isInvalid=true and isUpdated=true when expression returns false (constraint violated)', async () => {
+      // constraint starts valid (isInvalid=false), expression returns false → violated → update to true
       const mockTargetConstraints: Record<string, TargetConstraint> = {
-        'constraint-1': createMockTargetConstraint('constraint-1', 'true', false)
+        'constraint-1': createMockTargetConstraint('constraint-1', 'age >= 0', false)
+      };
+
+      const fhirPathContext = { test: 'context' };
+      const fhirPathTerminologyCache = {};
+      const terminologyServerUrl = 'https://tx.fhir.org/r4';
+
+      mockFhirpathEvaluate.mockReturnValue([false]);
+      mockHandleFhirPathResult.mockResolvedValue([false]);
+
+      const result = await evaluateTargetConstraints(
+        fhirPathContext,
+        fhirPathTerminologyCache,
+        mockTargetConstraints,
+        terminologyServerUrl
+      );
+
+      expect(result.isUpdated).toBe(true);
+      expect(result.updatedTargetConstraints['constraint-1'].isInvalid).toBe(true);
+    });
+
+    it('should set isInvalid=false and isUpdated=true when expression returns true (constraint met)', async () => {
+      // constraint starts violated (isInvalid=true), expression returns true → met → update to false
+      const mockTargetConstraints: Record<string, TargetConstraint> = {
+        'constraint-1': createMockTargetConstraint('constraint-1', 'age >= 0', true)
       };
 
       const fhirPathContext = { test: 'context' };
@@ -432,12 +467,13 @@ describe('targetConstraint', () => {
       );
 
       expect(result.isUpdated).toBe(true);
-      expect(result.updatedTargetConstraints['constraint-1'].isInvalid).toBe(true);
+      expect(result.updatedTargetConstraints['constraint-1'].isInvalid).toBe(false);
     });
 
-    it('should return false for isUpdated when no constraints change', async () => {
+    it('should return isUpdated=false when constraint value does not change', async () => {
+      // constraint already correctly valid (isInvalid=false), expression returns true → no change
       const mockTargetConstraints: Record<string, TargetConstraint> = {
-        'constraint-1': createMockTargetConstraint('constraint-1', 'true', true)
+        'constraint-1': createMockTargetConstraint('constraint-1', 'age >= 0', false)
       };
 
       const fhirPathContext = { test: 'context' };
@@ -455,7 +491,7 @@ describe('targetConstraint', () => {
       );
 
       expect(result.isUpdated).toBe(false);
-      expect(result.updatedTargetConstraints['constraint-1'].isInvalid).toBe(true);
+      expect(result.updatedTargetConstraints['constraint-1'].isInvalid).toBe(false);
     });
 
     it('should use cached results for repeated expressions', async () => {
@@ -506,13 +542,43 @@ describe('targetConstraint', () => {
       expect(result.isUpdated).toBe(false);
     });
 
-    it('should handle empty results and intersect edge cases', async () => {
+    it('should keep isInvalid=true when intersect still returns empty after a form edit (constraint remains violated)', async () => {
+      // After any form edit, all constraints are re-evaluated. If an intersect constraint was
+      // already violated (isInvalid=true) and the expression still returns [], isInvalid must
+      // stay true — without the fix, the generic empty case would reset it to false.
+      const mockTargetConstraints: Record<string, TargetConstraint> = {
+        'constraint-intersect': createMockTargetConstraint(
+          'constraint-intersect',
+          'item.intersect(empty)',
+          true // violated from previous evaluation
+        )
+      };
+
+      const fhirPathContext = { test: 'context' };
+      const fhirPathTerminologyCache = {};
+      const terminologyServerUrl = 'https://tx.fhir.org/r4';
+
+      mockFhirpathEvaluate.mockReturnValue([]);
+      mockHandleFhirPathResult.mockResolvedValue([]);
+
+      const result = await evaluateTargetConstraints(
+        fhirPathContext,
+        fhirPathTerminologyCache,
+        mockTargetConstraints,
+        terminologyServerUrl
+      );
+
+      expect(result.isUpdated).toBe(false);
+      expect(result.updatedTargetConstraints['constraint-intersect'].isInvalid).toBe(true);
+    });
+
+    it('should set isInvalid=false for empty result (safe default) and isInvalid=true for intersect empty result (constraint violated)', async () => {
       const mockTargetConstraints: Record<string, TargetConstraint> = {
         'constraint-empty': createMockTargetConstraint('constraint-empty', 'empty.result', true),
         'constraint-intersect': createMockTargetConstraint(
           'constraint-intersect',
           'item.intersect(empty)',
-          true
+          false // starts valid
         )
       };
 
@@ -531,8 +597,10 @@ describe('targetConstraint', () => {
       );
 
       expect(result.isUpdated).toBe(true);
+      // Generic empty → safe default: not invalid
       expect(result.updatedTargetConstraints['constraint-empty'].isInvalid).toBe(false);
-      expect(result.updatedTargetConstraints['constraint-intersect'].isInvalid).toBe(false);
+      // Intersect empty → constraint violated: invalid
+      expect(result.updatedTargetConstraints['constraint-intersect'].isInvalid).toBe(true);
     });
   });
 
@@ -586,10 +654,77 @@ describe('targetConstraint', () => {
       // Check that linkIds were added to the constraints
       expect(mockTargetConstraints['constraint-1'].linkId).toBe('item-1');
       expect(mockTargetConstraints['constraint-2'].linkId).toBe('item-2');
+      // constraint with no location and no pre-set linkId is not mapped
       expect(mockTargetConstraints['constraint-no-location'].linkId).toBeUndefined();
     });
 
-    it('should handle multiple constraints pointing to the same linkId', () => {
+    it('should map item-level constraints by their pre-set linkId (no location)', () => {
+      // Constraints extracted from item extensions have linkId set during extraction
+      // (no location extension). readTargetConstraintLocationLinkIds should include these
+      // in the returned map.
+      const mockQuestionnaire: Questionnaire = {
+        resourceType: 'Questionnaire',
+        status: 'active',
+        item: [
+          { linkId: 'field-a', type: 'string', text: 'Field A' },
+          { linkId: 'field-b', type: 'string', text: 'Field B' }
+        ]
+      };
+
+      // No location: these take the else-if(linkId) branch, not the location branch.
+      // If location were set, it would override linkId via FHIRPath resolution instead.
+      const mockTargetConstraints: Record<string, TargetConstraint> = {
+        'item-level-1': {
+          ...createMockTargetConstraint('item-level-1', 'field.exists()'),
+          linkId: 'field-a', // set during extraction
+          location: undefined
+        },
+        'item-level-2': {
+          ...createMockTargetConstraint('item-level-2', 'other.exists()'),
+          linkId: 'field-b', // set during extraction
+          location: undefined
+        }
+      };
+
+      const result = readTargetConstraintLocationLinkIds(mockQuestionnaire, mockTargetConstraints);
+
+      // No fhirpath evaluation needed — linkId already known from extraction
+      expect(mockFhirpathEvaluate).not.toHaveBeenCalled();
+
+      expect(result).toEqual({
+        'field-a': ['item-level-1'],
+        'field-b': ['item-level-2']
+      });
+    });
+
+    it('should accumulate multiple item-level constraints on the same linkId', () => {
+      const mockQuestionnaire: Questionnaire = {
+        resourceType: 'Questionnaire',
+        status: 'active',
+        item: [{ linkId: 'shared-field', type: 'string', text: 'Shared' }]
+      };
+
+      const mockTargetConstraints: Record<string, TargetConstraint> = {
+        'constraint-a': {
+          ...createMockTargetConstraint('constraint-a', 'expr-a'),
+          linkId: 'shared-field',
+          location: undefined
+        },
+        'constraint-b': {
+          ...createMockTargetConstraint('constraint-b', 'expr-b'),
+          linkId: 'shared-field',
+          location: undefined
+        }
+      };
+
+      const result = readTargetConstraintLocationLinkIds(mockQuestionnaire, mockTargetConstraints);
+
+      expect(result['shared-field']).toHaveLength(2);
+      expect(result['shared-field']).toContain('constraint-a');
+      expect(result['shared-field']).toContain('constraint-b');
+    });
+
+    it('should handle multiple constraints pointing to the same linkId via location', () => {
       const mockQuestionnaire: Questionnaire = {
         resourceType: 'Questionnaire',
         status: 'active',

--- a/packages/smart-forms-renderer/src/test/validate.test.ts
+++ b/packages/smart-forms-renderer/src/test/validate.test.ts
@@ -753,6 +753,79 @@ describe('validate', () => {
       expect(result).toEqual({}); // Should be empty since item is hidden
     });
 
+    it('should pass severityCode through to the OperationOutcome issue severity', () => {
+      const errorConstraint = {
+        key: 'tc-error',
+        linkId: 'test-item',
+        isInvalid: true,
+        severityCode: 'error' as const,
+        human: 'Systolic must be greater than diastolic',
+        valueExpression: { language: 'text/fhirpath', expression: 'systolic >= diastolic' }
+      };
+
+      const warningConstraint = {
+        key: 'tc-warning',
+        linkId: 'warning-item',
+        isInvalid: true,
+        severityCode: 'warning' as const,
+        human: 'Consider reviewing this value',
+        valueExpression: { language: 'text/fhirpath', expression: 'value > 0' }
+      };
+
+      mockQuestionnaireStore.getState.mockReturnValue({
+        itemMap: {
+          'test-item': { linkId: 'test-item', type: 'integer', text: 'Systolic' },
+          'warning-item': { linkId: 'warning-item', type: 'integer', text: 'Value' }
+        },
+        targetConstraints: {
+          'tc-error': errorConstraint,
+          'tc-warning': warningConstraint
+        },
+        enableWhenIsActivated: false,
+        enableWhenItems: { singleItems: {}, repeatItems: {} },
+        enableWhenExpressions: { singleExpressions: {}, repeatExpressions: {} }
+      } as any);
+
+      mockIsItemHidden.mockReturnValue(false);
+
+      const result = validateTargetConstraint();
+
+      expect(result['test-item'].issue[0].severity).toBe('error');
+      expect(result['warning-item'].issue[0].severity).toBe('warning');
+    });
+
+    it('should pass human text through to the OperationOutcome issue details', () => {
+      const mockTargetConstraint = {
+        key: 'tc-1',
+        linkId: 'test-item',
+        isInvalid: true,
+        severityCode: 'error' as const,
+        human: 'Systolic must be greater than diastolic',
+        valueExpression: { language: 'text/fhirpath', expression: 'systolic >= diastolic' }
+      };
+
+      mockQuestionnaireStore.getState.mockReturnValue({
+        itemMap: {
+          'test-item': { linkId: 'test-item', type: 'integer', text: 'Systolic' }
+        },
+        targetConstraints: { 'tc-1': mockTargetConstraint },
+        enableWhenIsActivated: false,
+        enableWhenItems: { singleItems: {}, repeatItems: {} },
+        enableWhenExpressions: { singleExpressions: {}, repeatExpressions: {} }
+      } as any);
+
+      mockIsItemHidden.mockReturnValue(false);
+
+      const result = validateTargetConstraint();
+
+      expect(result['test-item'].issue[0].details?.text).toBe(
+        'Systolic must be greater than diastolic'
+      );
+      expect(result['test-item'].issue[0].details?.coding?.[0]?.display).toBe(
+        'Systolic must be greater than diastolic'
+      );
+    });
+
     it('should handle target constraints without linkId', () => {
       const mockTargetConstraint = {
         key: 'tc-1',
@@ -1266,6 +1339,38 @@ describe('validate', () => {
 
       expect(result.issue[0].details?.coding?.[0]?.code).toBe(ValidationResult.invariant);
       expect(result.issue[0].code).toBe('business-rule');
+    });
+
+    it('should use the provided severity on the OperationOutcome issue', () => {
+      const result = createValidationOperationOutcome(
+        ValidationResult.invariant,
+        mockQItem,
+        mockQrItem,
+        0,
+        'QuestionnaireResponse.item[0]',
+        [],
+        'warning'
+      );
+
+      expect(result.issue[0].severity).toBe('warning');
+    });
+
+    it('should set humanReadable as details text for invariant results', () => {
+      const result = createValidationOperationOutcome(
+        ValidationResult.invariant,
+        mockQItem,
+        mockQrItem,
+        0,
+        'QuestionnaireResponse.item[0]',
+        [],
+        'error',
+        'Systolic must be greater than diastolic'
+      );
+
+      expect(result.issue[0].details?.text).toBe('Systolic must be greater than diastolic');
+      expect(result.issue[0].details?.coding?.[0]?.display).toBe(
+        'Systolic must be greater than diastolic'
+      );
     });
 
     it('should handle unknown validation result types', () => {

--- a/packages/smart-forms-renderer/src/utils/questionnaireStoreUtils/extractTargetConstraint.ts
+++ b/packages/smart-forms-renderer/src/utils/questionnaireStoreUtils/extractTargetConstraint.ts
@@ -1,4 +1,4 @@
-import type { Extension, Questionnaire } from 'fhir/r4';
+import type { Extension, Questionnaire, QuestionnaireItem } from 'fhir/r4';
 import type {
   TargetConstraint,
   TargetConstraintExpression,
@@ -55,17 +55,36 @@ export function constructTargetConstraint(extension: Extension): TargetConstrain
 export function extractTargetConstraints(
   questionnaire: Questionnaire
 ): Record<string, TargetConstraint> {
-  if (!questionnaire.extension || questionnaire.extension.length === 0) {
-    return {};
-  }
-
   const targetConstraints: Record<string, TargetConstraint> = {};
-  for (const ext of questionnaire.extension) {
+
+  // Questionnaire-level extensions
+  for (const ext of questionnaire.extension ?? []) {
     const targetConstraint = constructTargetConstraint(ext);
     if (targetConstraint?.key) {
-      targetConstraints[targetConstraint?.key] = targetConstraint;
+      targetConstraints[targetConstraint.key] = targetConstraint;
     }
   }
 
+  // Item-level extensions (recursive)
+  extractTargetConstraintsFromItems(questionnaire.item ?? [], targetConstraints);
+
   return targetConstraints;
+}
+
+function extractTargetConstraintsFromItems(
+  items: QuestionnaireItem[],
+  targetConstraints: Record<string, TargetConstraint>
+) {
+  for (const item of items) {
+    for (const ext of item.extension ?? []) {
+      const targetConstraint = constructTargetConstraint(ext);
+      if (targetConstraint?.key) {
+        // Record the item's own linkId so the error surfaces on the correct field.
+        // readTargetConstraintLocationLinkIds will override this if a location is provided.
+        targetConstraint.linkId = item.linkId;
+        targetConstraints[targetConstraint.key] = targetConstraint;
+      }
+    }
+    extractTargetConstraintsFromItems(item.item ?? [], targetConstraints);
+  }
 }

--- a/packages/smart-forms-renderer/src/utils/targetConstraint.ts
+++ b/packages/smart-forms-renderer/src/utils/targetConstraint.ts
@@ -90,19 +90,20 @@ export async function evaluateInitialTargetConstraints(
       const result = await handleFhirPathResult(fhirPathResult);
 
       // Update targetConstraints if length of result array > 0
-      // Only update when current isInvalid value is different from the result, otherwise it will result in am infinite loop as per #733
-      if (result.length > 0 && initialValue !== result[0] && typeof result[0] === 'boolean') {
-        targetConstraints[key].isInvalid = result[0];
+      // Per FHIR spec, constraint expressions evaluate to true when the constraint is *met* (valid), so isInvalid = !result
+      // Only update when current isInvalid value differs from the new value, otherwise it will result in an infinite loop as per #733
+      if (result.length > 0 && initialValue !== !result[0] && typeof result[0] === 'boolean') {
+        targetConstraints[key].isInvalid = !result[0];
       }
 
-      // Update isInvalid value to false if no result is returned
-      if (result.length === 0 && initialValue !== false) {
+      // Update isInvalid value to false if no result is returned (intersect handled separately below)
+      if (result.length === 0 && !expression.includes('intersect') && initialValue !== false) {
         targetConstraints[key].isInvalid = false;
       }
 
-      // handle intersect edge case - evaluate() returns empty array if result is false
-      if (expression.includes('intersect') && result.length === 0 && initialValue !== false) {
-        targetConstraints[key].isInvalid = false;
+      // handle intersect edge case - evaluate() returns empty array if result is false (constraint violated)
+      if (expression.includes('intersect') && result.length === 0 && initialValue !== true) {
+        targetConstraints[key].isInvalid = true;
       }
 
       // If fhirPathResult is an async terminology call, cache the result
@@ -150,21 +151,22 @@ export async function evaluateTargetConstraints(
       const result = await handleFhirPathResult(fhirPathResult);
 
       // Update targetConstraints if length of result array > 0
-      // Only update when current isInvalid value is different from the result, otherwise it will result in am infinite loop as per #733
-      if (result.length > 0 && initialValue !== result[0] && typeof result[0] === 'boolean') {
-        targetConstraints[key].isInvalid = result[0];
+      // Per FHIR spec, constraint expressions evaluate to true when the constraint is *met* (valid), so isInvalid = !result
+      // Only update when current isInvalid value differs from the new value, otherwise it will result in an infinite loop as per #733
+      if (result.length > 0 && initialValue !== !result[0] && typeof result[0] === 'boolean') {
+        targetConstraints[key].isInvalid = !result[0];
         isUpdated = true;
       }
 
-      // Update isInvalid value to false if no result is returned
-      if (result.length === 0 && initialValue !== false) {
+      // Update isInvalid value to false if no result is returned (intersect handled separately below)
+      if (result.length === 0 && !expression.includes('intersect') && initialValue !== false) {
         targetConstraints[key].isInvalid = false;
         isUpdated = true;
       }
 
-      // handle intersect edge case - evaluate() returns empty array if result is false
-      if (expression.includes('intersect') && result.length === 0 && initialValue !== false) {
-        targetConstraints[key].isInvalid = false;
+      // handle intersect edge case - evaluate() returns empty array if result is false (constraint violated)
+      if (expression.includes('intersect') && result.length === 0 && initialValue !== true) {
+        targetConstraints[key].isInvalid = true;
         isUpdated = true;
       }
 
@@ -190,6 +192,7 @@ export function readTargetConstraintLocationLinkIds(
   const targetConstraintLinkIds: Record<string, string[]> = {};
   for (const [targetConstraintKey, targetConstraint] of Object.entries(targetConstraints)) {
     if (targetConstraint.location) {
+      // location overrides item-level linkId: resolve via FHIRPath and store the result
       const targetConstraintLinkId = getTargetConstraintLocationLinkId(
         questionnaire,
         targetConstraint.location
@@ -206,6 +209,13 @@ export function readTargetConstraintLocationLinkIds(
 
         // Add to targetConstraint.linkId
         targetConstraints[targetConstraintKey].linkId = targetConstraintLinkId;
+      }
+    } else if (targetConstraint.linkId) {
+      // No location — constraint was defined on the item directly, linkId set during extraction
+      if (targetConstraintLinkIds[targetConstraint.linkId]) {
+        targetConstraintLinkIds[targetConstraint.linkId].push(targetConstraintKey);
+      } else {
+        targetConstraintLinkIds[targetConstraint.linkId] = [targetConstraintKey];
       }
     }
   }

--- a/packages/smart-forms-renderer/src/utils/validate.ts
+++ b/packages/smart-forms-renderer/src/utils/validate.ts
@@ -136,7 +136,9 @@ export function validateTargetConstraint(): Record<string, OperationOutcome> {
         null as unknown as QuestionnaireResponseItem, // We don't need a QuestionnaireResponseItem here
         null,
         locationExpression,
-        []
+        [],
+        targetConstraint.severityCode,
+        targetConstraint.human
       );
 
       const invalidItemKey = targetConstraint.linkId ?? `target-constraint-${targetConstraint.key}`;
@@ -781,12 +783,22 @@ export function createValidationOperationOutcome(
   qrItem: QuestionnaireResponseItem | null,
   answerIndex: number | null,
   locationExpression: string,
-  existingOperationOutcomeIssues: OperationOutcomeIssue[] = []
+  existingOperationOutcomeIssues: OperationOutcomeIssue[] = [],
+  severity: 'error' | 'warning' = 'error',
+  humanReadable?: string
 ): OperationOutcome {
   return {
     resourceType: 'OperationOutcome',
     issue: existingOperationOutcomeIssues.concat(
-      createValidationOperationOutcomeIssue(error, qItem, qrItem, answerIndex, locationExpression)
+      createValidationOperationOutcomeIssue(
+        error,
+        qItem,
+        qrItem,
+        answerIndex,
+        locationExpression,
+        severity,
+        humanReadable
+      )
     )
   };
 }


### PR DESCRIPTION
## Summary

- Blocks save-as-final (and save-as-amendment) when the form has validation errors — navigates to the first tab containing an error, highlights required fields, and shows a snackbar
- Same gate added to the viewer's "Save as Final" button for in-progress responses
- Fixes `targetConstraint` — the feature was entirely non-functional due to four compounding bugs; fixing it is a prerequisite for the save gate relying on `invalidItems`
- Fixes validation feedback not appearing on `date`/`dateTime` fields
- Fixes validation feedback squishing horizontally in grid cells for autocomplete choice fields

## Changes

### Save gate — renderer (`SaveAsFinalAction.tsx`)

When `responseHasErrors` is true, save-as-final (and save-as-amendment) now:
1. Calls `highlightRequiredItems()` to surface required-field errors
2. Walks the questionnaire item tree to find the first tab containing an invalid item and navigates there via `switchTab()`
3. Shows a snackbar: _"The form has errors that must be fixed before saving as final."_
4. Aborts — extraction is not triggered

Both the write-back and non-write-back code paths are gated. New utility `renderer/utils/tabNavigation.ts` — `findFirstErrorTabIndex()` — with 12 unit tests.

### Save gate — viewer (`ViewerSaveAsFinal.tsx`)

The viewer's "Save as Final" button (shown for in-progress responses) now checks `responseHasErrors` before opening the confirmation dialog. If errors are present it calls `highlightRequiredItems()` and shows a snackbar: _"This response has errors. Edit the response to view and fix them before saving as final."_

### `responseHasErrors` added to store

`questionnaireResponseStore` gains a `responseHasErrors: boolean` derived from whether any OperationOutcome issue has `severity: 'error' | 'fatal'`. This distinguishes hard errors from warnings so the save gate doesn't block when only warnings are present. Updated in all six state-setting locations.

`validateTargetConstraint()` now also passes `targetConstraint.severityCode` and `targetConstraint.human` through to the OperationOutcome, replacing the previous hardcoded `severity: 'error'`.

### `targetConstraint` bug fixes (fixes #1954)

Four bugs were making the feature entirely non-functional:

1. **Item-level constraints never extracted** — `extractTargetConstraints` only read `questionnaire.extension`; most constraints live on `item.extension`. Added recursive traversal of `questionnaire.item`.

2. **`targetConstraintLinkIds` map not populated for item-level constraints** — `readTargetConstraintLocationLinkIds` only mapped constraints with a `location` extension. Added an `else if (targetConstraint.linkId)` branch for the common case.

3. **Expression logic inverted** — `isInvalid = result[0]` should be `isInvalid = !result[0]`. Per the FHIR spec, constraint expressions return `true` when the constraint is **met** (valid). The inversion meant spec-compliant expressions never showed errors. Also fixed the `intersect()` edge case where fhirpath.js returns `[]` for `false`.

   > **Breaking change:** questionnaires using expressions written in the old (inverted) convention (returning `true` when violated) will stop working. Expressions must return `true` when valid.

4. **Validation filter silently dropped item-level constraints** — the synthetic `target-constraint-${key}` fallback key doesn't exist in `itemMap`, causing the visibility filter to drop every item-level constraint from `filteredInvalidItems`. Implicitly resolved by bug 1: storing `linkId` on the `TargetConstraint` object means the real linkId is now used.

### Date/dateTime validation feedback

`CustomDateItem` and `CustomDateTimeItem` called `useDateValidation` directly, which only validates date format and has no awareness of target constraints, required fields, or `invalidItems`. Both components now call `useValidationFeedback` first and fall back to format feedback, matching the pattern used by other field types.

This resolves point 1 of #1971 (targetConstraint errors not displaying on date fields). Point 2 of that issue (`minValue`/`maxValue` not enforced on date items) is not addressed here.

### Validation feedback squishing in grid cells (choice select fields)

Autocomplete-based choice components were rendering feedback as a flex sibling of the Autocomplete, squishing it horizontally in grid cells. Replaced `StyledRequiredTypography` with `FormControl` + `FormHelperText` in `ChoiceSelectAnswerOptionFields`, `ChoiceSelectAnswerValueSetFields`, `OpenChoiceSelectAnswerOptionField`, and `OpenChoiceSelectAnswerValueSetField`. Error border added via `error={!!feedback}` on `StandardTextField`.

## Test plan

- [ ] Open a questionnaire with required fields — leave some empty, click "Save as Final" — gate fires, first error tab is selected, required fields highlighted
- [ ] Fill all required fields — "Save as Final" proceeds normally
- [ ] Questionnaire with `targetConstraint` expressions (returns `true` when valid) — violate constraint, confirm error shown; fix it, confirm error clears; save-as-final blocked then allowed
- [ ] In-progress response in viewer with missing required fields — "Save as Final" shows snackbar, does not open dialog
- [ ] Date/dateTime field with targetConstraint — confirm error feedback appears
- [ ] Autocomplete choice field in a grid — confirm validation feedback stacks vertically below the input

🤖 Generated with [Claude Code](https://claude.com/claude-code)