### PR TITLE
fix: clearing autocomplete choice fields leaves stale answers in Ques…

### DIFF
--- a/packages/smart-forms-renderer/src/components/FormComponents/OpenChoiceItems/OpenChoiceAutocompleteItem.tsx
+++ b/packages/smart-forms-renderer/src/components/FormComponents/OpenChoiceItems/OpenChoiceAutocompleteItem.tsx
@@ -129,9 +129,12 @@ function OpenChoiceAutocompleteItem(props: BaseItemProps) {
       setInput(newValue);
     }
 
+    // newValue is null when the field is cleared e.g. via the clear button ("clear") or Escape ("clearOnEscape") -
+    // the reason is not "input"/"selectOption" in those cases, so update the QR immediately here
     if (newValue === null) {
       setInput('');
-      newValue = '';
+      onQrItemChange(createEmptyQrItem(qItem, answerKey));
+      return;
     }
 
     if (typeof newValue === 'string' && reason === 'input') {

--- a/packages/smart-forms-renderer/src/components/FormComponents/RepeatGroup/RepeatGroup.tsx
+++ b/packages/smart-forms-renderer/src/components/FormComponents/RepeatGroup/RepeatGroup.tsx
@@ -26,6 +26,7 @@ import type { QuestionnaireItem, QuestionnaireResponseItem } from 'fhir/r4';
 import useInitialiseRepeatGroups from '../../../hooks/useInitialiseRepeatGroups';
 import { useQuestionnaireStore } from '../../../stores';
 import RepeatGroupView from './RepeatGroupView';
+import { qrItemHasItemsOrAnswer } from '../../../utils/manageForm';
 import { generateNewRepeatId } from '../../../utils/repeatId';
 
 interface RepeatGroupProps
@@ -62,6 +63,13 @@ function RepeatGroup(props: RepeatGroupProps) {
   const [repeatGroups, setRepeatGroups] = useState(initialRepeatGroups);
 
   function handleAnswerChange(newQrItem: QuestionnaireResponseItem, index: number) {
+    // If the change leaves the repeat group instance with no items or answers (e.g. its last
+    // answer was cleared), remove the instance entirely - same as the Remove Item button
+    if (!qrItemHasItemsOrAnswer(newQrItem)) {
+      handleRemoveItem(index);
+      return;
+    }
+
     const updatedRepeatGroups = [...repeatGroups];
 
     if (newQrItem.item) {

--- a/packages/smart-forms-renderer/src/components/FormComponents/RepeatItem/RepeatItem.tsx
+++ b/packages/smart-forms-renderer/src/components/FormComponents/RepeatItem/RepeatItem.tsx
@@ -15,13 +15,18 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import type {
   PropsWithParentIsReadOnlyAttribute,
   PropsWithQrItemChangeHandler
 } from '../../../interfaces/renderProps.interface';
-import type { QuestionnaireItem, QuestionnaireResponseItem } from 'fhir/r4';
+import type {
+  QuestionnaireItem,
+  QuestionnaireResponseItem,
+  QuestionnaireResponseItemAnswer
+} from 'fhir/r4';
 import { createEmptyQrItem } from '../../../utils/qrItem';
+import { answerHasValue } from '../../../utils/manageForm';
 import { FullWidthFormComponentBox } from '../../Box.styles';
 import AddItemButton from './AddItemButton';
 import { TransitionGroup } from 'react-transition-group';
@@ -44,6 +49,8 @@ interface RepeatItemProps extends PropsWithQrItemChangeHandler, PropsWithParentI
 
 /**
  * Main component to render a repeating, non-group Questionnaire item.
+ * Repeat answer instances (including empty ones) are tracked in local state, similar to
+ * RepeatGroup and GroupTable - only answers with values are emitted to the QuestionnaireResponse.
  *
  * @author Sean Fong
  */
@@ -54,17 +61,28 @@ function RepeatItem(props: RepeatItemProps) {
 
   const readOnly = useReadOnly(qItem, parentIsReadOnly);
 
-  const repeatAnswers = useInitialiseRepeatAnswers(qItem.linkId, qrItem);
+  const initialRepeatAnswers = useInitialiseRepeatAnswers(qItem.linkId, qrItem);
+
+  const [repeatAnswers, setRepeatAnswers] = useState(initialRepeatAnswers);
+
+  // Emit only answers with values - empty answer instances stay in local state so the
+  // QuestionnaireResponse is not polluted with value-less stub answers e.g. { id: answerKey }
+  function emitAnswersWithValues(updatedRepeatAnswers: (QuestionnaireResponseItemAnswer | null)[]) {
+    onQrItemChange({
+      ...createEmptyQrItem(qItem, undefined),
+      answer: updatedRepeatAnswers.flatMap((repeatAnswer) =>
+        repeatAnswer && answerHasValue(repeatAnswer) ? [repeatAnswer] : []
+      )
+    });
+  }
 
   // Event Handlers
   function handleAnswerChange(newQrItem: QuestionnaireResponseItem, index: number) {
     const updatedRepeatAnswers = [...repeatAnswers];
     updatedRepeatAnswers[index] = newQrItem.answer ? newQrItem.answer[0] : null;
 
-    onQrItemChange({
-      ...createEmptyQrItem(qItem, undefined),
-      answer: updatedRepeatAnswers.flatMap((repeatAnswer) => (repeatAnswer ? [repeatAnswer] : []))
-    });
+    setRepeatAnswers(updatedRepeatAnswers);
+    emitAnswersWithValues(updatedRepeatAnswers);
   }
 
   function handleRemoveItem(index: number) {
@@ -73,23 +91,16 @@ function RepeatItem(props: RepeatItemProps) {
     updatedRepeatAnswers.splice(index, 1);
 
     if (updatedRepeatAnswers.length === 0) {
-      onQrItemChange({ ...createEmptyQrItem(qItem, undefined) });
-      return;
+      updatedRepeatAnswers.push({ id: generateNewRepeatId(qItem.linkId) });
     }
 
-    onQrItemChange({
-      ...createEmptyQrItem(qItem, undefined),
-      answer: updatedRepeatAnswers.flatMap((repeatAnswer) => (repeatAnswer ? [repeatAnswer] : []))
-    });
+    setRepeatAnswers(updatedRepeatAnswers);
+    emitAnswersWithValues(updatedRepeatAnswers);
   }
 
   function handleAddItem() {
-    const updatedRepeatAnswers = [...repeatAnswers, { id: generateNewRepeatId(qItem.linkId) }];
-
-    onQrItemChange({
-      ...createEmptyQrItem(qItem, undefined),
-      answer: updatedRepeatAnswers.flatMap((repeatAnswer) => (repeatAnswer ? [repeatAnswer] : []))
-    });
+    // The new answer instance has no value yet, so the QuestionnaireResponse does not change
+    setRepeatAnswers([...repeatAnswers, { id: generateNewRepeatId(qItem.linkId) }]);
   }
 
   return (

--- a/packages/smart-forms-renderer/src/components/FormComponents/Tables/GroupTable.tsx
+++ b/packages/smart-forms-renderer/src/components/FormComponents/Tables/GroupTable.tsx
@@ -28,6 +28,7 @@ import useReadOnly from '../../../hooks/useReadOnly';
 import GroupTableView from './GroupTableView';
 import type { GroupTableRowModel } from '../../../interfaces/groupTable.interface';
 import { getGroupTableItemsToUpdate } from '../../../utils/groupTable';
+import { qrItemHasItemsOrAnswer } from '../../../utils/manageForm';
 import useGroupTableRows from '../../../hooks/useGroupTableRows';
 import { flushSync } from 'react-dom';
 import { generateNewRepeatId } from '../../../utils/repeatId';
@@ -139,6 +140,13 @@ function GroupTable(props: GroupTableProps) {
 
   // Event Handlers
   function handleRowChange(newQrRow: QuestionnaireResponseItem, index: number) {
+    // If the change leaves the row with no items or answers (e.g. its last answer was
+    // cleared), remove the row entirely - same as the Remove Item button
+    if (!qrItemHasItemsOrAnswer(newQrRow)) {
+      handleRemoveRow(index);
+      return;
+    }
+
     const updatedTableRows = [...tableRows];
 
     if (newQrRow.item) {

--- a/packages/smart-forms-renderer/src/test/clearChoiceField.test.tsx
+++ b/packages/smart-forms-renderer/src/test/clearChoiceField.test.tsx
@@ -676,6 +676,239 @@ describe('clearing choice fields removes the answer from updatableResponse', () 
     expect(getUpdatableResponseString()).toContain('condition-1');
   });
 
+  test('RepeatGroup - clearing the only answer in a row removes the whole row instance (issue #1994 follow-up)', async () => {
+    const questionnaire: Questionnaire = {
+      resourceType: 'Questionnaire',
+      status: 'active',
+      item: [
+        {
+          linkId: 'new-medications',
+          text: 'New medications',
+          type: 'group',
+          repeats: true,
+          item: [
+            {
+              linkId: 'medication',
+              text: 'Medication',
+              type: 'choice',
+              extension: [autocompleteItemControlExtension],
+              answerValueSet: 'https://example.com/fhir/ValueSet/medications'
+            },
+            {
+              linkId: 'dosage',
+              text: 'Dosage',
+              type: 'string'
+            }
+          ]
+        }
+      ]
+    };
+
+    // One repeat group instance whose only answer is the medication
+    const questionnaireResponse: QuestionnaireResponse = {
+      resourceType: 'QuestionnaireResponse',
+      status: 'in-progress',
+      item: [
+        {
+          linkId: 'new-medications',
+          text: 'New medications',
+          item: [
+            {
+              linkId: 'medication',
+              text: 'Medication',
+              answer: [
+                {
+                  valueCoding: {
+                    system: 'http://snomed.info/sct',
+                    code: '1162331000168106',
+                    display: 'Cocaine (Perrigo) 0.5% mouthwash'
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    };
+
+    render(
+      <SmartFormsRenderer
+        questionnaire={questionnaire}
+        questionnaireResponse={questionnaireResponse}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByDisplayValue(/Cocaine/)).toBeTruthy());
+    expect(getUpdatableResponseString()).toContain('1162331000168106');
+
+    const clearButton = document.querySelector('.MuiAutocomplete-clearIndicator');
+    expect(clearButton).toBeTruthy();
+    fireEvent.click(clearButton as Element);
+
+    // The whole row instance is removed - no { linkId, text, item: [] } husk remains
+    await waitFor(() => expect(getUpdatableResponseString()).not.toContain('1162331000168106'));
+    await waitFor(() =>
+      expect(getUpdatableResponseString()).not.toContain('"linkId":"new-medications"')
+    );
+    // Only the response root remains, with an empty top-level item array
+    expect(
+      (questionnaireResponseStore.getState().updatableResponse.item ?? []).length
+    ).toBe(0);
+  });
+
+  test('RepeatGroup - clearing one answer keeps the row when it still has other answers', async () => {
+    const questionnaire: Questionnaire = {
+      resourceType: 'Questionnaire',
+      status: 'active',
+      item: [
+        {
+          linkId: 'new-medications',
+          text: 'New medications',
+          type: 'group',
+          repeats: true,
+          item: [
+            {
+              linkId: 'medication',
+              text: 'Medication',
+              type: 'choice',
+              extension: [autocompleteItemControlExtension],
+              answerValueSet: 'https://example.com/fhir/ValueSet/medications'
+            },
+            {
+              linkId: 'dosage',
+              text: 'Dosage',
+              type: 'string'
+            }
+          ]
+        }
+      ]
+    };
+
+    const questionnaireResponse: QuestionnaireResponse = {
+      resourceType: 'QuestionnaireResponse',
+      status: 'in-progress',
+      item: [
+        {
+          linkId: 'new-medications',
+          text: 'New medications',
+          item: [
+            {
+              linkId: 'medication',
+              text: 'Medication',
+              answer: [{ valueCoding: asthmaCoding }]
+            },
+            {
+              linkId: 'dosage',
+              text: 'Dosage',
+              answer: [{ valueString: '5mg daily' }]
+            }
+          ]
+        }
+      ]
+    };
+
+    render(
+      <SmartFormsRenderer
+        questionnaire={questionnaire}
+        questionnaireResponse={questionnaireResponse}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByDisplayValue('Asthma')).toBeTruthy());
+
+    const clearButton = document.querySelector('.MuiAutocomplete-clearIndicator');
+    fireEvent.click(clearButton as Element);
+
+    // Medication answer removed, but the row survives because dosage still has a value
+    await waitFor(() => expect(getUpdatableResponseString()).not.toContain('Asthma'));
+    expect(getUpdatableResponseString()).toContain('5mg daily');
+    expect(getUpdatableResponseString()).toContain('"linkId":"new-medications"');
+  });
+
+  test('gtable - clearing the only answer in a row removes the whole row instance', async () => {
+    const questionnaire: Questionnaire = {
+      resourceType: 'Questionnaire',
+      status: 'active',
+      item: [
+        {
+          linkId: 'new-diagnoses',
+          text: 'New diagnoses',
+          type: 'group',
+          repeats: true,
+          extension: [
+            {
+              url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl',
+              valueCodeableConcept: {
+                coding: [
+                  {
+                    system: 'http://hl7.org/fhir/questionnaire-item-control',
+                    code: 'gtable'
+                  }
+                ]
+              }
+            }
+          ],
+          item: [
+            {
+              linkId: 'condition',
+              text: 'Condition',
+              type: 'open-choice',
+              extension: [autocompleteItemControlExtension],
+              answerValueSet: 'https://example.com/fhir/ValueSet/conditions'
+            },
+            {
+              linkId: 'onset-date',
+              text: 'Onset date',
+              type: 'date'
+            }
+          ]
+        }
+      ]
+    };
+
+    const questionnaireResponse: QuestionnaireResponse = {
+      resourceType: 'QuestionnaireResponse',
+      status: 'in-progress',
+      item: [
+        {
+          linkId: 'new-diagnoses',
+          text: 'New diagnoses',
+          item: [
+            {
+              linkId: 'condition',
+              text: 'Condition',
+              answer: [{ valueCoding: asthmaCoding }]
+            }
+          ]
+        }
+      ]
+    };
+
+    render(
+      <SmartFormsRenderer
+        questionnaire={questionnaire}
+        questionnaireResponse={questionnaireResponse}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByDisplayValue('Asthma')).toBeTruthy());
+    expect(getUpdatableResponseString()).toContain('Asthma');
+
+    const clearButton = document.querySelector('.MuiAutocomplete-clearIndicator');
+    expect(clearButton).toBeTruthy();
+    fireEvent.click(clearButton as Element);
+
+    // The whole row instance is removed - no { linkId, text, item: [] } husk remains
+    await waitFor(() => expect(getUpdatableResponseString()).not.toContain('Asthma'));
+    await waitFor(() =>
+      expect(getUpdatableResponseString()).not.toContain('"linkId":"new-diagnoses"')
+    );
+    // Only the response root remains, with an empty top-level item array
+    expect(
+      (questionnaireResponseStore.getState().updatableResponse.item ?? []).length
+    ).toBe(0);
+  });
+
   test('RepeatItem Add Item button adds a visible empty row without changing the QuestionnaireResponse', async () => {
     const questionnaire: Questionnaire = {
       resourceType: 'Questionnaire',

--- a/packages/smart-forms-renderer/src/test/clearChoiceField.test.tsx
+++ b/packages/smart-forms-renderer/src/test/clearChoiceField.test.tsx
@@ -1,0 +1,730 @@
+/// <reference types="jest" />
+/// <reference types="@testing-library/jest-dom" />
+
+/*
+ * Copyright 2025 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, test } from '@jest/globals';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { Questionnaire, QuestionnaireResponse } from 'fhir/r4';
+import React from 'react';
+
+// react-markdown, react-dnd and react-dnd-html5-backend are ESM-only and cannot be transformed by ts-jest
+jest.mock('react-markdown', () => ({
+  __esModule: true,
+  default: (props: { children?: React.ReactNode }) => <>{props.children}</>
+}));
+jest.mock('react-dnd', () => ({
+  __esModule: true,
+  useDrop: () => [{ isOver: false, canDrop: false }, jest.fn()]
+}));
+jest.mock('react-dnd-html5-backend', () => ({
+  __esModule: true,
+  NativeTypes: { FILE: '__NATIVE_FILE__' }
+}));
+
+import SmartFormsRenderer from '../components/Renderer/SmartFormsRenderer';
+import { questionnaireResponseStore } from '../stores';
+
+// jsdom does not implement ResizeObserver, required by GroupTable's useResizeColumns
+global.ResizeObserver =
+  global.ResizeObserver ||
+  class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+
+// jsdom does not implement matchMedia, required by MUI useMediaQuery
+window.matchMedia =
+  window.matchMedia ||
+  ((query: string) =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn()
+    }) as unknown as MediaQueryList);
+
+const autocompleteItemControlExtension = {
+  url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl',
+  valueCodeableConcept: {
+    coding: [
+      {
+        system: 'http://hl7.org/fhir/questionnaire-item-control',
+        code: 'autocomplete'
+      }
+    ]
+  }
+};
+
+const asthmaCoding = {
+  system: 'http://snomed.info/sct',
+  code: '195967001',
+  display: 'Asthma'
+};
+
+function getUpdatableResponseString(): string {
+  return JSON.stringify(questionnaireResponseStore.getState().updatableResponse);
+}
+
+async function clearAutocompleteField(linkId: string) {
+  // MUI Autocomplete renders the clear indicator button whenever it holds a value
+  const itemBox = document.querySelector(`[data-linkid="${linkId}"]`) ?? document.body;
+  const clearButton = itemBox.querySelector('.MuiAutocomplete-clearIndicator');
+  expect(clearButton).not.toBeNull();
+  fireEvent.click(clearButton as Element);
+}
+
+describe('clearing choice fields removes the answer from updatableResponse', () => {
+  test('standalone ChoiceAutocomplete - answer without id', async () => {
+    const questionnaire: Questionnaire = {
+      resourceType: 'Questionnaire',
+      status: 'active',
+      item: [
+        {
+          linkId: 'condition',
+          text: 'Condition',
+          type: 'choice',
+          extension: [autocompleteItemControlExtension],
+          answerValueSet: 'https://example.com/fhir/ValueSet/conditions'
+        }
+      ]
+    };
+
+    const questionnaireResponse: QuestionnaireResponse = {
+      resourceType: 'QuestionnaireResponse',
+      status: 'in-progress',
+      item: [
+        {
+          linkId: 'condition',
+          text: 'Condition',
+          answer: [{ valueCoding: asthmaCoding }]
+        }
+      ]
+    };
+
+    render(
+      <SmartFormsRenderer
+        questionnaire={questionnaire}
+        questionnaireResponse={questionnaireResponse}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByDisplayValue('Asthma')).toBeTruthy());
+    expect(getUpdatableResponseString()).toContain('Asthma');
+
+    await clearAutocompleteField('condition');
+
+    await waitFor(() => expect(getUpdatableResponseString()).not.toContain('Asthma'));
+    await waitFor(() =>
+      expect(getUpdatableResponseString()).not.toContain('"linkId":"condition"')
+    );
+  });
+
+  test('standalone ChoiceAutocomplete - answer with an id (stub answer scenario from issue #1994)', async () => {
+    const questionnaire: Questionnaire = {
+      resourceType: 'Questionnaire',
+      status: 'active',
+      item: [
+        {
+          linkId: 'condition',
+          text: 'Condition',
+          type: 'choice',
+          extension: [autocompleteItemControlExtension],
+          answerValueSet: 'https://example.com/fhir/ValueSet/conditions'
+        }
+      ]
+    };
+
+    const questionnaireResponse: QuestionnaireResponse = {
+      resourceType: 'QuestionnaireResponse',
+      status: 'in-progress',
+      item: [
+        {
+          linkId: 'condition',
+          text: 'Condition',
+          answer: [{ id: 'someAnswerKey', valueCoding: asthmaCoding }]
+        }
+      ]
+    };
+
+    render(
+      <SmartFormsRenderer
+        questionnaire={questionnaire}
+        questionnaireResponse={questionnaireResponse}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByDisplayValue('Asthma')).toBeTruthy());
+    expect(getUpdatableResponseString()).toContain('Asthma');
+
+    await clearAutocompleteField('condition');
+
+    await waitFor(() => expect(getUpdatableResponseString()).not.toContain('Asthma'));
+    await waitFor(() =>
+      expect(getUpdatableResponseString()).not.toContain('"linkId":"condition"')
+    );
+  });
+
+  test('ChoiceAutocomplete inside a repeat group - answer without id', async () => {
+    const questionnaire: Questionnaire = {
+      resourceType: 'Questionnaire',
+      status: 'active',
+      item: [
+        {
+          linkId: 'problems',
+          text: 'New problems',
+          type: 'group',
+          repeats: true,
+          item: [
+            {
+              linkId: 'condition',
+              text: 'Condition',
+              type: 'choice',
+              extension: [autocompleteItemControlExtension],
+              answerValueSet: 'https://example.com/fhir/ValueSet/conditions'
+            },
+            {
+              linkId: 'note',
+              text: 'Note',
+              type: 'string'
+            }
+          ]
+        }
+      ]
+    };
+
+    const questionnaireResponse: QuestionnaireResponse = {
+      resourceType: 'QuestionnaireResponse',
+      status: 'in-progress',
+      item: [
+        {
+          linkId: 'problems',
+          text: 'New problems',
+          item: [
+            {
+              linkId: 'condition',
+              text: 'Condition',
+              answer: [{ valueCoding: asthmaCoding }]
+            },
+            {
+              linkId: 'note',
+              text: 'Note',
+              answer: [{ valueString: 'a note' }]
+            }
+          ]
+        }
+      ]
+    };
+
+    render(
+      <SmartFormsRenderer
+        questionnaire={questionnaire}
+        questionnaireResponse={questionnaireResponse}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByDisplayValue('Asthma')).toBeTruthy());
+    expect(getUpdatableResponseString()).toContain('Asthma');
+
+    await clearAutocompleteField('condition');
+
+    await waitFor(() => expect(getUpdatableResponseString()).not.toContain('Asthma'));
+    await waitFor(() =>
+      expect(getUpdatableResponseString()).not.toContain('"linkId":"condition"')
+    );
+  });
+
+  test('ChoiceSelect (answerOption) inside a repeat group - answer without id', async () => {
+    const questionnaire: Questionnaire = {
+      resourceType: 'Questionnaire',
+      status: 'active',
+      item: [
+        {
+          linkId: 'problems',
+          text: 'New problems',
+          type: 'group',
+          repeats: true,
+          item: [
+            {
+              linkId: 'severity',
+              text: 'Severity',
+              type: 'choice',
+              answerOption: [
+                { valueCoding: { code: 'mild', display: 'Mild' } },
+                { valueCoding: { code: 'severe', display: 'Severe' } }
+              ]
+            },
+            {
+              linkId: 'note',
+              text: 'Note',
+              type: 'string'
+            }
+          ]
+        }
+      ]
+    };
+
+    const questionnaireResponse: QuestionnaireResponse = {
+      resourceType: 'QuestionnaireResponse',
+      status: 'in-progress',
+      item: [
+        {
+          linkId: 'problems',
+          text: 'New problems',
+          item: [
+            {
+              linkId: 'severity',
+              text: 'Severity',
+              answer: [{ valueCoding: { code: 'severe', display: 'Severe' } }]
+            },
+            {
+              linkId: 'note',
+              text: 'Note',
+              answer: [{ valueString: 'a note' }]
+            }
+          ]
+        }
+      ]
+    };
+
+    render(
+      <SmartFormsRenderer
+        questionnaire={questionnaire}
+        questionnaireResponse={questionnaireResponse}
+      />
+    );
+
+    await waitFor(() =>
+      expect(
+        document.querySelector('[data-linkid="severity"] .MuiAutocomplete-clearIndicator')
+      ).toBeTruthy()
+    );
+    expect(getUpdatableResponseString()).toContain('Severe');
+
+    await clearAutocompleteField('severity');
+
+    await waitFor(() => expect(getUpdatableResponseString()).not.toContain('Severe'));
+    await waitFor(() => expect(getUpdatableResponseString()).not.toContain('"linkId":"severity"'));
+  });
+
+  test('ChoiceAutocomplete with repeats: true (RepeatItem) - answer with internal repeat id', async () => {
+    const questionnaire: Questionnaire = {
+      resourceType: 'Questionnaire',
+      status: 'active',
+      item: [
+        {
+          linkId: 'condition',
+          text: 'Condition',
+          type: 'choice',
+          repeats: true,
+          extension: [autocompleteItemControlExtension],
+          answerValueSet: 'https://example.com/fhir/ValueSet/conditions'
+        }
+      ]
+    };
+
+    // Simulates the state after a user selects a condition in a repeat item row -
+    // the answer carries the internal repeat id assigned by useInitialiseRepeatAnswers
+    const questionnaireResponse: QuestionnaireResponse = {
+      resourceType: 'QuestionnaireResponse',
+      status: 'in-progress',
+      item: [
+        {
+          linkId: 'condition',
+          text: 'Condition',
+          answer: [{ id: 'condition-repeat-000000', valueCoding: asthmaCoding }]
+        }
+      ]
+    };
+
+    render(
+      <SmartFormsRenderer
+        questionnaire={questionnaire}
+        questionnaireResponse={questionnaireResponse}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByDisplayValue('Asthma')).toBeTruthy());
+    expect(getUpdatableResponseString()).toContain('Asthma');
+
+    await clearAutocompleteField('condition');
+
+    await waitFor(() => expect(getUpdatableResponseString()).not.toContain('Asthma'));
+    await waitFor(() =>
+      expect(getUpdatableResponseString()).not.toContain('"linkId":"condition"')
+    );
+  });
+
+  test('ChoiceAutocomplete with repeats: true - clearing one row keeps the other row values and both rows visible', async () => {
+    const questionnaire: Questionnaire = {
+      resourceType: 'Questionnaire',
+      status: 'active',
+      item: [
+        {
+          linkId: 'condition',
+          text: 'Condition',
+          type: 'choice',
+          repeats: true,
+          extension: [autocompleteItemControlExtension],
+          answerValueSet: 'https://example.com/fhir/ValueSet/conditions'
+        }
+      ]
+    };
+
+    const questionnaireResponse: QuestionnaireResponse = {
+      resourceType: 'QuestionnaireResponse',
+      status: 'in-progress',
+      item: [
+        {
+          linkId: 'condition',
+          text: 'Condition',
+          answer: [
+            { id: 'condition-repeat-000000', valueCoding: asthmaCoding },
+            {
+              id: 'condition-repeat-000001',
+              valueCoding: { system: 'http://snomed.info/sct', code: '38341003', display: 'Hypertension' }
+            }
+          ]
+        }
+      ]
+    };
+
+    render(
+      <SmartFormsRenderer
+        questionnaire={questionnaire}
+        questionnaireResponse={questionnaireResponse}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByDisplayValue('Asthma')).toBeTruthy());
+    expect(getUpdatableResponseString()).toContain('Hypertension');
+
+    // Clear the first row only
+    const clearButtons = document.querySelectorAll(
+      '[data-linkid="condition"] .MuiAutocomplete-clearIndicator'
+    );
+    expect(clearButtons.length).toBe(2);
+    fireEvent.click(clearButtons[0]);
+
+    // First row answer removed, second row answer retained
+    await waitFor(() => expect(getUpdatableResponseString()).not.toContain('Asthma'));
+    expect(getUpdatableResponseString()).toContain('Hypertension');
+
+    // Both rows are still rendered - the cleared row stays as an empty row
+    const comboboxes = document.querySelectorAll('[data-linkid="condition"] .MuiAutocomplete-root');
+    expect(comboboxes.length).toBe(2);
+  });
+
+  test('ChoiceAutocomplete inside a gtable repeat group (Aboriginal Health Check shape) - clearing removes the value', async () => {
+    const questionnaire: Questionnaire = {
+      resourceType: 'Questionnaire',
+      status: 'active',
+      item: [
+        {
+          linkId: 'problems-summary',
+          text: 'New problems',
+          type: 'group',
+          repeats: true,
+          extension: [
+            {
+              url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl',
+              valueCodeableConcept: {
+                coding: [
+                  {
+                    system: 'http://hl7.org/fhir/questionnaire-item-control',
+                    code: 'gtable'
+                  }
+                ]
+              }
+            }
+          ],
+          item: [
+            {
+              linkId: 'conditionId',
+              type: 'string',
+              extension: [
+                {
+                  url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-hidden',
+                  valueBoolean: true
+                }
+              ]
+            },
+            {
+              linkId: 'condition',
+              text: 'Condition',
+              type: 'choice',
+              extension: [autocompleteItemControlExtension],
+              answerValueSet: 'https://example.com/fhir/ValueSet/conditions'
+            },
+            {
+              linkId: 'note',
+              text: 'Note',
+              type: 'string'
+            }
+          ]
+        }
+      ]
+    };
+
+    const questionnaireResponse: QuestionnaireResponse = {
+      resourceType: 'QuestionnaireResponse',
+      status: 'in-progress',
+      item: [
+        {
+          linkId: 'problems-summary',
+          text: 'New problems',
+          item: [
+            {
+              linkId: 'conditionId',
+              answer: [{ valueString: 'condition-1' }]
+            },
+            {
+              linkId: 'condition',
+              text: 'Condition',
+              answer: [{ valueCoding: asthmaCoding }]
+            },
+            {
+              linkId: 'note',
+              text: 'Note',
+              answer: [{ valueString: 'a note' }]
+            }
+          ]
+        }
+      ]
+    };
+
+    render(
+      <SmartFormsRenderer
+        questionnaire={questionnaire}
+        questionnaireResponse={questionnaireResponse}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByDisplayValue('Asthma')).toBeTruthy());
+    expect(getUpdatableResponseString()).toContain('Asthma');
+
+    // Clear the autocomplete cell in the gtable row
+    const clearButton = document.querySelector('.MuiAutocomplete-clearIndicator');
+    expect(clearButton).toBeTruthy();
+    fireEvent.click(clearButton as Element);
+
+    // The condition value is removed, sibling cells are retained
+    await waitFor(() => expect(getUpdatableResponseString()).not.toContain('Asthma'));
+    await waitFor(() =>
+      expect(getUpdatableResponseString()).not.toContain('"linkId":"condition","text"')
+    );
+    expect(getUpdatableResponseString()).toContain('a note');
+    expect(getUpdatableResponseString()).toContain('condition-1');
+  });
+
+  test('standalone OpenChoiceAutocomplete - clearing removes the value (health check condition field type)', async () => {
+    const questionnaire: Questionnaire = {
+      resourceType: 'Questionnaire',
+      status: 'active',
+      item: [
+        {
+          linkId: 'condition',
+          text: 'Condition',
+          type: 'open-choice',
+          extension: [autocompleteItemControlExtension],
+          answerValueSet: 'https://example.com/fhir/ValueSet/conditions'
+        }
+      ]
+    };
+
+    const questionnaireResponse: QuestionnaireResponse = {
+      resourceType: 'QuestionnaireResponse',
+      status: 'in-progress',
+      item: [
+        {
+          linkId: 'condition',
+          text: 'Condition',
+          answer: [{ valueCoding: asthmaCoding }]
+        }
+      ]
+    };
+
+    render(
+      <SmartFormsRenderer
+        questionnaire={questionnaire}
+        questionnaireResponse={questionnaireResponse}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByDisplayValue('Asthma')).toBeTruthy());
+    expect(getUpdatableResponseString()).toContain('Asthma');
+
+    await clearAutocompleteField('condition');
+
+    await waitFor(() => expect(getUpdatableResponseString()).not.toContain('Asthma'));
+    await waitFor(() =>
+      expect(getUpdatableResponseString()).not.toContain('"linkId":"condition"')
+    );
+  });
+
+  test('OpenChoiceAutocomplete inside a gtable repeat group (Aboriginal Health Check shape) - clearing removes the value', async () => {
+    const questionnaire: Questionnaire = {
+      resourceType: 'Questionnaire',
+      status: 'active',
+      item: [
+        {
+          linkId: 'medical-history-summary',
+          text: 'Medical history summary',
+          type: 'group',
+          repeats: true,
+          extension: [
+            {
+              url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl',
+              valueCodeableConcept: {
+                coding: [
+                  {
+                    system: 'http://hl7.org/fhir/questionnaire-item-control',
+                    code: 'gtable'
+                  }
+                ]
+              }
+            }
+          ],
+          item: [
+            {
+              linkId: 'conditionId',
+              type: 'string',
+              extension: [
+                {
+                  url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-hidden',
+                  valueBoolean: true
+                }
+              ]
+            },
+            {
+              linkId: 'condition',
+              text: 'Condition',
+              type: 'open-choice',
+              extension: [autocompleteItemControlExtension],
+              answerValueSet: 'https://example.com/fhir/ValueSet/conditions'
+            },
+            {
+              linkId: 'onset-date',
+              text: 'Onset date',
+              type: 'date'
+            }
+          ]
+        }
+      ]
+    };
+
+    const questionnaireResponse: QuestionnaireResponse = {
+      resourceType: 'QuestionnaireResponse',
+      status: 'in-progress',
+      item: [
+        {
+          linkId: 'medical-history-summary',
+          text: 'Medical history summary',
+          item: [
+            {
+              linkId: 'conditionId',
+              answer: [{ valueString: 'condition-1' }]
+            },
+            {
+              linkId: 'condition',
+              text: 'Condition',
+              answer: [{ valueCoding: asthmaCoding }]
+            }
+          ]
+        }
+      ]
+    };
+
+    render(
+      <SmartFormsRenderer
+        questionnaire={questionnaire}
+        questionnaireResponse={questionnaireResponse}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByDisplayValue('Asthma')).toBeTruthy());
+    expect(getUpdatableResponseString()).toContain('Asthma');
+
+    const clearButton = document.querySelector('.MuiAutocomplete-clearIndicator');
+    expect(clearButton).toBeTruthy();
+    fireEvent.click(clearButton as Element);
+
+    await waitFor(() => expect(getUpdatableResponseString()).not.toContain('Asthma'));
+    await waitFor(() =>
+      expect(getUpdatableResponseString()).not.toContain('"linkId":"condition","text"')
+    );
+    expect(getUpdatableResponseString()).toContain('condition-1');
+  });
+
+  test('RepeatItem Add Item button adds a visible empty row without changing the QuestionnaireResponse', async () => {
+    const questionnaire: Questionnaire = {
+      resourceType: 'Questionnaire',
+      status: 'active',
+      item: [
+        {
+          linkId: 'condition',
+          text: 'Condition',
+          type: 'choice',
+          repeats: true,
+          extension: [autocompleteItemControlExtension],
+          answerValueSet: 'https://example.com/fhir/ValueSet/conditions'
+        }
+      ]
+    };
+
+    const questionnaireResponse: QuestionnaireResponse = {
+      resourceType: 'QuestionnaireResponse',
+      status: 'in-progress',
+      item: [
+        {
+          linkId: 'condition',
+          text: 'Condition',
+          answer: [{ id: 'condition-repeat-000000', valueCoding: asthmaCoding }]
+        }
+      ]
+    };
+
+    render(
+      <SmartFormsRenderer
+        questionnaire={questionnaire}
+        questionnaireResponse={questionnaireResponse}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByDisplayValue('Asthma')).toBeTruthy());
+    const responseBeforeAdd = getUpdatableResponseString();
+
+    const addButton = document.querySelector('[data-test="button-add-repeat-item"]');
+    expect(addButton).toBeTruthy();
+    fireEvent.click(addButton as Element);
+
+    // A second (empty) row is rendered
+    await waitFor(() =>
+      expect(document.querySelectorAll('[data-linkid="condition"] .MuiAutocomplete-root').length).toBe(2)
+    );
+
+    // The QuestionnaireResponse is unchanged - no stub answer was added
+    expect(getUpdatableResponseString()).toBe(responseBeforeAdd);
+    expect(getUpdatableResponseString()).not.toContain('condition-repeat-000001');
+  });
+});

--- a/packages/smart-forms-renderer/src/test/clearChoiceField.test.tsx
+++ b/packages/smart-forms-renderer/src/test/clearChoiceField.test.tsx
@@ -135,9 +135,7 @@ describe('clearing choice fields removes the answer from updatableResponse', () 
     await clearAutocompleteField('condition');
 
     await waitFor(() => expect(getUpdatableResponseString()).not.toContain('Asthma'));
-    await waitFor(() =>
-      expect(getUpdatableResponseString()).not.toContain('"linkId":"condition"')
-    );
+    await waitFor(() => expect(getUpdatableResponseString()).not.toContain('"linkId":"condition"'));
   });
 
   test('standalone ChoiceAutocomplete - answer with an id (stub answer scenario from issue #1994)', async () => {
@@ -180,9 +178,7 @@ describe('clearing choice fields removes the answer from updatableResponse', () 
     await clearAutocompleteField('condition');
 
     await waitFor(() => expect(getUpdatableResponseString()).not.toContain('Asthma'));
-    await waitFor(() =>
-      expect(getUpdatableResponseString()).not.toContain('"linkId":"condition"')
-    );
+    await waitFor(() => expect(getUpdatableResponseString()).not.toContain('"linkId":"condition"'));
   });
 
   test('ChoiceAutocomplete inside a repeat group - answer without id', async () => {
@@ -249,9 +245,7 @@ describe('clearing choice fields removes the answer from updatableResponse', () 
     await clearAutocompleteField('condition');
 
     await waitFor(() => expect(getUpdatableResponseString()).not.toContain('Asthma'));
-    await waitFor(() =>
-      expect(getUpdatableResponseString()).not.toContain('"linkId":"condition"')
-    );
+    await waitFor(() => expect(getUpdatableResponseString()).not.toContain('"linkId":"condition"'));
   });
 
   test('ChoiceSelect (answerOption) inside a repeat group - answer without id', async () => {
@@ -370,9 +364,7 @@ describe('clearing choice fields removes the answer from updatableResponse', () 
     await clearAutocompleteField('condition');
 
     await waitFor(() => expect(getUpdatableResponseString()).not.toContain('Asthma'));
-    await waitFor(() =>
-      expect(getUpdatableResponseString()).not.toContain('"linkId":"condition"')
-    );
+    await waitFor(() => expect(getUpdatableResponseString()).not.toContain('"linkId":"condition"'));
   });
 
   test('ChoiceAutocomplete with repeats: true - clearing one row keeps the other row values and both rows visible', async () => {
@@ -402,7 +394,11 @@ describe('clearing choice fields removes the answer from updatableResponse', () 
             { id: 'condition-repeat-000000', valueCoding: asthmaCoding },
             {
               id: 'condition-repeat-000001',
-              valueCoding: { system: 'http://snomed.info/sct', code: '38341003', display: 'Hypertension' }
+              valueCoding: {
+                system: 'http://snomed.info/sct',
+                code: '38341003',
+                display: 'Hypertension'
+              }
             }
           ]
         }
@@ -577,9 +573,7 @@ describe('clearing choice fields removes the answer from updatableResponse', () 
     await clearAutocompleteField('condition');
 
     await waitFor(() => expect(getUpdatableResponseString()).not.toContain('Asthma'));
-    await waitFor(() =>
-      expect(getUpdatableResponseString()).not.toContain('"linkId":"condition"')
-    );
+    await waitFor(() => expect(getUpdatableResponseString()).not.toContain('"linkId":"condition"'));
   });
 
   test('OpenChoiceAutocomplete inside a gtable repeat group (Aboriginal Health Check shape) - clearing removes the value', async () => {
@@ -751,9 +745,7 @@ describe('clearing choice fields removes the answer from updatableResponse', () 
       expect(getUpdatableResponseString()).not.toContain('"linkId":"new-medications"')
     );
     // Only the response root remains, with an empty top-level item array
-    expect(
-      (questionnaireResponseStore.getState().updatableResponse.item ?? []).length
-    ).toBe(0);
+    expect((questionnaireResponseStore.getState().updatableResponse.item ?? []).length).toBe(0);
   });
 
   test('RepeatGroup - clearing one answer keeps the row when it still has other answers', async () => {
@@ -904,9 +896,7 @@ describe('clearing choice fields removes the answer from updatableResponse', () 
       expect(getUpdatableResponseString()).not.toContain('"linkId":"new-diagnoses"')
     );
     // Only the response root remains, with an empty top-level item array
-    expect(
-      (questionnaireResponseStore.getState().updatableResponse.item ?? []).length
-    ).toBe(0);
+    expect((questionnaireResponseStore.getState().updatableResponse.item ?? []).length).toBe(0);
   });
 
   test('RepeatItem Add Item button adds a visible empty row without changing the QuestionnaireResponse', async () => {
@@ -953,7 +943,9 @@ describe('clearing choice fields removes the answer from updatableResponse', () 
 
     // A second (empty) row is rendered
     await waitFor(() =>
-      expect(document.querySelectorAll('[data-linkid="condition"] .MuiAutocomplete-root').length).toBe(2)
+      expect(
+        document.querySelectorAll('[data-linkid="condition"] .MuiAutocomplete-root').length
+      ).toBe(2)
     );
 
     // The QuestionnaireResponse is unchanged - no stub answer was added

--- a/packages/smart-forms-renderer/src/test/manageForm.test.ts
+++ b/packages/smart-forms-renderer/src/test/manageForm.test.ts
@@ -22,6 +22,7 @@ import { beforeEach, describe, expect, jest } from '@jest/globals';
 import type { QuestionnaireResponse, QuestionnaireResponseItem } from 'fhir/r4';
 // Import the functions to test
 import {
+  answerHasValue,
   buildForm,
   destroyForm,
   getResponse,
@@ -531,6 +532,68 @@ describe('manageForm utils', () => {
       const result = qrItemHasItemsOrAnswer(qrItem);
 
       expect(result).toBe(false);
+    });
+
+    it('should return false when qrItem only has a stub answer with an answer key', () => {
+      // Emitted by createEmptyQrItem(qItem, answerKey) when clearing a field
+      const qrItem: QuestionnaireResponseItem = {
+        linkId: 'test-item',
+        text: 'Test Item',
+        answer: [{ id: 'someAnswerKey' }]
+      };
+
+      const result = qrItemHasItemsOrAnswer(qrItem);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when qrItem only has a stub answer with an internal repeat id', () => {
+      // Empty repeat answer instances are tracked in RepeatItem local state and
+      // should never count as an answer in the QuestionnaireResponse
+      const qrItem: QuestionnaireResponseItem = {
+        linkId: 'test-item',
+        text: 'Test Item',
+        answer: [{ id: 'test-item-repeat-abc123' }]
+      };
+
+      const result = qrItemHasItemsOrAnswer(qrItem);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return true when at least one answer entry has a value amongst stubs', () => {
+      const qrItem: QuestionnaireResponseItem = {
+        linkId: 'test-item',
+        text: 'Test Item',
+        answer: [{ id: 'someAnswerKey' }, { id: 'anotherAnswerKey', valueInteger: 0 }]
+      };
+
+      const result = qrItemHasItemsOrAnswer(qrItem);
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('answerHasValue', () => {
+    it('should return true for value[x] properties, including falsy values', () => {
+      expect(answerHasValue({ valueString: 'test' })).toBe(true);
+      expect(answerHasValue({ valueBoolean: false })).toBe(true);
+      expect(answerHasValue({ valueInteger: 0 })).toBe(true);
+      expect(answerHasValue({ valueDecimal: 0 })).toBe(true);
+      expect(answerHasValue({ id: 'someAnswerKey', valueCoding: { code: '195967001' } })).toBe(
+        true
+      );
+    });
+
+    it('should return true for answers with nested items', () => {
+      expect(answerHasValue({ item: [{ linkId: 'nested-item' }] })).toBe(true);
+    });
+
+    it('should return false for stub answers without a value', () => {
+      expect(answerHasValue({})).toBe(false);
+      expect(answerHasValue({ id: 'someAnswerKey' })).toBe(false);
+      expect(answerHasValue({ id: 'test-item-repeat-abc123' })).toBe(false);
+      expect(answerHasValue({ id: 'someAnswerKey', item: [] })).toBe(false);
     });
   });
 

--- a/packages/smart-forms-renderer/src/test/qrItem.test.ts
+++ b/packages/smart-forms-renderer/src/test/qrItem.test.ts
@@ -353,6 +353,9 @@ describe('updateQrItemsInGroup', () => {
 
     const qItemsIndexMap = { 'item-1': 0 };
 
+    // Mock the dependency
+    mockQrItemHasItemsOrAnswer.mockReturnValue(true);
+
     updateQrItemsInGroup(newQrItem, null, questionnaireResponseOrQrItem, qItemsIndexMap);
 
     expect(questionnaireResponseOrQrItem.item).toHaveLength(1);
@@ -380,10 +383,97 @@ describe('updateQrItemsInGroup', () => {
 
     const qItemsIndexMap = { 'item-1': 0 };
 
+    // Mock the dependency - an item with no answer has no items or answers
+    mockQrItemHasItemsOrAnswer.mockReturnValue(false);
+
     updateQrItemsInGroup(newQrItem, null, questionnaireResponseOrQrItem, qItemsIndexMap);
 
     // Item should be removed since it has no answer
     expect(questionnaireResponseOrQrItem.item).toHaveLength(0);
+  });
+
+  it('should remove existing item when replaced with an item containing only a stub answer', () => {
+    const existingItem: QuestionnaireResponseItem = {
+      linkId: 'item-1',
+      text: 'Condition',
+      answer: [{ id: 'someAnswerKey', valueCoding: { code: '195967001', display: 'Asthma' } }]
+    };
+
+    // Emitted by createEmptyQrItem(qItem, answerKey) when clearing a choice field
+    const newQrItem: QuestionnaireResponseItem = {
+      linkId: 'item-1',
+      text: 'Condition',
+      answer: [{ id: 'someAnswerKey' }]
+    };
+
+    const questionnaireResponseOrQrItem: QuestionnaireResponseItem = {
+      linkId: 'group-1',
+      text: 'Test Group',
+      item: [existingItem]
+    };
+
+    const qItemsIndexMap = { 'item-1': 0 };
+
+    // Mock the dependency - a stub answer with only an id has no items or answers
+    mockQrItemHasItemsOrAnswer.mockReturnValue(false);
+
+    updateQrItemsInGroup(newQrItem, null, questionnaireResponseOrQrItem, qItemsIndexMap);
+
+    // Item should be removed instead of being replaced by the stub
+    expect(questionnaireResponseOrQrItem.item).toHaveLength(0);
+  });
+
+  it('should not push stub-answer item into an empty group', () => {
+    const newQrItem: QuestionnaireResponseItem = {
+      linkId: 'item-1',
+      text: 'Condition',
+      answer: [{ id: 'someAnswerKey' }]
+    };
+
+    const questionnaireResponseOrQrItem: QuestionnaireResponseItem = {
+      linkId: 'group-1',
+      text: 'Test Group',
+      item: []
+    };
+
+    const qItemsIndexMap = { 'item-1': 0 };
+
+    // Mock the dependency - a stub answer with only an id has no items or answers
+    mockQrItemHasItemsOrAnswer.mockReturnValue(false);
+
+    updateQrItemsInGroup(newQrItem, null, questionnaireResponseOrQrItem, qItemsIndexMap);
+
+    expect(questionnaireResponseOrQrItem.item).toHaveLength(0);
+  });
+
+  it('should not insert stub-answer item at its supposed position', () => {
+    const existingItem2: QuestionnaireResponseItem = {
+      linkId: 'item-2',
+      text: 'Item 2',
+      answer: [{ valueString: 'value2' }]
+    };
+
+    const newQrItem: QuestionnaireResponseItem = {
+      linkId: 'item-1',
+      text: 'Condition',
+      answer: [{ id: 'someAnswerKey' }]
+    };
+
+    const questionnaireResponseOrQrItem: QuestionnaireResponseItem = {
+      linkId: 'group-1',
+      text: 'Test Group',
+      item: [existingItem2]
+    };
+
+    const qItemsIndexMap = { 'item-1': 0, 'item-2': 1 };
+
+    // Mock the dependency - a stub answer with only an id has no items or answers
+    mockQrItemHasItemsOrAnswer.mockReturnValue(false);
+
+    updateQrItemsInGroup(newQrItem, null, questionnaireResponseOrQrItem, qItemsIndexMap);
+
+    expect(questionnaireResponseOrQrItem.item).toHaveLength(1);
+    expect(questionnaireResponseOrQrItem.item?.[0].linkId).toBe('item-2');
   });
 
   it('should insert item at correct position based on index', () => {

--- a/packages/smart-forms-renderer/src/utils/manageForm.ts
+++ b/packages/smart-forms-renderer/src/utils/manageForm.ts
@@ -1,4 +1,9 @@
-import type { Questionnaire, QuestionnaireResponse, QuestionnaireResponseItem } from 'fhir/r4';
+import type {
+  Questionnaire,
+  QuestionnaireResponse,
+  QuestionnaireResponseItem,
+  QuestionnaireResponseItemAnswer
+} from 'fhir/r4';
 import type { RendererConfig } from '../stores';
 import {
   questionnaireResponseStore,
@@ -293,11 +298,44 @@ export function removeInternalIdsFromResponse(
   );
 }
 
+const answerValueKeys: (keyof QuestionnaireResponseItemAnswer)[] = [
+  'valueBoolean',
+  'valueDecimal',
+  'valueInteger',
+  'valueDate',
+  'valueDateTime',
+  'valueTime',
+  'valueString',
+  'valueUri',
+  'valueAttachment',
+  'valueCoding',
+  'valueQuantity',
+  'valueReference'
+];
+
+/**
+ * Check if a QuestionnaireResponseItemAnswer has an actual value - any value[x] property or nested items.
+ * Returns false for stub answers that only carry an internal answer key e.g. { id: answerKey }, which
+ * components emit via createEmptyQrItem() when a field is cleared.
+ */
+export function answerHasValue(answer: QuestionnaireResponseItemAnswer): boolean {
+  return (
+    answerValueKeys.some((key) => answer[key] !== undefined) ||
+    (!!answer.item && answer.item.length > 0)
+  );
+}
+
 /**
  * Check if a QuestionnaireResponseItem has either an item or an answer property.
+ * Answers only count if at least one entry has an actual value - a lone stub answer
+ * { id: answerKey } left behind by clearing a field does not count.
  *
  * @author Sean Fong
  */
 export function qrItemHasItemsOrAnswer(qrItem: QuestionnaireResponseItem): boolean {
-  return (!!qrItem.item && qrItem.item.length > 0) || (!!qrItem.answer && qrItem.answer.length > 0);
+  if (!!qrItem.item && qrItem.item.length > 0) {
+    return true;
+  }
+
+  return !!qrItem.answer && qrItem.answer.length > 0 && qrItem.answer.some(answerHasValue);
 }

--- a/packages/smart-forms-renderer/src/utils/qrItem.ts
+++ b/packages/smart-forms-renderer/src/utils/qrItem.ts
@@ -124,8 +124,12 @@ export function updateQrItemsInGroup(
   const qrItemsRealIndexArr = qrItems.map((qrItem) => qItemsIndexMap[qrItem.linkId]);
 
   if (newQrItem && newQrItem.linkId in qItemsIndexMap) {
+    // Only add/insert an item if it has items or answers with values - clearing a field emits an
+    // empty item (optionally with a stub answer { id: answerKey }) which should not be added
     if (qrItems.length === 0) {
-      qrItems.push(newQrItem);
+      if (qrItemHasItemsOrAnswer(newQrItem)) {
+        qrItems.push(newQrItem);
+      }
       return;
     }
 
@@ -135,7 +139,6 @@ export function updateQrItemsInGroup(
       // Add qrItem at the end of qrGroup if it is larger than the other indexes
       if (newQrItemIndex > qrItemsRealIndexArr[i]) {
         if (i === qrItemsRealIndexArr.length - 1) {
-          // As of 07-05-2025, added this here to prevent adding empty items - only add if an item has items or answers
           if (qrItemHasItemsOrAnswer(newQrItem)) {
             qrItems.push(newQrItem);
           }
@@ -146,7 +149,7 @@ export function updateQrItemsInGroup(
       // Replace or delete qrItem at its supposed position if its index is already present within qrGroup
       if (newQrItemIndex === qrItemsRealIndexArr[i]) {
         // newQrItem has answer value
-        if (newQrItem.item?.length || newQrItem.answer?.length) {
+        if (qrItemHasItemsOrAnswer(newQrItem)) {
           qrItems[i] = newQrItem;
           break;
         }
@@ -158,7 +161,9 @@ export function updateQrItemsInGroup(
 
       // Add qrItem at its supposed position if its index is not present within qrGroup
       if (newQrItemIndex < qrItemsRealIndexArr[i]) {
-        qrItems.splice(i, 0, newQrItem);
+        if (qrItemHasItemsOrAnswer(newQrItem)) {
+          qrItems.splice(i, 0, newQrItem);
+        }
         break;
       }
     }

--- a/packages/smart-forms-renderer/src/utils/validate.ts
+++ b/packages/smart-forms-renderer/src/utils/validate.ts
@@ -26,6 +26,7 @@ import type {
 } from 'fhir/r4';
 import { getQrItemsIndex, mapQItemsIndex } from './mapItem';
 import type { EnableWhenExpressions, EnableWhenItems } from '../interfaces/enableWhen.interface';
+import { answerHasValue } from './manageForm';
 import { isItemHidden } from './qItem';
 import {
   getDecimalPrecision,
@@ -494,7 +495,8 @@ function validateSingleItem(
 }
 
 /**
- * Check if an answer array is effectively empty (no answers or all string answers are empty/whitespace-only)
+ * Check if an answer array is effectively empty (no answers, all string answers are empty/whitespace-only,
+ * or all answers are value-less stubs e.g. { id: answerKey } left behind by clearing a field or an empty repeat instance)
  */
 function isAnswerEffectivelyEmpty(answers: QuestionnaireResponseItemAnswer[]): boolean {
   if (!answers || answers.length === 0) {
@@ -507,8 +509,8 @@ function isAnswerEffectivelyEmpty(answers: QuestionnaireResponseItemAnswer[]): b
       return answer.valueString.trim() === '';
     }
 
-    // For other answer types, they're not empty if they exist
-    return false;
+    // For other answer types, they're empty if they have no value[x] or nested items
+    return !answerHasValue(answer);
   });
 }
 


### PR DESCRIPTION
…tionnaireResponse (issue #1994)

Three related fixes for cleared fields persisting in the updatableResponse:

- OpenChoiceAutocompleteItem: the clear button fires onChange with reason "clear", which matched no branch in handleValueChange - the clear was swallowed and onQrItemChange never called, so the old valueCoding stayed in the response (the primary cause in the Aboriginal Health Check, whose condition fields are open-choice). Emit an empty item on newValue === null.

- updateQrItemsInGroup / qrItemHasItemsOrAnswer: a stub answer [{ id }] emitted by createEmptyQrItem(qItem, answerKey) no longer counts as an answer. Cleared items are now removed (not replaced by the stub) and stubs are never added on the empty-group/add-at-end/insert paths. New answerHasValue() helper checks for an actual value[x] or nested items.

- RepeatItem: empty repeat answer instances are now tracked in local state (same pattern as RepeatGroup/GroupTable) instead of being stored as value-less stub answers in the response.

Required validation now also treats value-less stub answers as empty, so cleared required fields are correctly flagged as invalid.

Adds end-to-end jsdom regression tests covering choice and open-choice autocompletes across standalone, repeat group, repeats:true and gtable contexts.