### PR TITLE
fix(sdc-assemble): use recursively-assembled child when flattening nested modular questionnaires

### DIFF
--- a/packages/sdc-assemble/src/test/assemble.test.ts
+++ b/packages/sdc-assemble/src/test/assemble.test.ts
@@ -33,6 +33,17 @@ const mockFetchQuestionnaireCallbackConfig = {
   sourceServerUrl: 'https://example.com/fhir'
 };
 
+// Collect every linkId in an item tree (depth-first), used to assert that (nested)
+// subQuestionnaire placeholders were resolved into their children's items.
+function collectLinkIds(items: Questionnaire['item']): string[] {
+  const linkIds: string[] = [];
+  for (const item of items ?? []) {
+    linkIds.push(item.linkId);
+    linkIds.push(...collectLinkIds(item.item));
+  }
+  return linkIds;
+}
+
 describe('assemble', () => {
   const createBaseQuestionnaire = (): Questionnaire => ({
     resourceType: 'Questionnaire',
@@ -214,6 +225,14 @@ describe('assemble', () => {
     expect(assembledQuestionnaire.version).toBe('1.0.0-assembled');
     expect(assembledQuestionnaire.url).toBe('http://example.com/assessments/test/1');
     expect(mockFetchSubquestionnaires).toHaveBeenCalledTimes(2);
+
+    // The nested subquestionnaire is itself modular: its `deep-subq-ref` placeholder must be
+    // resolved (recursively) into the deep subquestionnaire's `deep-question` item. Regression
+    // guard: if the recursive assembly result of a child is discarded, the child is spliced in
+    // un-assembled and `deep-subq-ref` survives while `deep-question` never appears.
+    const allLinkIds = collectLinkIds(assembledQuestionnaire.item);
+    expect(allLinkIds).toContain('deep-question');
+    expect(allLinkIds).not.toContain('deep-subq-ref');
   });
 
   it('should handle multiple subquestionnaires in same parent', async () => {

--- a/packages/sdc-assemble/src/utils/assemble.ts
+++ b/packages/sdc-assemble/src/utils/assemble.ts
@@ -144,8 +144,17 @@ async function assembleQuestionnaire(
     return subquestionnaires;
   }
 
-  // Recursively assemble subquestionnaires if required
-  for (let subquestionnaire of subquestionnaires) {
+  // Recursively assemble subquestionnaires if required.
+  // NB: iterate by index and write the assembled result BACK into the array. A `for...of` loop
+  // with `subquestionnaire = assembled` only reassigns the loop variable, leaving the array
+  // element (and therefore getItems() below) pointing at the un-assembled child — so a
+  // subquestionnaire that is itself modular would be spliced in without its own children resolved.
+  for (let i = 0; i < subquestionnaires.length; i++) {
+    const subquestionnaire = subquestionnaires[i];
+    if (!subquestionnaire) {
+      continue;
+    }
+
     const assembled: Questionnaire | OperationOutcome = await assembleQuestionnaire(
       subquestionnaire,
       totalCanonicals,
@@ -160,7 +169,7 @@ async function assembleQuestionnaire(
       return assembled;
     }
 
-    subquestionnaire = assembled;
+    subquestionnaires[i] = assembled;
   }
 
   // Check for prohibited attributes and compare matching language properties


### PR DESCRIPTION
## Problem

`assembleQuestionnaire` (packages/sdc-assemble/src/utils/assemble.ts) recurses into each subquestionnaire but **discards the result**:

```ts
for (let subquestionnaire of subquestionnaires) {
  const assembled = await assembleQuestionnaire(subquestionnaire, …, /* isRoot */ false, …);
  if (assembled.resourceType === 'OperationOutcome') return assembled;
  subquestionnaire = assembled;   // ← reassigns the loop variable, NOT the array element
}
…
const items = getItems(subquestionnaires); // reads the ORIGINAL, un-assembled children
```

Because `subquestionnaire = assembled` only rebinds the loop variable (and `assembleQuestionnaire` works on a `cloneDeep`, so the original is untouched), `getItems(subquestionnaires)` reads the **un-assembled** children. A subquestionnaire that is itself modular (nested / recursive modular questionnaire) is therefore spliced into its parent with its own `subQuestionnaire` placeholders **left unresolved** — nested modular never fully flattens.

## Fix

Iterate by index and write the assembled child back into the array, with a guard for the possibly-`undefined` element under `noUncheckedIndexedAccess`:

```ts
for (let i = 0; i < subquestionnaires.length; i++) {
  const subquestionnaire = subquestionnaires[i];
  if (!subquestionnaire) continue;
  const assembled = await assembleQuestionnaire(subquestionnaire, …, false, …);
  if (assembled.resourceType === 'OperationOutcome') return assembled;
  subquestionnaires[i] = assembled;
}
```

## Test

The existing `should handle recursive assembly of nested subquestionnaires` test only asserted `resourceType` / `version` / `url` / call-count, so it passed despite the bug. It is strengthened to assert that the deep child's item actually resolves into the output (`deep-question` present, `deep-subq-ref` placeholder gone). That assertion **fails on `main`** and passes with this change.

- Full `sdc-assemble` package suite: **123/123 passing**.