### PR TITLE
bump versions (renderer 1.4.0, sdc-populate 4.7.1) and update changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ For changelogs of other libraries, please refer to their respective repositories
 
 Changelog only includes changes from version 0.36.0 onwards.
 
+## [1.4.0] - 2026-07-03
+### Added
+- Instruction text (`display` items with `questionnaire-displayCategory: instructions`) is now programmatically associated with its parent input field via `aria-describedby` across all field types. Screen readers now announce the instruction text when the field receives focus, rather than requiring a separate tab to the instruction item. See issue [#1640](https://github.com/aehrc/smart-forms/issues/1640)
+- Added rendering of `Questionnaire.title` and `item.prefix`. Both now appear in the renderer, and support text styling via `rendering-style`, `rendering-markdown`, and `rendering-xhtml` extensions. Set `hideQuestionnaireTitle: true` in the renderer config to suppress the built-in title rendering.
+- Added `responseHasErrors` to the `QuestionnaireResponseStore`. This is `true` when the response contains items with error or fatal severity — it does not consider warnings.
+- Added item-level `targetConstraint` support. Constraints can now be defined directly on questionnaire items (not only at the questionnaire root), and are extracted and evaluated per-item.
+- Added screen reader announcements for error messages in input fields via `role='alert'` and `aria-live='assertive'`. See issue [#1745](https://github.com/aehrc/smart-forms/issues/1745)
+- Improved responsive layout on large screens — the renderer now expands to fill available screen width, with per-item max-widths applied to keep individual inputs at a readable size. See issue [#1936](https://github.com/aehrc/smart-forms/issues/1936)
+- Added horizontal dividers between repeat group instances in `RepeatGroupView`.
+- The remove button in repeat groups is now enabled even when only one instance remains, allowing users to clear pre-populated data. Removing the last instance leaves one blank instance in its place. See issue [#1810](https://github.com/aehrc/smart-forms/issues/1810)
+### Fixed
+- Fixed `targetConstraint` expression logic being inverted — per the FHIR spec, expressions should return `true` when the constraint is satisfied (valid). See issue [#1954](https://github.com/aehrc/smart-forms/issues/1954)
+- Fixed validation errors (required, `targetConstraint`) not surfacing on `date` and `dateTime` fields. These fields now correctly report constraint and required errors.
+- Fixed `date` and `dateTime` fields not validating against `minValue`/`maxValue` constraints.
+- Fixed repopulate dialog incorrectly showing unchanged repeat group items as modified after a user had deleted or reordered instances. The comparison was positional, so any shift in item index caused remaining items to appear as changed. Matching is now content-based. See issue [#1940](https://github.com/aehrc/smart-forms/issues/1940)
+- Fixed `getResponse()` and `removeEmptyAnswers()` stripping `item.definition` from returned QuestionnaireResponse items. See issue [#1801](https://github.com/aehrc/smart-forms/issues/1801)
+- Fixed selected value in choice select (autocomplete) fields appearing too far left due to missing padding. See issue [#1842](https://github.com/aehrc/smart-forms/issues/1842)
+- Fixed deeply nested repeat group content being pushed off-screen when zooming in, with no scrollbar to access it. Group items now scroll horizontally independently. See issue [#1809](https://github.com/aehrc/smart-forms/issues/1809)
+- Fixed validation feedback text not wrapping correctly in grid/table cells for autocomplete-based choice fields — it was rendered as a flex sibling of the input, compressing it into the remaining row space. Feedback now stacks below the input. Also fixes the missing error border on these fields when feedback is present.
+
 ## [1.3.1] - 2026-03-25
 ### Fixed
 - Fixed accordion scroll position jumping when expanding accordion items. See issue [#1796](https://github.com/aehrc/smart-forms/issues/1796)

--- a/apps/smart-forms-app/package.json
+++ b/apps/smart-forms-app/package.json
@@ -27,9 +27,9 @@
   "homepage": "https://github.com/aehrc/smart-forms#readme",
   "dependencies": {
     "@aehrc/sdc-assemble": "^2.0.2",
-    "@aehrc/sdc-populate": "^4.7.0",
+    "@aehrc/sdc-populate": "^4.7.1",
     "@aehrc/sdc-template-extract": "^1.0.15",
-    "@aehrc/smart-forms-renderer": "^1.3.1",
+    "@aehrc/smart-forms-renderer": "^1.4.0",
     "@dnd-kit/core": "^6.3.1",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,9 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aehrc/sdc-assemble": "^2.0.2",
-        "@aehrc/sdc-populate": "^4.7.0",
+        "@aehrc/sdc-populate": "^4.7.1",
         "@aehrc/sdc-template-extract": "^1.0.15",
-        "@aehrc/smart-forms-renderer": "^1.3.1",
+        "@aehrc/smart-forms-renderer": "^1.4.0",
         "@dnd-kit/core": "^6.3.1",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -41771,7 +41771,7 @@
     },
     "packages/sdc-populate": {
       "name": "@aehrc/sdc-populate",
-      "version": "4.7.0",
+      "version": "4.7.1",
       "license": "Apache-2.0",
       "dependencies": {
         "dayjs": "^1.11.21",
@@ -42327,10 +42327,10 @@
     },
     "packages/smart-forms-renderer": {
       "name": "@aehrc/smart-forms-renderer",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aehrc/sdc-populate": "^4.7.0",
+        "@aehrc/sdc-populate": "^4.7.1",
         "@aehrc/sdc-template-extract": "^1.0.15",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/packages/sdc-populate/CHANGELOG.md
+++ b/packages/sdc-populate/CHANGELOG.md
@@ -5,6 +5,11 @@ This log documents changes for [@aehrc/sdc-populate](https://www.npmjs.com/packa
 
 Changelog only includes changes from version 4.0.0 onwards.
 
+## [4.7.1] - 2026-07-03
+### Fixed
+- Fixed false-positive `OperationOutcomeIssue` errors for `toString()` and similar single-item FHIRPath functions in repeat group `initialExpression`s. Children of repeating `itemPopulationContext` groups are now excluded from global pre-evaluation and are always evaluated against the correctly scoped per-item context; children of non-repeating `itemPopulationContext` groups continue to be evaluated globally.
+- Increased populate operation timeout to 30 seconds, reducing false "Form not populated" errors caused by transient server slowness (e.g. cold caches on first use).
+
 ## [4.7.0] - 2026-03-25
 ### Added
 - Enable the FHIRPath `resolve()` function. The `fhirServerUrl` is now threaded through FHIRPath evaluations, allowing expressions that use `resolve()` to fetch referenced resources from the FHIR server. This also includes an upgrade of the `fhirpath` dependency from v3 to v4. See issue [#1806](https://github.com/aehrc/smart-forms/issues/1806)

--- a/packages/sdc-populate/package.json
+++ b/packages/sdc-populate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aehrc/sdc-populate",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "description": "Performs the $populate operation from the HL7 FHIR SDC (Structured Data Capture) specification: http://hl7.org/fhir/uv/sdc",
   "scripts": {
     "compile": "tsup src/index.ts --format cjs,esm --dts --clean --sourcemap",

--- a/packages/smart-forms-renderer/package.json
+++ b/packages/smart-forms-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aehrc/smart-forms-renderer",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "FHIR Structured Data Captured (SDC) rendering engine for Smart Forms",
   "main": "lib/index.js",
   "scripts": {
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/aehrc/smart-forms#readme",
   "dependencies": {
-    "@aehrc/sdc-populate": "^4.7.0",
+    "@aehrc/sdc-populate": "^4.7.1",
     "@aehrc/sdc-template-extract": "^1.0.15",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",


### PR DESCRIPTION
## Summary
- Bumps `@aehrc/smart-forms-renderer` from 1.3.1 to 1.4.0
- Bumps `@aehrc/sdc-populate` from 4.7.0 to 4.7.1
- Updates changelogs for both packages

## After merging
Create GitHub releases with tags:
- `v1.4.0` for `@aehrc/smart-forms-renderer`
- `sdc-populate@4.7.1` for `@aehrc/sdc-populate`