### PR TITLE
Replace moment with dayjs in sdc-populate

### DIFF
--- a/apps/smart-forms-app/package.json
+++ b/apps/smart-forms-app/package.json
@@ -53,7 +53,6 @@
     "html-react-parser": "4.2.10",
     "lodash.clonedeep": "^4.5.0",
     "material-ui-popup-state": "^5.3.3",
-    "moment": "^2.30.1",
     "monaco-editor": "^0.54.0",
     "nanoid": "^5.1.2",
     "notistack": "^3.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39333,8 +39333,7 @@
         "fhir-sdc-helpers": "^0.1.0",
         "fhirclient": "^2.6.3",
         "fhirpath": "^4.10.1",
-        "js-base64": "^3.7.8",
-        "moment": "^2.30.1"
+        "js-base64": "^3.7.8"
       },
       "devDependencies": {
         "@jest/globals": "^30.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,6 @@
         "html-react-parser": "4.2.10",
         "lodash.clonedeep": "^4.5.0",
         "material-ui-popup-state": "^5.3.3",
-        "moment": "^2.30.1",
         "monaco-editor": "^0.54.0",
         "nanoid": "^5.1.2",
         "notistack": "^3.0.2",
@@ -28260,14 +28259,6 @@
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/monaco-editor": {

--- a/packages/sdc-populate/package.json
+++ b/packages/sdc-populate/package.json
@@ -22,8 +22,7 @@
     "fhir-sdc-helpers": "^0.1.0",
     "fhirclient": "^2.6.3",
     "fhirpath": "^4.10.1",
-    "js-base64": "^3.7.8",
-    "moment": "^2.30.1"
+    "js-base64": "^3.7.8"
   },
   "devDependencies": {
     "@jest/globals": "^30.3.0",

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/constructResponse.test.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/constructResponse.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { describe, expect, it } from '@jest/globals';
-import { checkIsDateTime, checkIsTime, convertDateTimeToDate } from '../utils/constructResponse';
+import { checkIsDateTime, convertDateTimeToDate } from '../utils/constructResponse';
 
 // These tests lock the date versus dateTime discrimination used by parseValueToAnswer() to decide
 // whether a populated answer becomes a valueDate or a valueDateTime. The suite runs with
@@ -125,22 +125,5 @@ describe('convertDateTimeToDate', () => {
 
   it('returns the original value for a time-only value', () => {
     expect(convertDateTimeToDate('10:00:00')).toBe('10:00:00');
-  });
-});
-
-describe('checkIsTime', () => {
-  it('accepts a time, with or without fractional seconds', () => {
-    expect(checkIsTime('00:00:00')).toBe(true);
-    expect(checkIsTime('14:30:45')).toBe(true);
-    expect(checkIsTime('23:59:60')).toBe(true);
-    expect(checkIsTime('14:30:45.123')).toBe(true);
-  });
-
-  it('rejects an out-of-range or malformed time', () => {
-    expect(checkIsTime('24:00:00')).toBe(false);
-    expect(checkIsTime('14:60:00')).toBe(false);
-    expect(checkIsTime('14:30')).toBe(false);
-    expect(checkIsTime('2023-06-15T14:30:45Z')).toBe(false);
-    expect(checkIsTime('')).toBe(false);
   });
 });

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/constructResponse.test.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/constructResponse.test.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2025 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from '@jest/globals';
+import { checkIsDateTime, checkIsTime, convertDateTimeToDate } from '../utils/constructResponse';
+
+// These tests lock the date versus dateTime discrimination used by parseValueToAnswer() to decide
+// whether a populated answer becomes a valueDate or a valueDateTime. The suite runs with
+// TZ=Australia/Sydney (see the package test script), which is why values without an explicit
+// offset resolve against +10:00 or +11:00.
+
+describe('checkIsDateTime', () => {
+  it('accepts a full ISO dateTime with a Z offset', () => {
+    expect(checkIsDateTime('2023-06-15T14:30:45Z')).toBe(true);
+  });
+
+  it('accepts a full ISO dateTime with a numeric offset', () => {
+    expect(checkIsDateTime('2023-06-15T14:30:45+10:00')).toBe(true);
+    expect(checkIsDateTime('2023-06-15T14:30:45-05:00')).toBe(true);
+  });
+
+  it('accepts an ISO dateTime with fractional seconds', () => {
+    expect(checkIsDateTime('2023-06-15T14:30:45.123Z')).toBe(true);
+  });
+
+  it('accepts an ISO dateTime with no offset', () => {
+    expect(checkIsDateTime('2023-06-15T14:30:45')).toBe(true);
+  });
+
+  it('accepts a date', () => {
+    expect(checkIsDateTime('2023-06-15')).toBe(true);
+  });
+
+  it('accepts a bare year-month', () => {
+    expect(checkIsDateTime('2023-06')).toBe(true);
+  });
+
+  it('accepts a bare year', () => {
+    expect(checkIsDateTime('2023')).toBe(true);
+  });
+
+  it('rejects an empty or whitespace-only string', () => {
+    expect(checkIsDateTime('')).toBe(false);
+    expect(checkIsDateTime(' ')).toBe(false);
+  });
+
+  it('rejects a time-only value', () => {
+    expect(checkIsDateTime('10:00:00')).toBe(false);
+    expect(checkIsDateTime('14:30:45')).toBe(false);
+  });
+
+  it('rejects a non-date string', () => {
+    expect(checkIsDateTime('not-a-date')).toBe(false);
+  });
+
+  it('rejects a non-ISO date ordering', () => {
+    expect(checkIsDateTime('15/06/2023')).toBe(false);
+  });
+
+  it('accepts out-of-range date components, which are normalised before the format check', () => {
+    // The value is normalised by dayjs before being checked, so an overflowing month or day rolls
+    // over rather than failing. Locked in as existing behaviour, not as a recommendation.
+    expect(checkIsDateTime('2023-13-01')).toBe(true);
+    expect(checkIsDateTime('2023-01-32')).toBe(true);
+    expect(checkIsDateTime('2023-02-29')).toBe(true);
+    expect(checkIsDateTime('2024-02-29')).toBe(true);
+  });
+});
+
+describe('convertDateTimeToDate', () => {
+  it('converts a full ISO dateTime with a Z offset to a local date', () => {
+    // 14:30:45Z is 2023-06-16 in Australia/Sydney.
+    expect(convertDateTimeToDate('2023-06-15T14:30:45Z')).toBe('2023-06-16');
+  });
+
+  it('converts a full ISO dateTime with a numeric offset to a local date', () => {
+    expect(convertDateTimeToDate('2023-06-15T14:30:45+10:00')).toBe('2023-06-15');
+    expect(convertDateTimeToDate('2023-06-15T14:30:45-05:00')).toBe('2023-06-16');
+  });
+
+  it('converts an ISO dateTime with fractional seconds', () => {
+    expect(convertDateTimeToDate('2023-06-15T14:30:45.123Z')).toBe('2023-06-16');
+  });
+
+  it('converts an ISO dateTime with no offset', () => {
+    expect(convertDateTimeToDate('2023-06-15T14:30:45')).toBe('2023-06-15');
+  });
+
+  it('applies the offset when it crosses a year boundary', () => {
+    expect(convertDateTimeToDate('2023-12-31T23:59:59+10:00')).toBe('2024-01-01');
+  });
+
+  it('expands a date to a full date', () => {
+    expect(convertDateTimeToDate('2023-06-15')).toBe('2023-06-15');
+  });
+
+  it('expands a bare year-month to the first of the month', () => {
+    expect(convertDateTimeToDate('2023-06')).toBe('2023-06-01');
+  });
+
+  it('expands a bare year to the first of January', () => {
+    expect(convertDateTimeToDate('2023')).toBe('2023-01-01');
+  });
+
+  it('returns the original value when it is not parseable', () => {
+    expect(convertDateTimeToDate('')).toBe('');
+    expect(convertDateTimeToDate(' ')).toBe(' ');
+    expect(convertDateTimeToDate('not-a-date')).toBe('not-a-date');
+    expect(convertDateTimeToDate('15/06/2023')).toBe('15/06/2023');
+  });
+
+  it('returns the original value for a time-only value', () => {
+    expect(convertDateTimeToDate('10:00:00')).toBe('10:00:00');
+  });
+});
+
+describe('checkIsTime', () => {
+  it('accepts a time, with or without fractional seconds', () => {
+    expect(checkIsTime('00:00:00')).toBe(true);
+    expect(checkIsTime('14:30:45')).toBe(true);
+    expect(checkIsTime('23:59:60')).toBe(true);
+    expect(checkIsTime('14:30:45.123')).toBe(true);
+  });
+
+  it('rejects an out-of-range or malformed time', () => {
+    expect(checkIsTime('24:00:00')).toBe(false);
+    expect(checkIsTime('14:60:00')).toBe(false);
+    expect(checkIsTime('14:30')).toBe(false);
+    expect(checkIsTime('2023-06-15T14:30:45Z')).toBe(false);
+    expect(checkIsTime('')).toBe(false);
+  });
+});

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/constructResponse.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/constructResponse.ts
@@ -33,8 +33,8 @@ import type {
   ValueSetPromise
 } from '../interfaces/expressions.interface';
 import { filterValueSetAnswersRecursive, resolveValueSetPromises } from './processValueSets';
-import moment from 'moment';
 import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
 import fhirpath from 'fhirpath';
 // Need to specifically import from 'index.js' to get it working with ts
 import fhirpath_r4_model from 'fhirpath/fhir-context/r4/index.js';
@@ -50,6 +50,11 @@ import type {
 import { handleFhirPathResult } from './createFhirPathContext';
 import { TERMINOLOGY_SERVER_URL } from '../../globals';
 import { getDisplayName } from './humanName';
+
+// Required by checkIsDateTime() and convertDateTimeToDate() for strict parsing against a list of
+// accepted formats. Without this plugin, dayjs ignores the format argument and falls back to a
+// lenient parse.
+dayjs.extend(customParseFormat);
 
 /**
  * Constructs a questionnaireResponse recursively from a specified questionnaire, its subject and its initialExpressions.
@@ -517,16 +522,16 @@ function getAnswerValues(
 export function checkIsDateTime(value: string): boolean {
   const acceptedFormats = ['YYYY', 'YYYY-MM', 'YYYY-MM-DD', 'YYYY-MM-DDTHH:mm:ssZ'];
   const formattedDate = dayjs(value).format();
-  return moment(formattedDate, acceptedFormats, true).isValid();
+  return dayjs(formattedDate, acceptedFormats, true).isValid();
 }
 
 export function convertDateTimeToDate(value: string): string {
   const acceptedFormats = ['YYYY-MM-DDTHH:mm:ssZ'];
   const formattedDate = dayjs(value).format();
-  const isDateTime = moment(formattedDate, acceptedFormats, true).isValid();
+  const isDateTime = dayjs(formattedDate, acceptedFormats, true).isValid();
 
   if (isDateTime) {
-    return moment(formattedDate).format('YYYY-MM-DD');
+    return dayjs(formattedDate).format('YYYY-MM-DD');
   }
 
   return value;


### PR DESCRIPTION
Fixes #2052

`moment` was used in exactly three places, all inside `checkIsDateTime` and `convertDateTimeToDate` in `constructResponse.ts`, and `dayjs` was already imported by the same file. The three calls now use `dayjs`, `moment` is removed from `packages/sdc-populate` and from `apps/smart-forms-app` (which listed it without importing it), and the root lockfile is regenerated. `moment` is in maintenance mode and was the heaviest dependency in the populate chain (5.2 MB installed versus 1.9 MB for `dayjs`), so this removes a dependency rather than swapping one for another.

The module extends `dayjs` with the `customParseFormat` plugin locally: strict parsing against a format list silently degrades to lenient parsing without it.

Why a dependency swap ships a test file: `checkIsDateTime` decides whether a populated answer becomes `valueDate` or `valueDateTime`, and moment and dayjs strict parsing are not identical in general. The new `constructResponse.test.ts` locks that discrimination across offsets, fractional seconds, out-of-range components, and non-ISO orderings. The file passes identically against the old `moment` implementation and the new `dayjs` one, with the test run pinned to `TZ=Australia/Sydney`.

Testing: full `sdc-populate` suite green (20 suites, 185 tests) and the renderer consumer suite green.

Follow-up, not in this PR: `smart-forms-renderer` carries an identical `checkIsDateTime` in `calculatedExpression.ts`; consolidating the two copies is a separate change.
