### PR TITLE
Remove the webfont side effect from the renderer entrypoint

### DIFF
--- a/apps/smart-forms-app/index.html
+++ b/apps/smart-forms-app/index.html
@@ -8,10 +8,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no" />
     <meta name="theme-color" content="#000000" />
     <title>Smart Forms</title>
-
-    <!-- Inter font -->
-    <link rel="preconnect" href="https://rsms.me/" />
-    <link rel="stylesheet" crossorigin="anonymous" href="https://rsms.me/inter/inter.css" />
   </head>
   <body>
     <div id="root"></div>

--- a/apps/smart-forms-app/package.json
+++ b/apps/smart-forms-app/package.json
@@ -33,6 +33,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@fontsource/inter": "^5.2.8",
     "@fontsource/material-icons": "^5.2.7",
     "@fontsource/roboto": "^5.2.10",
     "@microlink/react-json-view": "^1.31.20",

--- a/apps/smart-forms-app/src/main.tsx
+++ b/apps/smart-forms-app/src/main.tsx
@@ -15,6 +15,9 @@
  * limitations under the License.
  */
 
+// Self-hosted Inter, the typeface requested by the renderer and app themes
+import '@fontsource/inter';
+
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import type { DefaultOptions } from '@tanstack/react-query';

--- a/documentation/docs/dev/renderer-overview.mdx
+++ b/documentation/docs/dev/renderer-overview.mdx
@@ -22,6 +22,20 @@ To install, run this command:
 npm install @aehrc/smart-forms-renderer
 ```
 
+### Typography
+
+The renderer theme asks for the [Inter](https://rsms.me/inter/) typeface, falling back to your platform's default sans-serif font. The library does not load any webfont itself, so provide Inter in your own application if you want the intended typography. The simplest way is to self-host it:
+
+```bash
+npm install @fontsource/inter
+```
+
+```ts title="Your application entrypoint"
+import '@fontsource/inter';
+```
+
+Linking a hosted stylesheet or declaring your own `@font-face` works equally well.
+
 ## Usage
 
 ### Basic Usage

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -22,6 +22,7 @@
     "@docusaurus/theme-live-codeblock": "^3.9.2",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@fontsource/inter": "^5.2.8",
     "@mdx-js/react": "^3.1.1",
     "@mui/material": "^7.3.4",
     "@tanstack/react-query": "^5.90.5",

--- a/documentation/src/css/custom.css
+++ b/documentation/src/css/custom.css
@@ -4,6 +4,9 @@
  * work well for content-centric websites.
  */
 
+/* Self-hosted Inter, the typeface requested by the renderer theme in live code blocks. */
+@import '@fontsource/inter/index.css';
+
 /* You can override the default Infima variables here. */
 :root {
   --ifm-color-primary: #1976d2;

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
+        "@fontsource/inter": "^5.2.8",
         "@fontsource/material-icons": "^5.2.7",
         "@fontsource/roboto": "^5.2.10",
         "@microlink/react-json-view": "^1.31.20",
@@ -1287,6 +1288,7 @@
         "@docusaurus/theme-live-codeblock": "^3.9.2",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
+        "@fontsource/inter": "^5.2.8",
         "@mdx-js/react": "^3.1.1",
         "@mui/material": "^7.3.4",
         "@tanstack/react-query": "^5.90.5",
@@ -39889,7 +39891,6 @@
         "@aehrc/sdc-template-extract": "^1.0.15",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
-        "@fontsource/inter": "^5.2.8",
         "@fontsource/material-icons": "^5.2.7",
         "@fontsource/roboto": "^5.2.10",
         "@mui/icons-material": "^7.1.1",
@@ -39951,8 +39952,14 @@
         "typescript": "^5.9.3"
       },
       "peerDependencies": {
+        "@fontsource/inter": "^5.0.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@fontsource/inter": {
+          "optional": true
+        }
       }
     },
     "packages/smart-forms-renderer/node_modules/@mui/icons-material": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39952,14 +39952,8 @@
         "typescript": "^5.9.3"
       },
       "peerDependencies": {
-        "@fontsource/inter": "^5.0.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@fontsource/inter": {
-          "optional": true
-        }
       }
     },
     "packages/smart-forms-renderer/node_modules/@mui/icons-material": {

--- a/packages/smart-forms-renderer/README.md
+++ b/packages/smart-forms-renderer/README.md
@@ -11,20 +11,7 @@ View the changelog [here](https://github.com/aehrc/smart-forms/blob/main/CHANGEL
 
 We recently updated to v1.0.0 which includes some breaking changes. Please refer to the [migration guide](https://github.com/aehrc/smart-forms/blob/main/MIGRATION-v1.0.md) for more information.
 
-## Typography
-
-The renderer theme asks for the [Inter](https://rsms.me/inter/) typeface, falling back to the platform's default sans-serif font. The library does not load any webfont itself, so if you want the intended typography, provide Inter in your own application. The simplest way is to self-host it:
-
-```bash
-npm install @fontsource/inter
-```
-
-```ts
-// In your application entrypoint
-import '@fontsource/inter';
-```
-
-Linking a hosted stylesheet or declaring your own `@font-face` works equally well. If Inter is not available the renderer still lays out correctly, it just uses your platform's default sans-serif font.
+The renderer does not load any webfont itself. To get the intended [Inter](https://rsms.me/inter/) typography, provide the font in your own application as described in the [Typography section of the documentation](https://smartforms.csiro.au/docs/dev/renderer-overview#typography).
 
 ---
 

--- a/packages/smart-forms-renderer/README.md
+++ b/packages/smart-forms-renderer/README.md
@@ -11,6 +11,21 @@ View the changelog [here](https://github.com/aehrc/smart-forms/blob/main/CHANGEL
 
 We recently updated to v1.0.0 which includes some breaking changes. Please refer to the [migration guide](https://github.com/aehrc/smart-forms/blob/main/MIGRATION-v1.0.md) for more information.
 
+## Typography
+
+The renderer theme asks for the [Inter](https://rsms.me/inter/) typeface, falling back to the platform's default sans-serif font. The library does not load any webfont itself, so if you want the intended typography, provide Inter in your own application. The simplest way is to self-host it:
+
+```bash
+npm install @fontsource/inter
+```
+
+```ts
+// In your application entrypoint
+import '@fontsource/inter';
+```
+
+Linking a hosted stylesheet or declaring your own `@font-face` works equally well. If Inter is not available the renderer still lays out correctly, it just uses your platform's default sans-serif font.
+
 ---
 
 Copyright © 2025, Commonwealth Scientific and Industrial Research Organisation (CSIRO) ABN 41 687 119 230. All rights reserved.

--- a/packages/smart-forms-renderer/package.json
+++ b/packages/smart-forms-renderer/package.json
@@ -32,7 +32,6 @@
     "@aehrc/sdc-template-extract": "^1.0.15",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
-    "@fontsource/inter": "^5.2.8",
     "@fontsource/material-icons": "^5.2.7",
     "@fontsource/roboto": "^5.2.10",
     "@mui/icons-material": "^7.1.1",
@@ -62,8 +61,14 @@
     "zustand": "^5.0.14"
   },
   "peerDependencies": {
+    "@fontsource/inter": "^5.0.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@fontsource/inter": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@babel/core": "^7.29.6",

--- a/packages/smart-forms-renderer/package.json
+++ b/packages/smart-forms-renderer/package.json
@@ -61,14 +61,8 @@
     "zustand": "^5.0.14"
   },
   "peerDependencies": {
-    "@fontsource/inter": "^5.0.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
-  },
-  "peerDependenciesMeta": {
-    "@fontsource/inter": {
-      "optional": true
-    }
   },
   "devDependencies": {
     "@babel/core": "^7.29.6",

--- a/packages/smart-forms-renderer/src/index.ts
+++ b/packages/smart-forms-renderer/src/index.ts
@@ -1,6 +1,3 @@
-// Import self-host typography Inter font
-import '@fontsource/inter';
-
 // interface exports
 export type {
   Tab,


### PR DESCRIPTION
Fixes #2050

`src/index.ts` opened with `import '@fontsource/inter'`, so importing anything from `@aehrc/smart-forms-renderer` (a store, a type, `buildForm`) loaded a webfont as a side effect, which is meaningless or breaking in React Native, SSR, and node-side populate and extract tooling. The import is removed and the barrel is now side-effect free, a prerequisite for ever declaring `sideEffects: false` or adding an exports map.

Consumer-visible impact: a web consumer that does not provide Inter falls back to the platform sans-serif. Layout is unaffected, only the typeface, but this suits a minor version rather than a patch. The migration is one line, `import '@fontsource/inter'` at the app entry, documented in the Typography section of `documentation/docs/dev/renderer-overview.mdx`; the renderer README points there.

In this repo: `apps/smart-forms-app` self-hosts Inter through its own `@fontsource/inter` import and the `rsms.me` CDN link in `index.html` is removed, leaving one font source. `documentation` imports it in `custom.css` so the live code blocks keep their typography. The renderer itself keeps no reference to the package: an optional peerDependency was considered and dropped as inert, since npm neither installs optional peers nor warns when they are absent.

Testing: renderer and app jest suites match main's baseline, and the renderer, app, and documentation builds are green, with the app bundle still emitting the Inter woff files from its own import.

Known follow-up: the nested `packages/smart-forms-renderer/package-lock.json` still lists `@fontsource/inter`; regenerating it standalone is blocked by a pre-existing storybook ERESOLVE, so it is left for dependabot.
