### PR TITLE
Remove the unused axios runtime dependency from sdc-assemble

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14835,6 +14835,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
       "dependencies": {
         "debug": "4"
       },
@@ -15489,6 +15490,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/at-least-node": {
@@ -15941,6 +15943,7 @@
       "version": "1.18.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
       "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
@@ -15953,6 +15956,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
       "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -17389,6 +17393,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -18755,6 +18760,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -19589,6 +19595,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
@@ -21180,6 +21187,7 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
       "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -21815,6 +21823,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -22403,6 +22412,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -39308,7 +39318,6 @@
       "version": "2.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "axios": "^1.18.1",
         "lodash.clonedeep": "^4.5.0"
       },
       "devDependencies": {

--- a/packages/sdc-assemble/package.json
+++ b/packages/sdc-assemble/package.json
@@ -19,7 +19,6 @@
   },
   "homepage": "https://github.com/aehrc/smart-forms#readme",
   "dependencies": {
-    "axios": "^1.18.1",
     "lodash.clonedeep": "^4.5.0"
   },
   "devDependencies": {

--- a/packages/sdc-assemble/src/utils/fetchSubquestionnaires.ts
+++ b/packages/sdc-assemble/src/utils/fetchSubquestionnaires.ts
@@ -66,7 +66,8 @@ export async function fetchSubquestionnaires(
         continue;
       }
 
-      // Fallback to get Bundle from response.data (axios scenario)
+      // Fallback to get Bundle from response.data, for responses that wrap the payload in a
+      // data property, as axios-style HTTP clients do
       if (
         settledPromise.value &&
         typeof settledPromise.value === 'object' &&
@@ -77,7 +78,7 @@ export async function fetchSubquestionnaires(
         continue;
       }
 
-      // Handle OperationOutcome in response.data (axios scenario)
+      // Handle OperationOutcome in response.data, for the same wrapped-payload shape
       if (
         settledPromise.value &&
         typeof settledPromise.value === 'object' &&


### PR DESCRIPTION
Fixes #2049.

## Problem

`packages/sdc-assemble/package.json:22` declares `axios` under `dependencies`, but nothing in the package imports it:

```
$ grep -rn "from 'axios'\|require('axios')" packages/sdc-assemble/src
$ 
```

The only axios contact is duck-typed response handling at `packages/sdc-assemble/src/utils/fetchSubquestionnaires.ts:69` and `:80`, which unwraps a `data` property when the caller-supplied `FetchResourceCallback` returns an HTTP client response wrapper rather than a bare `Bundle`. That is a plain `'data' in value` property check, so it does not need axios installed. The tests covering it (`src/test/fetchSubquestionnaires.test.ts:133`, `:168`) build object literals and do not import axios either. The axios call in `README.md:28` is inside an example of consumer-written callback code, so it is the consumer's dependency, not the package's.

## Change

Remove `axios` from `packages/sdc-assemble/package.json` `dependencies`, and regenerate the root `package-lock.json`.

It is **not** moved to `devDependencies`, because no source file and no test imports it. After the change, `npm ls axios --all` shows axios remaining in the tree only as a dev transitive (`jest-process-manager` to `wait-on` to `axios`), so the lockfile hunk is mostly `"dev": true` markers being added to axios and its transitive deps. No workspace source outside `apps/demo-renderer-app` (which is outside the workspace and declares its own axios) imports axios, so nothing was relying on the hoist.

I also reworded the two comments that said "axios scenario" to describe the response shape instead of naming the library, since that wording is what made the dependency look load-bearing. Happy to drop that part if you would rather keep the diff to `package.json` plus the lockfile.

## Consumer-visible impact

Every consumer of `@aehrc/sdc-assemble` stops installing axios transitively, and the package stops pinning an axios range consumers may not want. This matters for React Native and mobile consumers, where unused transitive weight is a real cost. No behaviour change: the axios-shaped response tolerance is unaffected because it is duck-typed.

## Changelog

`packages/sdc-assemble/CHANGELOG.md` has no `## [Unreleased]` heading, and cutting a version is your call, so I have not added an entry. Happy to add one under whichever heading you prefer.

## Checks run

Local Node is v26.5.0 with npm 11, whereas `LOCAL_DEVELOPMENT.md` asks for Node 20, so I measured a baseline on unmodified `main` first and compared.

| Check | Baseline on `main` | After the change |
| --- | --- | --- |
| `cd packages/sdc-assemble && npm test` | 10 suites passed, 123 tests passed | 10 suites passed, 123 tests passed |
| `cd packages/sdc-assemble && npm run build` (tsup) | success | success |
| `npx prettier --check` on the 3 touched files | n/a | pass |
| `npx eslint -c eslint.config.mjs` on the touched source file | 1 pre-existing warning at line 37 (`no-explicit-any`), 0 errors | unchanged: same 1 warning, 0 errors |

Not run: the other packages' suites, the app build, and Storybook. Relying on CI for those.

## Note on the lockfile

Three sibling PRs are being opened at the same time and each regenerates the root `package-lock.json`. If one of them lands first, the lockfile hunk here will need regenerating (`npm install` at the root); the `package.json` and source changes are conflict-free.
