### PR TITLE
fix(sdc-assemble): preserve regular items mixed with subQuestionnaire placeholders

### DIFF
--- a/packages/sdc-assemble/src/test/assemble.test.ts
+++ b/packages/sdc-assemble/src/test/assemble.test.ts
@@ -294,6 +294,88 @@ describe('assemble', () => {
     expect(assembledQuestionnaire.item?.[0]?.item?.[1]?.linkId).toBe('medical-history');
   });
 
+  it('should preserve regular items mixed alongside a subquestionnaire placeholder', async () => {
+    // A form group that mixes a regular question (index 0) with a subQuestionnaire placeholder
+    // (index 1). getItems() returns a compact list with a single entry (index 0), so without
+    // aligning it to the parent item positions the child items land on the regular question —
+    // dropping it — while the placeholder at index 1 is left unresolved.
+    const mixedQuestionnaire: Questionnaire = {
+      resourceType: 'Questionnaire',
+      id: 'mixed-subq',
+      status: 'draft',
+      version: '1.0.0',
+      url: 'http://example.com/assessments/test/1',
+      meta: {
+        profile: ['http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-modular']
+      },
+      item: [
+        {
+          linkId: 'root-group',
+          type: 'group',
+          item: [
+            {
+              linkId: 'manifestation',
+              type: 'choice',
+              text: 'Manifestation'
+            },
+            {
+              linkId: 'begin-ref',
+              type: 'display',
+              extension: [
+                {
+                  url: 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-subQuestionnaire',
+                  valueCanonical: 'http://example.com/assessments/test/1/ManifestationBegin|1.0.0'
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    };
+
+    const beginSubquestionnaire: Questionnaire = {
+      resourceType: 'Questionnaire',
+      id: 'manifestation-begin',
+      status: 'draft',
+      version: '1.0.0',
+      url: 'http://example.com/assessments/test/1/ManifestationBegin',
+      item: [
+        { linkId: 'beginUnknown', type: 'boolean', text: 'Onset unknown' },
+        { linkId: 'beginDate', type: 'date', text: 'Onset date' }
+      ]
+    };
+
+    const inputParameters = createInputParameters(mixedQuestionnaire);
+
+    mockFetchSubquestionnaires.mockResolvedValue([beginSubquestionnaire]);
+
+    const result = await assemble(
+      inputParameters,
+      mockFetchQuestionnaireCallback,
+      mockFetchQuestionnaireCallbackConfig
+    );
+
+    expect(result.resourceType).toBe('Questionnaire');
+    const assembledQuestionnaire = result as Questionnaire;
+
+    const assembledItems = assembledQuestionnaire.item?.[0]?.item;
+    // The regular manifestation question is kept in place; the placeholder is replaced by the
+    // subquestionnaire's items (in order), with no leftover subQuestionnaire placeholder.
+    expect(assembledItems?.map((item) => item.linkId)).toEqual([
+      'manifestation',
+      'beginUnknown',
+      'beginDate'
+    ]);
+    const hasUnresolvedPlaceholder = assembledItems?.some((item) =>
+      item.extension?.some(
+        (ext) =>
+          ext.url ===
+          'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-subQuestionnaire'
+      )
+    );
+    expect(hasUnresolvedPlaceholder).toBe(false);
+  });
+
   it('should propagate contained resources from subquestionnaires', async () => {
     const rootQuestionnaire = createBaseQuestionnaire();
 

--- a/packages/sdc-assemble/src/test/canonical.test.ts
+++ b/packages/sdc-assemble/src/test/canonical.test.ts
@@ -16,8 +16,8 @@
  */
 
 import { describe, expect, it } from '@jest/globals';
-import type { Questionnaire } from 'fhir/r4';
-import { getCanonicalUrls } from '../utils/canonical';
+import type { Questionnaire, QuestionnaireItem } from 'fhir/r4';
+import { alignItemsWithParentForm, getCanonicalUrls } from '../utils/canonical';
 
 describe('getCanonicalUrls', () => {
   const mockParentQuestionnaire: Questionnaire = {
@@ -322,5 +322,77 @@ describe('getCanonicalUrls', () => {
       expect(Array.isArray(result)).toBe(true);
       expect(result).toEqual([]);
     });
+  });
+});
+
+describe('alignItemsWithParentForm', () => {
+  const subQuestionnaireItem = (linkId: string, canonical: string): QuestionnaireItem => ({
+    linkId,
+    type: 'display',
+    extension: [
+      {
+        url: 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-subQuestionnaire',
+        valueCanonical: canonical
+      }
+    ]
+  });
+
+  const buildParent = (formItems: QuestionnaireItem[]): Questionnaire => ({
+    resourceType: 'Questionnaire',
+    id: 'parent',
+    status: 'draft',
+    item: [{ linkId: 'form', type: 'group', item: formItems }]
+  });
+
+  it('aligns compact subquestionnaire items to a regular item mixed before a placeholder', () => {
+    // Form order: [regular question, placeholder]. getItems() only sees the one subquestionnaire,
+    // so its compact list has a single entry at index 0.
+    const parent = buildParent([
+      { linkId: 'realQuestion', type: 'string' },
+      subQuestionnaireItem('placeholder', 'http://example.com/child')
+    ]);
+    const childItems: QuestionnaireItem[] = [
+      { linkId: 'childA', type: 'boolean' },
+      { linkId: 'childB', type: 'date' }
+    ];
+
+    const aligned = alignItemsWithParentForm(parent, [childItems]);
+
+    // The child items land at the placeholder's position (index 1), not the regular item (index 0).
+    expect(aligned).toEqual([null, childItems]);
+  });
+
+  it('aligns multiple placeholders interleaved with regular items', () => {
+    const parent = buildParent([
+      subQuestionnaireItem('placeholderA', 'http://example.com/childA'),
+      { linkId: 'realQuestion', type: 'string' },
+      subQuestionnaireItem('placeholderB', 'http://example.com/childB')
+    ]);
+    const childAItems: QuestionnaireItem[] = [{ linkId: 'a', type: 'boolean' }];
+    const childBItems: QuestionnaireItem[] = [{ linkId: 'b', type: 'date' }];
+
+    const aligned = alignItemsWithParentForm(parent, [childAItems, childBItems]);
+
+    expect(aligned).toEqual([childAItems, null, childBItems]);
+  });
+
+  it('leaves an all-placeholder form unchanged (index-for-index)', () => {
+    const parent = buildParent([
+      subQuestionnaireItem('placeholderA', 'http://example.com/childA'),
+      subQuestionnaireItem('placeholderB', 'http://example.com/childB')
+    ]);
+    const childAItems: QuestionnaireItem[] = [{ linkId: 'a', type: 'boolean' }];
+    const childBItems: QuestionnaireItem[] = [{ linkId: 'b', type: 'date' }];
+
+    const aligned = alignItemsWithParentForm(parent, [childAItems, childBItems]);
+
+    expect(aligned).toEqual([childAItems, childBItems]);
+  });
+
+  it('returns the compact list untouched when the parent has no form items', () => {
+    const parent: Questionnaire = { resourceType: 'Questionnaire', id: 'empty', status: 'draft' };
+    const compact = [[{ linkId: 'a', type: 'boolean' } as QuestionnaireItem]];
+
+    expect(alignItemsWithParentForm(parent, compact)).toBe(compact);
   });
 });

--- a/packages/sdc-assemble/src/utils/assemble.ts
+++ b/packages/sdc-assemble/src/utils/assemble.ts
@@ -37,7 +37,7 @@ import {
 } from './getProperties';
 import { propagateProperties } from './propagate';
 import cloneDeep from 'lodash.clonedeep';
-import { getCanonicalUrls } from './canonical';
+import { alignItemsWithParentForm, getCanonicalUrls } from './canonical';
 
 /**
  * The $assemble operation - https://build.fhir.org/ig/HL7/sdc/OperationDefinition-Questionnaire-assemble.html
@@ -178,8 +178,14 @@ async function assembleQuestionnaire(
     return matchingLanguageOutcome;
   }
 
-  // Get items
-  const items: (QuestionnaireItem[] | null)[] = getItems(subquestionnaires);
+  // Get items, then align them with the parent form's item positions so that regular items mixed
+  // in alongside subQuestionnaire placeholders are preserved in place (getItems returns a compact
+  // list with one entry per subquestionnaire, but propagateProperties looks them up by parent item
+  // position).
+  const items: (QuestionnaireItem[] | null)[] = alignItemsWithParentForm(
+    parentQuestionnaire,
+    getItems(subquestionnaires)
+  );
 
   // Get urls with versions
   const urls: string[] = getUrls(subquestionnaires);

--- a/packages/sdc-assemble/src/utils/canonical.ts
+++ b/packages/sdc-assemble/src/utils/canonical.ts
@@ -15,8 +15,29 @@
  * limitations under the License.
  */
 
-import type { OperationOutcome, Questionnaire } from 'fhir/r4';
+import type { OperationOutcome, Questionnaire, QuestionnaireItem } from 'fhir/r4';
 import { createErrorOutcome } from './operationOutcome';
+
+export const SUB_QUESTIONNAIRE_EXTENSION_URL =
+  'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-subQuestionnaire';
+
+/**
+ * Tests whether a questionnaire item is a subQuestionnaire placeholder, i.e. it carries a
+ * sdc-questionnaire-subQuestionnaire extension with a valueCanonical.
+ *
+ * @param item - The QuestionnaireItem to test
+ * @returns True if the item references a subquestionnaire, false otherwise
+ *
+ * @author Sean Fong
+ */
+export function itemIsSubQuestionnaire(item: QuestionnaireItem): boolean {
+  return (
+    item.extension?.some(
+      (extension) =>
+        extension.url === SUB_QUESTIONNAIRE_EXTENSION_URL && !!extension.valueCanonical
+    ) ?? false
+  );
+}
 
 /**
  * Retrieves all the canonical urls from a parent questionnaire
@@ -58,10 +79,7 @@ export function getCanonicalUrls(
 
     // Get subquestionnaire extension
     const subQuestionnaireExtension = qItem.extension.find(
-      (extension) =>
-        extension.url ===
-          'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-subQuestionnaire' &&
-        extension.valueCanonical
+      (extension) => extension.url === SUB_QUESTIONNAIRE_EXTENSION_URL && extension.valueCanonical
     );
 
     // Proceed to next item if subquestionnaire extension is not present
@@ -84,4 +102,49 @@ export function getCanonicalUrls(
   }
 
   return canonicals;
+}
+
+/**
+ * Aligns the assembled items collected from subquestionnaires with the parent form's item
+ * positions.
+ *
+ * `getItems()` returns one entry per subquestionnaire, in the document order the subquestionnaire
+ * placeholders appear under `parentQuestionnaire.item[0].item` (the same order as
+ * {@link getCanonicalUrls}). `propagateProperties()`, however, walks the parent form items by
+ * position and looks up `itemsFromSubquestionnaires[i]` at that same index. Those two only line up
+ * when *every* child of the form is a subQuestionnaire placeholder. As soon as a regular
+ * (non-placeholder) item is mixed in — e.g. a real question sitting next to a placeholder — the
+ * compact list is offset from the parent positions, so the wrong item gets replaced and the
+ * placeholder is left unresolved.
+ *
+ * This re-expands the compact list into an array the same length as `parentQuestionnaire.item[0].item`,
+ * placing each subquestionnaire's items at its placeholder's position and `null` at every regular
+ * item so `propagateProperties()` keeps those regular items in place.
+ *
+ * @param parentQuestionnaire - The parent Questionnaire resource
+ * @param compactItemsFromSubquestionnaires - Items collected from subquestionnaires, one entry per subquestionnaire in document order
+ * @returns Items aligned to the parent form item positions (null where the parent item is not a subQuestionnaire placeholder)
+ *
+ * @author Sean Fong
+ */
+export function alignItemsWithParentForm(
+  parentQuestionnaire: Questionnaire,
+  compactItemsFromSubquestionnaires: (QuestionnaireItem[] | null)[]
+): (QuestionnaireItem[] | null)[] {
+  const qForm = parentQuestionnaire.item?.[0]?.item;
+  if (!qForm) {
+    return compactItemsFromSubquestionnaires;
+  }
+
+  const alignedItems: (QuestionnaireItem[] | null)[] = [];
+  let subquestionnaireIndex = 0;
+  for (const qItem of qForm) {
+    if (itemIsSubQuestionnaire(qItem)) {
+      alignedItems.push(compactItemsFromSubquestionnaires[subquestionnaireIndex++] ?? null);
+    } else {
+      alignedItems.push(null);
+    }
+  }
+
+  return alignedItems;
 }


### PR DESCRIPTION
### Problem

`$assemble` assumed every child of a form group (`item[0].item`) is a `sdc-questionnaire-subQuestionnaire` placeholder. `getItems()` returns a **compact** list (one entry per subquestionnaire, in document order) while `propagateProperties()` indexes it by **parent item position**. Those only align when the group is all placeholders.

When a regular item is mixed in with placeholders, the child items are applied at the wrong positions — regular items are silently **dropped** and the placeholder is left in the output with its `subQuestionnaire` extension **unresolved**.

#### Reproduction

Form group mixing a regular question with a placeholder:

```jsonc
// item[0].item
[
  { "linkId": "manifestation", "type": "choice" },           // regular item (index 0)
  { "linkId": "begin-ref", "type": "display", "extension": [ // placeholder  (index 1)
      { "url": ".../sdc-questionnaire-subQuestionnaire",
        "valueCanonical": ".../ManifestationBegin|1.0.0" } ] }
]
```
child `ManifestationBegin` → `[ beginUnknown (boolean), beginDate (date) ]`

| Expected | Actual (before fix) |
|---|---|
| `manifestation`, `beginUnknown`, `beginDate` | `beginUnknown`, `beginDate`, `begin-ref` *(unresolved)* — `manifestation` dropped |

### Fix

Add `alignItemsWithParentForm()` (`utils/canonical.ts`) that re-expands the compact per-subquestionnaire item list into an array aligned to the parent form's item positions — child items at each placeholder position, `null` for every regular item. `assembleQuestionnaire()` aligns the list before calling `propagateProperties()`.

`propagateProperties()` is **unchanged**: its existing contract (positional array, `null` where the parent item is not a placeholder — as its own unit tests already encode) is exactly what it now receives. Also extracts the extension URL into a `SUB_QUESTIONNAIRE_EXTENSION_URL` constant and an `itemIsSubQuestionnaire()` predicate, reused by `getCanonicalUrls()`.

### Behaviour change

- **Pure-modular forms (all placeholders): identical output** — the aligned array equals the compact array index-for-index.
- **Mixed forms: now correct** — regular items keep their position, placeholders are replaced in place, no leftover unresolved placeholders.

### Tests

- `assemble.test.ts`: end-to-end `should preserve regular items mixed alongside a subquestionnaire placeholder` — verified it **fails on `main`** (`manifestation` dropped) and passes with this change.
- `canonical.test.ts`: unit tests for `alignItemsWithParentForm` (regular-before-placeholder, interleaved, all-placeholder no-op, empty-form passthrough).
- Full suite: **128 passed** (was 123). `npm run build` (tsup CJS/ESM/DTS) succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
