### PR TITLE
[WIP] fix: allergy manifestation not pre-populated in Aboriginal Health Check (issue #1975)

### DIFF
--- a/apps/smart-forms-app/src/test/aboriginalFormExtraction.test.tsx
+++ b/apps/smart-forms-app/src/test/aboriginalFormExtraction.test.tsx
@@ -40,17 +40,21 @@ vi.mock('fhirclient', async () => {
   return {
     ...actual,
     client: (input: string | { serverUrl?: string }) => {
-      const actualClient = actual.client(input as never);
       const serverUrl = typeof input === 'string' ? input : input?.serverUrl;
 
       if (serverUrl === terminologyServerUrl) {
-        return actualClient;
+        // Use native fetch to forward requests to the real terminology server.
+        // vi.importActual resolves the Node entry of fhirclient which has no `client`,
+        // so we can't use actual.client() here.
+        return {
+          request: ({ url }: { url: string }) =>
+            fetch(`${serverUrl}/${url}`, {
+              headers: { Accept: 'application/json' }
+            }).then((res) => res.json())
+        };
       }
 
-      return {
-        ...actualClient,
-        request: mockedRequest
-      };
+      return { request: mockedRequest };
     }
   };
 });

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/populate.test.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/populate.test.ts
@@ -16,19 +16,15 @@ import { resolveLookupPromises } from '../utils/resolveLookupPromises';
 import { resolvedLookupAboriginalTorresStraitIslanderHealthCheck } from '../../test-data-shared/AboriginalTorresStraitIslanderHealthCheck/resolvedLookupAboriginalTorresStraitIslanderHealthCheck';
 import fhirpath from 'fhirpath';
 import fhirpath_r4_model from 'fhirpath/fhir-context/r4/index.js';
+import { stampFhirpathMetadata } from '../utils/evaluateExpressions';
 
-// fhirpath v4 requires array context variable items to have __path__ (attached non-enumerably
-// when objects pass through fhirpath.evaluate). Plain static TS objects lack this, so we
-// run each FHIR resource item through fhirpath's $this to stamp __path__ onto it.
+// Prepares a fhirpath context for use in tests by stamping __path__ on all resource arrays.
+// Uses the same stampFhirpathMetadata helper used in production code.
 function prepareContextForFhirpathV4(ctx: Record<string, any>): Record<string, any> {
   const prepared = { ...ctx };
   for (const [key, value] of Object.entries(prepared)) {
-    if (Array.isArray(value) && value.some((i) => i?.resourceType)) {
-      prepared[key] = value.map((item) => {
-        if (!item?.resourceType) return item;
-        const result = fhirpath.evaluate(item, '$this', {}, fhirpath_r4_model) as any[];
-        return result[0] ?? item;
-      });
+    if (Array.isArray(value) && value.some((i: any) => i?.resourceType)) {
+      prepared[key] = value.map(stampFhirpathMetadata);
     }
   }
   return prepared;
@@ -212,6 +208,78 @@ describe('populate', () => {
     )?.valueAttachment?.data as string;
     const decodedResultContext = JSON.parse(Base64.decode(resultContext));
     expect(decodedResultContext).toStrictEqual(mockContext);
+  });
+});
+
+describe('populate - fhirpath v4 __path__ requirement for nested BackboneElements', () => {
+  /**
+   * Reproduces the regression seen in aboriginalFormPopulation.test.tsx where
+   * AllergyIntolerance.reaction.manifestation.select(...) returns empty even though the
+   * data is present.
+   *
+   * Root cause: fhirpath v4 requires __path__ to be stamped on context variable items.
+   * Resources fetched via fetchResourceCallback arrive as plain JSON (no __path__).
+   * When fhirpath evaluates itemPopulationContext it returns top-level resources with __path__,
+   * but nested BackboneElements (reaction[]) inside those resources still lack __path__.
+   * Navigating through reaction.manifestation inside select() then silently returns empty.
+   *
+   * The fix is to stamp __path__ on every resource BEFORE it is used as a context variable.
+   */
+  it('reaction.manifestation.select() throws for a plain resource (no __path__)', () => {
+    const allergyPlain = {
+      resourceType: 'AllergyIntolerance',
+      id: 'allergy-plain',
+      reaction: [
+        {
+          manifestation: [
+            {
+              coding: [{ system: 'http://snomed.info/sct', code: '271807003', display: 'Rash' }]
+            }
+          ]
+        }
+      ]
+    };
+
+    // Without __path__, fhirpath v4 throws when navigating nested BackboneElements.
+    // In constructRepeatGroupInstances this error is caught silently → field stays empty.
+    expect(() =>
+      fhirpath.evaluate(
+        {},
+        "%allergy.reaction.manifestation.select((coding.where(system='http://snomed.info/sct') | coding.where(system!='http://snomed.info/sct').first() | text).first())",
+        { allergy: [allergyPlain] },
+        fhirpath_r4_model
+      )
+    ).toThrow();
+  });
+
+  it('reaction.manifestation.select() returns Rash after __path__ is stamped via $this', () => {
+    const allergyPlain = {
+      resourceType: 'AllergyIntolerance',
+      id: 'allergy-stamped',
+      reaction: [
+        {
+          manifestation: [
+            {
+              coding: [{ system: 'http://snomed.info/sct', code: '271807003', display: 'Rash' }]
+            }
+          ]
+        }
+      ]
+    };
+
+    // Stamp __path__ by running through fhirpath.evaluate with $this
+    const stamped = (fhirpath.evaluate(allergyPlain, '$this', {}, fhirpath_r4_model) as any[])[0];
+
+    const result = fhirpath.evaluate(
+      {},
+      "%allergy.reaction.manifestation.select((coding.where(system='http://snomed.info/sct') | coding.where(system!='http://snomed.info/sct').first() | text).first())",
+      { allergy: [stamped] },
+      fhirpath_r4_model
+    );
+
+    // With __path__ stamped, the nested navigation works correctly
+    expect(result).toHaveLength(1);
+    expect((result[0] as any).display).toBe('Rash');
   });
 });
 

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/populate.test.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/populate.test.ts
@@ -273,3 +273,87 @@ describe('populate - repeat group with toString()', () => {
     }
   });
 });
+
+// Minimal questionnaire with a NON-repeating group that has itemPopulationContext.
+// Children's initialExpressions must be evaluated globally (not per-instance via repeat group
+// logic). The child expression uses a simple flat property (.id) to isolate this behaviour.
+const qNonRepeatGroupSimple = {
+  resourceType: 'Questionnaire',
+  id: 'non-repeat-ipc-simple-test',
+  status: 'active',
+  item: [
+    {
+      linkId: 'patient-group',
+      type: 'group',
+      extension: [
+        {
+          url: SDC_ITEM_POP_CTX,
+          valueExpression: {
+            name: 'PatientCtx',
+            language: 'text/fhirpath',
+            expression: '%PatientBundle.entry.resource'
+          }
+        }
+      ],
+      item: [
+        {
+          linkId: 'patient-id',
+          type: 'string',
+          extension: [
+            {
+              url: SDC_INITIAL_EXPR,
+              valueExpression: {
+                language: 'text/fhirpath',
+                expression: '%PatientCtx.id'
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+
+describe('populate - non-repeating itemPopulationContext children evaluated globally', () => {
+  it('populates a child item whose initialExpression uses a simple property of the context variable', async () => {
+    const mockContext = {
+      resource: { resourceType: 'QuestionnaireResponse', status: 'in-progress' },
+      rootResource: { resourceType: 'QuestionnaireResponse', status: 'in-progress' },
+      patient: { resourceType: 'Patient', id: 'test-patient' },
+      PatientBundle: {
+        resourceType: 'Bundle',
+        type: 'searchset',
+        entry: [{ resource: { resourceType: 'Patient', id: 'test-patient-123' } }]
+      }
+    };
+
+    (createFhirPathContext as jest.Mock).mockImplementation(async () => mockContext);
+    (resolveLookupPromises as jest.Mock).mockImplementation(async () => ({}));
+
+    const inputParameters: InputParameters = {
+      resourceType: 'Parameters',
+      parameter: [
+        { name: 'questionnaire', resource: qNonRepeatGroupSimple as any },
+        { name: 'subject', valueReference: { type: 'Patient', reference: 'Patient/test-patient' } }
+      ]
+    };
+
+    const result = await populate(
+      inputParameters,
+      mockFetchResourceCallback,
+      mockFetchResourceCallbackConfig,
+      mockTerminologyCallback,
+      mockTerminologyCallbackConfig
+    );
+
+    const response = (result as OutputParameters).parameter.find((p) => p.name === 'response')
+      ?.resource as QuestionnaireResponse;
+
+    const patientIdItem = response.item
+      ?.find((i) => i.linkId === 'patient-group')
+      ?.item?.find((i) => i.linkId === 'patient-id');
+
+    expect(patientIdItem?.answer?.[0]?.valueString).toBe('test-patient-123');
+  });
+});
+

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/populate.test.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/populate.test.ts
@@ -356,4 +356,3 @@ describe('populate - non-repeating itemPopulationContext children evaluated glob
     expect(patientIdItem?.answer?.[0]?.valueString).toBe('test-patient-123');
   });
 });
-

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/readPopulationExpressions.test.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/readPopulationExpressions.test.ts
@@ -115,3 +115,60 @@ describe('readPopulationExpressions - itemPopulationContext', () => {
     );
   });
 });
+
+describe('readPopulationExpressions - non-repeating itemPopulationContext', () => {
+  // A non-repeating group with itemPopulationContext is a single-instance group whose
+  // children's initialExpressions should be evaluated globally (once, against the full
+  // context), not per-instance.
+  const questionnaire: Questionnaire = {
+    resourceType: 'Questionnaire',
+    status: 'active',
+    item: [
+      {
+        linkId: 'allergy-group',
+        type: 'group',
+        extension: [
+          {
+            url: SDC_ITEM_POP_CTX,
+            valueExpression: {
+              name: 'AllergyCtx',
+              language: 'text/fhirpath',
+              expression: '%AllergyBundle.entry.resource'
+            }
+          }
+        ],
+        item: [
+          {
+            linkId: 'allergy-display',
+            type: 'string',
+            extension: [
+              {
+                url: SDC_INITIAL_EXPR,
+                valueExpression: {
+                  language: 'text/fhirpath',
+                  expression: '%AllergyCtx.code.coding.display'
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  };
+
+  const { initialExpressions, itemPopulationContexts } = readPopulationExpressions(questionnaire);
+
+  it('includes children of a non-repeating itemPopulationContext group in initialExpressions', () => {
+    expect(initialExpressions['allergy-display']).toBeDefined();
+    expect(initialExpressions['allergy-display'].expression).toEqual(
+      '%AllergyCtx.code.coding.display'
+    );
+  });
+
+  it('registers the itemPopulationContext', () => {
+    expect(itemPopulationContexts['AllergyCtx']).toBeDefined();
+    expect(itemPopulationContexts['AllergyCtx'].expression).toEqual(
+      '%AllergyBundle.entry.resource'
+    );
+  });
+});

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/evaluateExpressions.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/evaluateExpressions.ts
@@ -29,6 +29,27 @@ import { handleFhirPathResult } from './createFhirPathContext';
 import { TERMINOLOGY_SERVER_URL } from '../../globals';
 
 /**
+ * Stamps fhirpath's internal __path__ metadata onto a FHIR resource so it can be safely
+ * used as an array context variable (%name) in subsequent fhirpath.evaluate() calls.
+ *
+ * fhirpath v4 requires each item in an array context variable to carry __path__ so the
+ * R4 model can resolve nested BackboneElement paths (e.g. reaction.manifestation.select(…)).
+ * Without it, fhirpath throws when navigating past the first level.
+ *
+ * The mechanism is documented in the fhirpath README and CHANGELOG (since v2.11.0):
+ * objects returned by fhirpath.evaluate() automatically receive __path__.
+ * Evaluating a resource against '$this' is the minimal way to attach this metadata
+ * to plain JSON objects that have not yet passed through fhirpath.
+ *
+ * Non-resource values (no resourceType) are returned unchanged.
+ */
+export function stampFhirpathMetadata(item: any): any {
+  if (!item?.resourceType) return item;
+  const stamped = fhirpath.evaluate(item, '$this', {}, fhirpath_r4_model) as any[];
+  return stamped[0] ?? item;
+}
+
+/**
  * Use FHIRPath.js to evaluate initialExpressions and generate its values to be populated into the questionnaireResponse.
  * Removes unsupported functions from expressions to avoid errors. Populates values for each linkId.
  *
@@ -85,7 +106,11 @@ export async function generateExpressionValues(
           terminologyUrl: terminologyServerUrl ?? TERMINOLOGY_SERVER_URL,
           ...(fhirServerUrl && { fhirServerUrl })
         });
-        itemPopulationContext.value = await handleFhirPathResult(fhirPathResult);
+        const rawValues = await handleFhirPathResult(fhirPathResult);
+
+        // Stamp __path__ on each resource so it can be safely used as an array context variable
+        // in constructRepeatGroupInstances. See stampFhirpathMetadata for full explanation.
+        itemPopulationContext.value = rawValues.map(stampFhirpathMetadata);
       } catch (e) {
         // e is not thrown as an Error type in fhirpath.js, so we can't use `if (e instanceof Error)` here
         console.warn(
@@ -148,8 +173,9 @@ export async function evaluateItemPopulationContexts(
         continue;
       }
 
-      // Save evaluated item population context result into context object
-      contextMap[itemPopulationContext.name] = evaluatedResult;
+      // Stamp __path__ on each resource before storing in contextMap.
+      // See stampFhirpathMetadata for full explanation.
+      contextMap[itemPopulationContext.name] = evaluatedResult.map(stampFhirpathMetadata);
     }
   }
 

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/readPopulationExpressions.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/readPopulationExpressions.ts
@@ -73,8 +73,12 @@ function readQuestionnaireItemRecursive(
       }
     }
 
-    // Children of an itemPopulationContext group are evaluated per-item, not globally
-    const childrenUnderContext = underItemPopulationContext || !!itemPopulationContext;
+    // Children of a *repeating* itemPopulationContext group are evaluated per-item in
+    // constructRepeatGroupInstances, so they must be excluded from the global map.
+    // Non-repeating groups (repeats: false) with itemPopulationContext are single-instance;
+    // their children are evaluated globally once the context variable is available.
+    const childrenUnderContext =
+      underItemPopulationContext || (!!itemPopulationContext && !!item.repeats);
     items.forEach((item) => {
       readQuestionnaireItemRecursive(item, populationExpressions, childrenUnderContext);
     });


### PR DESCRIPTION
## Related issue
Closes #1975

## Status
Work in progress - investigation not yet complete. Opening as a draft PR to link the branch to the issue and share progress with the team.

The `Patient with no fixed address` test is now **passing**. The `Allergies` manifestation test is still **failing**.

---

## What has been done

### sdc-populate fixes

**`evaluateExpressions.ts`** - Added `stampFhirpathMetadata()` helper:
FHIRPath v4 requires an internal `__path__` property on resources used as context variables for nested BackboneElement navigation (e.g. `reaction.manifestation.coding`). This helper does a JSON round-trip (to strip any stale `__path__` inherited from Bundle navigation) then calls `fhirpath.evaluate(resource, '$this', {}, r4model)` to re-stamp the correct path.

**`populate.ts`** - Upfront stamping of all root FHIR resources in `fhirPathContext` before any FHIRPath evaluation begins.

**`readPopulationExpressions.ts`** - Fixed `childrenUnderContext` logic so that children of non-repeating `itemPopulationContext` groups are not incorrectly excluded from global evaluation. This fixed the Patient with no fixed address regression.

### smart-forms-renderer fix

**`OpenChoiceAutocompleteField.tsx`** - Removed `value={input}` prop that was being passed to `StandardTextField` inside MUI Autocomplete. This prop was overriding Autocomplete's internal `inputValue` management and preventing populated values from displaying.

### Diagnostic tests added

**`sdc-populate/test/populate.test.ts`** - New unit tests that prove `__path__` stamping works and the full `select()` expression with `async: true` returns `Rash` after Bundle extraction and stamping (using the exact integration test allergy data).

### Investigation document

**`docs/investigation-allergy-rash-population-failure.md`** - Full investigation log with confirmed facts, decision table, and next steps.

---

## Still failing - open question

Debug logging in `OpenChoiceAutocompleteItem` shows the renderer receives an answer with only a random ID and no `valueCoding` for the SNOMED allergy manifestation. The random ID confirms the manifestation QR item is absent from the populated QR for allergy 1.

Yet the Jest unit test of the exact same FHIRPath expression passes. The gap between Jest and the Playwright integration test environment is not yet understood. See issue #1975 for the full question to the team.
