### PR TITLE
Make the terminology transport injectable

### DIFF
--- a/documentation/docs/dev/storehooks/terminology-server-store/index.mdx
+++ b/documentation/docs/dev/storehooks/terminology-server-store/index.mdx
@@ -7,6 +7,8 @@ sidebar_position: 5
 The TerminologyServerStore exposes the following properties:
 
 - **url**
+- **fetchTerminologyCallback**
+- **requestTimeoutMs**
 
 Here's how you use the store hook in your React functional component:
 
@@ -23,5 +25,45 @@ function App() {
 ```
 
 There are some live examples on the following pages that demonstrate how to use the hooks.
+
+## Supplying your own terminology transport
+
+By default the renderer makes its terminology requests (`ValueSet/$expand`, `ValueSet/$validate-code`
+and `CodeSystem/$lookup`) with the built-in [fhirclient](https://github.com/smart-on-fhir/client-js)
+transport, which needs a browser `fetch`. If you are hosting the renderer somewhere that cannot use it,
+React Native for example, or you need to add authentication headers or your own caching, supply a
+`fetchTerminologyCallback` once at startup and every terminology request will go through it instead:
+
+```ts
+import { terminologyServerStore } from '@aehrc/smart-forms-renderer';
+import type { FetchTerminologyCallback } from '@aehrc/smart-forms-renderer';
+
+const fetchTerminologyCallback: FetchTerminologyCallback = async (query, requestConfig) => {
+  const { terminologyServerUrl } = requestConfig;
+  const baseUrl = terminologyServerUrl.endsWith('/')
+    ? terminologyServerUrl
+    : `${terminologyServerUrl}/`;
+
+  const response = await myHttpClient.get(`${baseUrl}${query}`);
+  return response.json();
+};
+
+terminologyServerStore.getState().setRequestOptions({
+  fetchTerminologyCallback,
+  requestTimeoutMs: 20000
+});
+```
+
+`query` is the request relative to the terminology server, for example
+`ValueSet/$expand?url=http://example.com/ValueSet/test`, and the callback must resolve with the parsed
+JSON body and reject on a transport or HTTP error. This is the same callback shape
+`@aehrc/sdc-populate`'s `populateQuestionnaire()` accepts, so one implementation can serve both.
+
+`requestTimeoutMs` sets how long a single terminology request may take before it is abandoned, which
+defaults to 5000. Raise it for slower networks such as mobile.
+
+Both options are optional and independent: leaving `fetchTerminologyCallback` unset keeps the built-in
+transport. `setRequestOptions()` only changes the options you pass, and `resetRequestOptions()` puts
+both back to their defaults.
 
 Refer to the [API Reference](/docs/api/smart-forms-renderer/interfaces/TerminologyServerStoreType) for more information on each property.

--- a/documentation/docs/dev/storehooks/terminology-server-store/index.mdx
+++ b/documentation/docs/dev/storehooks/terminology-server-store/index.mdx
@@ -59,11 +59,14 @@ terminologyServerStore.getState().setRequestOptions({
 JSON body and reject on a transport or HTTP error. This is the same callback shape
 `@aehrc/sdc-populate`'s `populateQuestionnaire()` accepts, so one implementation can serve both.
 
-`requestTimeoutMs` sets how long a single terminology request may take before it is abandoned, which
-defaults to 5000. Raise it for slower networks such as mobile.
+`requestTimeoutMs` sets how long a value set expansion may take during form build before it is
+abandoned, which defaults to 5000. It applies only to the batch `$expand` of `answerValueSet`
+bindings; `$validate-code` and `CodeSystem/$lookup` are not timed. Raise it for slower networks such
+as mobile.
 
 Both options are optional and independent: leaving `fetchTerminologyCallback` unset keeps the built-in
 transport. `setRequestOptions()` only changes the options you pass, and `resetRequestOptions()` puts
-both back to their defaults.
+both back to their defaults. Unlike the terminology server URL, which `buildForm()` resets on every
+build, these options persist across `buildForm()` calls, so set them once at startup.
 
 Refer to the [API Reference](/docs/api/smart-forms-renderer/interfaces/TerminologyServerStoreType) for more information on each property.

--- a/packages/smart-forms-renderer/src/components/FormComponents/ItemParts/ItemRepopulateButton.tsx
+++ b/packages/smart-forms-renderer/src/components/FormComponents/ItemParts/ItemRepopulateButton.tsx
@@ -50,6 +50,7 @@ function ItemRepopulateButton(props: ItemRepopulateButtonProps) {
   const fhirContext = useSmartConfigStore.use.fhirContext();
 
   const defaultTerminologyServerUrl = useTerminologyServerStore.use.url();
+  const injectedFetchTerminologyCallback = useTerminologyServerStore.use.fetchTerminologyCallback();
 
   const sourceQuestionnaire = useQuestionnaireStore.use.sourceQuestionnaire();
 
@@ -88,7 +89,7 @@ function ItemRepopulateButton(props: ItemRepopulateButtonProps) {
       user: user,
       encounter: encounter ?? undefined,
       fhirContext: fhirContext ?? undefined,
-      fetchTerminologyCallback: fetchTerminologyCallback,
+      fetchTerminologyCallback: injectedFetchTerminologyCallback ?? fetchTerminologyCallback,
       fetchTerminologyRequestConfig: {
         terminologyServerUrl: defaultTerminologyServerUrl
       }

--- a/packages/smart-forms-renderer/src/globals.ts
+++ b/packages/smart-forms-renderer/src/globals.ts
@@ -16,3 +16,7 @@
  */
 
 export const TERMINOLOGY_SERVER_URL = 'https://tx.ontoserver.csiro.au/fhir';
+
+// How long a single terminology request is allowed to take before it is abandoned.
+// Overridable via terminologyServerStore.setRequestOptions({ requestTimeoutMs }).
+export const TERMINOLOGY_REQUEST_TIMEOUT_MS = 5000;

--- a/packages/smart-forms-renderer/src/globals.ts
+++ b/packages/smart-forms-renderer/src/globals.ts
@@ -17,6 +17,8 @@
 
 export const TERMINOLOGY_SERVER_URL = 'https://tx.ontoserver.csiro.au/fhir';
 
-// How long a single terminology request is allowed to take before it is abandoned.
+// How long a value set expansion may take during form build before it is abandoned. This
+// currently applies only to the batch $expand of answerValueSet bindings in
+// resolveValueSetPromises(); other terminology calls have no timeout.
 // Overridable via terminologyServerStore.setRequestOptions({ requestTimeoutMs }).
 export const TERMINOLOGY_REQUEST_TIMEOUT_MS = 5000;

--- a/packages/smart-forms-renderer/src/index.ts
+++ b/packages/smart-forms-renderer/src/index.ts
@@ -36,12 +36,18 @@ export {
   QuestionnaireTitleText
 } from './components';
 
+// terminology transport exports
+// Re-exported from '@aehrc/sdc-populate' so a consumer can type a terminology transport for the
+// renderer without depending on that package directly. The same callback works for both.
+export type { FetchTerminologyCallback, FetchTerminologyRequestConfig } from '@aehrc/sdc-populate';
+
 // state management store exports
 export type {
   QuestionnaireStoreType,
   QuestionnaireResponseStoreType,
   SmartConfigStoreType,
   TerminologyServerStoreType,
+  TerminologyRequestOptions,
   RendererConfig,
   RendererConfigStoreType
 } from './stores';

--- a/packages/smart-forms-renderer/src/stores/index.ts
+++ b/packages/smart-forms-renderer/src/stores/index.ts
@@ -10,7 +10,10 @@ export type { QuestionnaireResponseStoreType } from './questionnaireResponseStor
 
 export type { SmartConfigStoreType } from './smartConfigStore';
 
-export type { TerminologyServerStoreType } from './terminologyServerStore';
+export type {
+  TerminologyRequestOptions,
+  TerminologyServerStoreType
+} from './terminologyServerStore';
 
 export type { RendererConfig, RendererConfigStoreType } from './rendererConfigStore';
 

--- a/packages/smart-forms-renderer/src/stores/terminologyServerStore.ts
+++ b/packages/smart-forms-renderer/src/stores/terminologyServerStore.ts
@@ -47,7 +47,9 @@ export interface TerminologyRequestOptions {
 /**
  * TerminologyServerStore properties and methods
  * Properties can be accessed for fine-grain details.
- * Methods are usually used internally, using them from an external source is not recommended.
+ * Methods are usually used internally. The exceptions are `setUrl` and `setRequestOptions`
+ * (with their reset counterparts), which are the supported public entry points for configuring
+ * the terminology server URL and the terminology transport.
  *
  * @property url - The current terminology server URL
  * @property fetchTerminologyCallback - The injected terminology transport, or `null` to use the built-in `fhirclient` one

--- a/packages/smart-forms-renderer/src/stores/terminologyServerStore.ts
+++ b/packages/smart-forms-renderer/src/stores/terminologyServerStore.ts
@@ -34,7 +34,9 @@ import type { FetchTerminologyCallback } from '@aehrc/sdc-populate';
  *   parsed JSON body of the response, and reject on a transport or HTTP error.
  *   This is the same callback shape `@aehrc/sdc-populate` accepts, so one implementation can serve both.
  *
- * @property requestTimeoutMs - How long a single terminology request may take before it is abandoned.
+ * @property requestTimeoutMs - How long a value set expansion may take during form build before it
+ *   is abandoned. Applies only to the batch `$expand` of `answerValueSet` bindings; `$validate-code`
+ *   and `CodeSystem/$lookup` are not timed.
  *   - Default: `5000`
  */
 export interface TerminologyRequestOptions {
@@ -49,7 +51,7 @@ export interface TerminologyRequestOptions {
  *
  * @property url - The current terminology server URL
  * @property fetchTerminologyCallback - The injected terminology transport, or `null` to use the built-in `fhirclient` one
- * @property requestTimeoutMs - The timeout applied to a single terminology request, in milliseconds
+ * @property requestTimeoutMs - The timeout applied to build-time batch value set expansion, in milliseconds
  * @property setUrl - Set the terminology server URL
  * @property resetUrl - Reset the terminology server URL to the default
  * @property setRequestOptions - Set one or more terminology request options, leaving the rest untouched

--- a/packages/smart-forms-renderer/src/stores/terminologyServerStore.ts
+++ b/packages/smart-forms-renderer/src/stores/terminologyServerStore.ts
@@ -17,7 +17,30 @@
 
 import { createStore } from 'zustand/vanilla';
 import { createSelectors } from './selector';
-import { TERMINOLOGY_SERVER_URL } from '../globals';
+import { TERMINOLOGY_REQUEST_TIMEOUT_MS, TERMINOLOGY_SERVER_URL } from '../globals';
+import type { FetchTerminologyCallback } from '@aehrc/sdc-populate';
+
+/**
+ * Options that control how the renderer talks to a terminology server.
+ * Every property is optional, anything left out keeps its current value.
+ *
+ * @property fetchTerminologyCallback - Transport used for every terminology request the renderer makes
+ *   (`ValueSet/$expand`, `ValueSet/$validate-code` and `CodeSystem/$lookup`).
+ *   Leave this unset (or `null`) to use the built-in `fhirclient` transport, which is the default.
+ *   Supply a callback to route terminology traffic through your own HTTP client, which is what
+ *   non-browser hosts such as React Native need. The callback is given the request as a query string
+ *   relative to the terminology server, e.g. `ValueSet/$expand?url=...`, plus a request config
+ *   carrying the `terminologyServerUrl` the renderer resolved for that call. It must resolve with the
+ *   parsed JSON body of the response, and reject on a transport or HTTP error.
+ *   This is the same callback shape `@aehrc/sdc-populate` accepts, so one implementation can serve both.
+ *
+ * @property requestTimeoutMs - How long a single terminology request may take before it is abandoned.
+ *   - Default: `5000`
+ */
+export interface TerminologyRequestOptions {
+  fetchTerminologyCallback?: FetchTerminologyCallback | null;
+  requestTimeoutMs?: number;
+}
 
 /**
  * TerminologyServerStore properties and methods
@@ -25,15 +48,23 @@ import { TERMINOLOGY_SERVER_URL } from '../globals';
  * Methods are usually used internally, using them from an external source is not recommended.
  *
  * @property url - The current terminology server URL
+ * @property fetchTerminologyCallback - The injected terminology transport, or `null` to use the built-in `fhirclient` one
+ * @property requestTimeoutMs - The timeout applied to a single terminology request, in milliseconds
  * @property setUrl - Set the terminology server URL
  * @property resetUrl - Reset the terminology server URL to the default
+ * @property setRequestOptions - Set one or more terminology request options, leaving the rest untouched
+ * @property resetRequestOptions - Reset every terminology request option to its default
  *
  * @author Sean Fong
  */
 export interface TerminologyServerStoreType {
   url: string;
+  fetchTerminologyCallback: FetchTerminologyCallback | null;
+  requestTimeoutMs: number;
   setUrl: (newUrl: string) => void;
   resetUrl: () => void;
+  setRequestOptions: (options: TerminologyRequestOptions) => void;
+  resetRequestOptions: () => void;
 }
 
 /**
@@ -46,8 +77,23 @@ export interface TerminologyServerStoreType {
  */
 export const terminologyServerStore = createStore<TerminologyServerStoreType>()((set) => ({
   url: TERMINOLOGY_SERVER_URL,
+  fetchTerminologyCallback: null,
+  requestTimeoutMs: TERMINOLOGY_REQUEST_TIMEOUT_MS,
   setUrl: (newUrl: string) => set(() => ({ url: newUrl })),
-  resetUrl: () => set(() => ({ url: TERMINOLOGY_SERVER_URL }))
+  resetUrl: () => set(() => ({ url: TERMINOLOGY_SERVER_URL })),
+  setRequestOptions: (options: TerminologyRequestOptions) =>
+    set((state) => ({
+      fetchTerminologyCallback:
+        options.fetchTerminologyCallback === undefined
+          ? state.fetchTerminologyCallback
+          : options.fetchTerminologyCallback,
+      requestTimeoutMs: options.requestTimeoutMs ?? state.requestTimeoutMs
+    })),
+  resetRequestOptions: () =>
+    set(() => ({
+      fetchTerminologyCallback: null,
+      requestTimeoutMs: TERMINOLOGY_REQUEST_TIMEOUT_MS
+    }))
 }));
 
 /**

--- a/packages/smart-forms-renderer/src/test/terminologyRequest.test.ts
+++ b/packages/smart-forms-renderer/src/test/terminologyRequest.test.ts
@@ -1,0 +1,328 @@
+/*
+ * Copyright 2025 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import type { FetchTerminologyCallback } from '@aehrc/sdc-populate';
+import type { ValueSet } from 'fhir/r4';
+import type { ValueSetPromise } from '../interfaces/valueSet.interface';
+
+// Mock the fhirclient, which is the built-in default transport
+jest.mock('fhirclient', () => ({
+  client: jest.fn()
+}));
+
+import { client } from 'fhirclient';
+import { TERMINOLOGY_REQUEST_TIMEOUT_MS } from '../globals';
+import { terminologyServerStore } from '../stores/terminologyServerStore';
+import { getTerminologyRequestTimeoutMs, terminologyRequest } from '../utils/terminologyRequest';
+import {
+  getValueSetPromise,
+  resolveValueSetPromises,
+  validateCodePromise
+} from '../utils/valueSet';
+import { getCodeSystemLookupPromise } from '../utils/questionnaireStoreUtils/addDisplayToCodings';
+
+const mockClient = client as jest.MockedFunction<typeof client>;
+
+const TERMINOLOGY_SERVER_URL = 'https://tx.fhir.org/r4';
+
+/**
+ * Wires up the built-in fhirclient transport to resolve with the given response,
+ * and returns the mocked request function so its arguments can be asserted.
+ */
+function mockFhirClientResponse(response: unknown) {
+  const mockRequest = jest.fn() as jest.MockedFunction<any>;
+  mockRequest.mockResolvedValue(response);
+  mockClient.mockReturnValue({ request: mockRequest } as any);
+  return mockRequest;
+}
+
+function injectTerminologyCallback(response: unknown) {
+  const fetchTerminologyCallback = jest.fn(() =>
+    Promise.resolve(response)
+  ) as jest.MockedFunction<FetchTerminologyCallback>;
+  terminologyServerStore.getState().setRequestOptions({ fetchTerminologyCallback });
+  return fetchTerminologyCallback;
+}
+
+describe('terminologyRequest', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    terminologyServerStore.getState().resetRequestOptions();
+  });
+
+  describe('default transport', () => {
+    it('should use the built-in fhirclient transport when no callback is injected', async () => {
+      const mockResponse = { resourceType: 'ValueSet', status: 'active' };
+      const mockRequest = mockFhirClientResponse(mockResponse);
+
+      const result = await terminologyRequest(
+        'ValueSet/$expand?url=http://example.com/ValueSet/test',
+        TERMINOLOGY_SERVER_URL
+      );
+
+      expect(mockClient).toHaveBeenCalledWith({ serverUrl: TERMINOLOGY_SERVER_URL });
+      expect(mockRequest).toHaveBeenCalledWith({
+        url: 'ValueSet/$expand?url=http://example.com/ValueSet/test'
+      });
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should default fetchTerminologyCallback to null', () => {
+      expect(terminologyServerStore.getState().fetchTerminologyCallback).toBeNull();
+    });
+
+    it('should fall back to the built-in transport when the injected callback is set back to null', async () => {
+      const fetchTerminologyCallback = injectTerminologyCallback({ resourceType: 'ValueSet' });
+      terminologyServerStore.getState().setRequestOptions({ fetchTerminologyCallback: null });
+
+      const mockRequest = mockFhirClientResponse({ resourceType: 'ValueSet' });
+      await terminologyRequest('ValueSet/$expand?url=x', TERMINOLOGY_SERVER_URL);
+
+      expect(fetchTerminologyCallback).not.toHaveBeenCalled();
+      expect(mockRequest).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('injected transport', () => {
+    it('should call the injected callback with the query and the resolved terminology server url', async () => {
+      const mockResponse = { resourceType: 'ValueSet', status: 'active' };
+      const fetchTerminologyCallback = injectTerminologyCallback(mockResponse);
+
+      const result = await terminologyRequest(
+        'ValueSet/$expand?url=http://example.com/ValueSet/test',
+        TERMINOLOGY_SERVER_URL
+      );
+
+      expect(fetchTerminologyCallback).toHaveBeenCalledWith(
+        'ValueSet/$expand?url=http://example.com/ValueSet/test',
+        { terminologyServerUrl: TERMINOLOGY_SERVER_URL }
+      );
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should not touch the fhirclient transport when a callback is injected', async () => {
+      injectTerminologyCallback({ resourceType: 'ValueSet' });
+
+      await terminologyRequest('ValueSet/$expand?url=x', TERMINOLOGY_SERVER_URL);
+
+      expect(mockClient).not.toHaveBeenCalled();
+    });
+
+    it('should propagate a rejection from the injected callback', async () => {
+      const fetchTerminologyCallback = jest.fn(() =>
+        Promise.reject(new Error('Transport unavailable'))
+      ) as jest.MockedFunction<FetchTerminologyCallback>;
+      terminologyServerStore.getState().setRequestOptions({ fetchTerminologyCallback });
+
+      await expect(
+        terminologyRequest('ValueSet/$expand?url=x', TERMINOLOGY_SERVER_URL)
+      ).rejects.toThrow('Transport unavailable');
+    });
+  });
+
+  describe('call sites', () => {
+    it('should route getValueSetPromise through the injected callback', async () => {
+      const mockValueSet: ValueSet = { resourceType: 'ValueSet', status: 'active', id: 'vs-1' };
+      const fetchTerminologyCallback = injectTerminologyCallback(mockValueSet);
+
+      const result = await getValueSetPromise(
+        'http://example.com/ValueSet/test',
+        TERMINOLOGY_SERVER_URL
+      );
+
+      expect(fetchTerminologyCallback).toHaveBeenCalledWith(
+        'ValueSet/$expand?url=http://example.com/ValueSet/test',
+        { terminologyServerUrl: TERMINOLOGY_SERVER_URL }
+      );
+      expect(mockClient).not.toHaveBeenCalled();
+      expect(result).toEqual(mockValueSet);
+    });
+
+    it('should route getValueSetPromise through the injected callback for an embedded $expand url', async () => {
+      const fetchTerminologyCallback = injectTerminologyCallback({
+        resourceType: 'ValueSet',
+        status: 'active'
+      });
+
+      await getValueSetPromise(
+        'https://tx.ontoserver.csiro.au/fhir/ValueSet/$expand?url=http://example.com/ValueSet/test',
+        TERMINOLOGY_SERVER_URL
+      );
+
+      expect(fetchTerminologyCallback).toHaveBeenCalledWith(
+        'ValueSet/$expand?url=http://example.com/ValueSet/test',
+        { terminologyServerUrl: 'https://tx.ontoserver.csiro.au/fhir/' }
+      );
+    });
+
+    it('should route validateCodePromise through the injected callback', async () => {
+      const mockValidateCodeResponse = {
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'code', valueCode: 'mg' },
+          { name: 'system', valueUri: 'http://unitsofmeasure.org' },
+          { name: 'display', valueString: 'milligram' }
+        ]
+      };
+      const fetchTerminologyCallback = injectTerminologyCallback(mockValidateCodeResponse);
+
+      const result = await validateCodePromise(
+        'http://hl7.org/fhir/ValueSet/ucum-units',
+        'http://unitsofmeasure.org',
+        'mg',
+        TERMINOLOGY_SERVER_URL
+      );
+
+      expect(fetchTerminologyCallback).toHaveBeenCalledWith(
+        'ValueSet/$validate-code?url=http://hl7.org/fhir/ValueSet/ucum-units&system=http://unitsofmeasure.org&code=mg',
+        { terminologyServerUrl: TERMINOLOGY_SERVER_URL }
+      );
+      expect(mockClient).not.toHaveBeenCalled();
+      expect(result).toEqual(mockValidateCodeResponse);
+    });
+
+    it('should route getCodeSystemLookupPromise through the injected callback', async () => {
+      const mockLookupResponse = {
+        resourceType: 'Parameters',
+        parameter: [{ name: 'display', valueString: 'Diabetes mellitus' }]
+      };
+      const fetchTerminologyCallback = injectTerminologyCallback(mockLookupResponse);
+
+      const result = await getCodeSystemLookupPromise(
+        'system=http://snomed.info/sct&code=73211009',
+        TERMINOLOGY_SERVER_URL
+      );
+
+      expect(fetchTerminologyCallback).toHaveBeenCalledWith(
+        'CodeSystem/$lookup?system=http://snomed.info/sct&code=73211009',
+        { terminologyServerUrl: TERMINOLOGY_SERVER_URL }
+      );
+      expect(mockClient).not.toHaveBeenCalled();
+      expect(result).toEqual(mockLookupResponse);
+    });
+
+    it('should keep using the fhirclient transport at every call site by default', async () => {
+      const mockRequest = mockFhirClientResponse({ resourceType: 'ValueSet', status: 'active' });
+
+      await getValueSetPromise('http://example.com/ValueSet/test', TERMINOLOGY_SERVER_URL);
+      await validateCodePromise(
+        'http://hl7.org/fhir/ValueSet/ucum-units',
+        'http://unitsofmeasure.org',
+        'mg',
+        TERMINOLOGY_SERVER_URL
+      );
+      await getCodeSystemLookupPromise(
+        'system=http://snomed.info/sct&code=73211009',
+        TERMINOLOGY_SERVER_URL
+      );
+
+      expect(mockClient).toHaveBeenCalledTimes(3);
+      expect(mockRequest).toHaveBeenNthCalledWith(1, {
+        url: 'ValueSet/$expand?url=http://example.com/ValueSet/test'
+      });
+      expect(mockRequest).toHaveBeenNthCalledWith(2, {
+        url: 'ValueSet/$validate-code?url=http://hl7.org/fhir/ValueSet/ucum-units&system=http://unitsofmeasure.org&code=mg'
+      });
+      expect(mockRequest).toHaveBeenNthCalledWith(3, {
+        url: 'CodeSystem/$lookup?system=http://snomed.info/sct&code=73211009'
+      });
+    });
+  });
+
+  describe('requestTimeoutMs', () => {
+    it('should default to 5000 milliseconds', () => {
+      expect(TERMINOLOGY_REQUEST_TIMEOUT_MS).toBe(5000);
+      expect(getTerminologyRequestTimeoutMs()).toBe(5000);
+    });
+
+    it('should return the configured timeout', () => {
+      terminologyServerStore.getState().setRequestOptions({ requestTimeoutMs: 30000 });
+      expect(getTerminologyRequestTimeoutMs()).toBe(30000);
+    });
+
+    it('should abandon a value set that takes longer than the configured timeout', async () => {
+      terminologyServerStore.getState().setRequestOptions({ requestTimeoutMs: 10 });
+
+      const valueSetPromises: Record<string, ValueSetPromise> = {
+        slow: {
+          promise: new Promise<ValueSet>((resolve) => {
+            setTimeout(() => resolve({ resourceType: 'ValueSet', status: 'active' }), 200);
+          })
+        }
+      };
+
+      const result = await resolveValueSetPromises(valueSetPromises);
+
+      expect(result['slow']).toBeUndefined();
+    });
+
+    it('should keep a value set that resolves within the configured timeout', async () => {
+      terminologyServerStore.getState().setRequestOptions({ requestTimeoutMs: 500 });
+
+      const mockValueSet: ValueSet = { resourceType: 'ValueSet', status: 'active', id: 'vs-1' };
+      const valueSetPromises: Record<string, ValueSetPromise> = {
+        slow: {
+          promise: new Promise<ValueSet>((resolve) => {
+            setTimeout(() => resolve(mockValueSet), 50);
+          })
+        }
+      };
+
+      const result = await resolveValueSetPromises(valueSetPromises);
+
+      expect(result['slow'].valueSet).toEqual(mockValueSet);
+    });
+  });
+
+  describe('setRequestOptions and resetRequestOptions', () => {
+    it('should leave the other options untouched when only one is set', () => {
+      const fetchTerminologyCallback = injectTerminologyCallback({ resourceType: 'ValueSet' });
+
+      terminologyServerStore.getState().setRequestOptions({ requestTimeoutMs: 20000 });
+
+      expect(terminologyServerStore.getState().fetchTerminologyCallback).toBe(
+        fetchTerminologyCallback
+      );
+      expect(terminologyServerStore.getState().requestTimeoutMs).toBe(20000);
+    });
+
+    it('should leave the terminology server url untouched', () => {
+      terminologyServerStore.getState().setUrl('https://example.com/fhir');
+      terminologyServerStore.getState().setRequestOptions({ requestTimeoutMs: 20000 });
+
+      expect(terminologyServerStore.getState().url).toBe('https://example.com/fhir');
+
+      terminologyServerStore.getState().resetUrl();
+    });
+
+    it('should restore every option to its default', () => {
+      injectTerminologyCallback({ resourceType: 'ValueSet' });
+      terminologyServerStore.getState().setRequestOptions({ requestTimeoutMs: 20000 });
+
+      terminologyServerStore.getState().resetRequestOptions();
+
+      expect(terminologyServerStore.getState().fetchTerminologyCallback).toBeNull();
+      expect(terminologyServerStore.getState().requestTimeoutMs).toBe(
+        TERMINOLOGY_REQUEST_TIMEOUT_MS
+      );
+    });
+  });
+});

--- a/packages/smart-forms-renderer/src/test/terminologyRequest.test.ts
+++ b/packages/smart-forms-renderer/src/test/terminologyRequest.test.ts
@@ -85,10 +85,6 @@ describe('terminologyRequest', () => {
       expect(result).toEqual(mockResponse);
     });
 
-    it('should default fetchTerminologyCallback to null', () => {
-      expect(terminologyServerStore.getState().fetchTerminologyCallback).toBeNull();
-    });
-
     it('should fall back to the built-in transport when the injected callback is set back to null', async () => {
       const fetchTerminologyCallback = injectTerminologyCallback({ resourceType: 'ValueSet' });
       terminologyServerStore.getState().setRequestOptions({ fetchTerminologyCallback: null });
@@ -248,9 +244,8 @@ describe('terminologyRequest', () => {
   });
 
   describe('requestTimeoutMs', () => {
-    it('should default to 5000 milliseconds', () => {
-      expect(TERMINOLOGY_REQUEST_TIMEOUT_MS).toBe(5000);
-      expect(getTerminologyRequestTimeoutMs()).toBe(5000);
+    afterEach(() => {
+      jest.useRealTimers();
     });
 
     it('should return the configured timeout', () => {
@@ -259,7 +254,8 @@ describe('terminologyRequest', () => {
     });
 
     it('should abandon a value set that takes longer than the configured timeout', async () => {
-      terminologyServerStore.getState().setRequestOptions({ requestTimeoutMs: 10 });
+      jest.useFakeTimers();
+      terminologyServerStore.getState().setRequestOptions({ requestTimeoutMs: 100 });
 
       const valueSetPromises: Record<string, ValueSetPromise> = {
         slow: {
@@ -269,12 +265,15 @@ describe('terminologyRequest', () => {
         }
       };
 
-      const result = await resolveValueSetPromises(valueSetPromises);
+      const resultPromise = resolveValueSetPromises(valueSetPromises);
+      await jest.advanceTimersByTimeAsync(200);
+      const result = await resultPromise;
 
       expect(result['slow']).toBeUndefined();
     });
 
     it('should keep a value set that resolves within the configured timeout', async () => {
+      jest.useFakeTimers();
       terminologyServerStore.getState().setRequestOptions({ requestTimeoutMs: 500 });
 
       const mockValueSet: ValueSet = { resourceType: 'ValueSet', status: 'active', id: 'vs-1' };
@@ -286,7 +285,9 @@ describe('terminologyRequest', () => {
         }
       };
 
-      const result = await resolveValueSetPromises(valueSetPromises);
+      const resultPromise = resolveValueSetPromises(valueSetPromises);
+      await jest.advanceTimersByTimeAsync(500);
+      const result = await resultPromise;
 
       expect(result['slow'].valueSet).toEqual(mockValueSet);
     });

--- a/packages/smart-forms-renderer/src/utils/questionnaireStoreUtils/addDisplayToCodings.ts
+++ b/packages/smart-forms-renderer/src/utils/questionnaireStoreUtils/addDisplayToCodings.ts
@@ -17,7 +17,7 @@
 
 import type { Coding, QuestionnaireItemAnswerOption } from 'fhir/r4';
 import type { CodeSystemLookupPromise } from '../../interfaces/lookup.interface';
-import { client } from 'fhirclient';
+import { terminologyRequest } from '../terminologyRequest';
 
 // Use this for QuestionnaireStore.cachedValueSetCodings
 export async function addDisplayToCacheCodings(
@@ -125,9 +125,7 @@ export async function addDisplayToCodingArray(
 }
 
 export function getCodeSystemLookupPromise(query: string, terminologyServerUrl: string) {
-  return client({ serverUrl: terminologyServerUrl }).request({
-    url: `CodeSystem/$lookup?${query}`
-  });
+  return terminologyRequest(`CodeSystem/$lookup?${query}`, terminologyServerUrl);
 }
 
 export async function resolveLookupPromises(

--- a/packages/smart-forms-renderer/src/utils/terminologyRequest.ts
+++ b/packages/smart-forms-renderer/src/utils/terminologyRequest.ts
@@ -44,7 +44,9 @@ export function terminologyRequest(query: string, terminologyServerUrl: string):
 }
 
 /**
- * Returns the timeout, in milliseconds, that a single terminology request is allowed to take.
+ * Returns the timeout, in milliseconds, that a value set expansion may take during form build
+ * before it is abandoned. Applies only to the batch `$expand` of `answerValueSet` bindings in
+ * `resolveValueSetPromises()`; other terminology calls have no timeout.
  * Defaults to 5000, overridable via `terminologyServerStore.getState().setRequestOptions()`.
  */
 export function getTerminologyRequestTimeoutMs(): number {

--- a/packages/smart-forms-renderer/src/utils/terminologyRequest.ts
+++ b/packages/smart-forms-renderer/src/utils/terminologyRequest.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { client } from 'fhirclient';
+import { terminologyServerStore } from '../stores/terminologyServerStore';
+
+/**
+ * Performs a single terminology request and resolves with the parsed JSON body.
+ *
+ * This is the one seam through which every terminology request the renderer makes passes,
+ * covering `ValueSet/$expand`, `ValueSet/$validate-code` and `CodeSystem/$lookup`.
+ * By default it uses the built-in `fhirclient` transport. When a consumer has supplied a
+ * `fetchTerminologyCallback` via `terminologyServerStore.getState().setRequestOptions()`, that
+ * callback is used instead, which lets hosts without a browser `fetch` (React Native, for example)
+ * route terminology traffic through their own HTTP client.
+ *
+ * @param query - The request relative to the terminology server, e.g. `ValueSet/$expand?url=...`
+ * @param terminologyServerUrl - Base URL of the terminology server this request is directed at
+ * @returns A promise of the parsed response body
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function terminologyRequest(query: string, terminologyServerUrl: string): Promise<any> {
+  const { fetchTerminologyCallback } = terminologyServerStore.getState();
+
+  if (fetchTerminologyCallback) {
+    return fetchTerminologyCallback(query, { terminologyServerUrl });
+  }
+
+  return client({ serverUrl: terminologyServerUrl }).request({ url: query });
+}
+
+/**
+ * Returns the timeout, in milliseconds, that a single terminology request is allowed to take.
+ * Defaults to 5000, overridable via `terminologyServerStore.getState().setRequestOptions()`.
+ */
+export function getTerminologyRequestTimeoutMs(): number {
+  return terminologyServerStore.getState().requestTimeoutMs;
+}

--- a/packages/smart-forms-renderer/src/utils/valueSet.ts
+++ b/packages/smart-forms-renderer/src/utils/valueSet.ts
@@ -26,7 +26,6 @@ import type {
   QuestionnaireItem,
   ValueSet
 } from 'fhir/r4';
-import { client } from 'fhirclient';
 import type { FhirResourceString } from '../interfaces/populate.interface';
 import type { VariableXFhirQuery } from '../interfaces/variables.interface';
 import type {
@@ -35,6 +34,7 @@ import type {
   ValueSetPromise
 } from '../interfaces/valueSet.interface';
 import { getRelevantCodingProperties } from './choice';
+import { getTerminologyRequestTimeoutMs, terminologyRequest } from './terminologyRequest';
 
 const VALID_VALUE_SET_URL_REGEX =
   /https?:\/\/(www\.)?[-\w@:%.+~#=]{2,256}\.[a-z]{2,4}\b([-@\w:%+.~#?&/=]*ValueSet[-@\w:%+.~#?&/=]*)/;
@@ -66,9 +66,7 @@ export function getValueSetPromise(url: string, terminologyServerUrl: string): P
 
   valueSetUrl = valueSetUrl.replace('|', '&version=');
 
-  return client({ serverUrl: terminologyServerUrl }).request({
-    url: 'ValueSet/$expand?url=' + valueSetUrl
-  });
+  return terminologyRequest('ValueSet/$expand?url=' + valueSetUrl, terminologyServerUrl);
 }
 
 function validateCodeResponseIsValid(response: any): response is ValidateCodeResponse {
@@ -91,9 +89,10 @@ export async function validateCodePromise(
   code: string,
   terminologyServerUrl: string
 ): Promise<ValidateCodeResponse | null> {
-  const validateCodeResponse = await client({ serverUrl: terminologyServerUrl }).request({
-    url: `ValueSet/$validate-code?url=${url}&system=${system}&code=${code}`
-  });
+  const validateCodeResponse = await terminologyRequest(
+    `ValueSet/$validate-code?url=${url}&system=${system}&code=${code}`,
+    terminologyServerUrl
+  );
 
   if (validateCodeResponse && validateCodeResponseIsValid(validateCodeResponse)) {
     return validateCodeResponse;
@@ -121,7 +120,7 @@ export async function resolveValueSetPromises(
   const valueSetPromiseKeys = Object.keys(valueSetPromises);
   const valueSetPromiseValues = Object.values(valueSetPromises);
 
-  const timeoutMs = 5000;
+  const timeoutMs = getTerminologyRequestTimeoutMs();
   const promises = valueSetPromiseValues.map((valueSetPromise) =>
     addTimeoutToPromise(valueSetPromise.promise, timeoutMs)
   );


### PR DESCRIPTION
Fixes #2060

Three functions each built their own terminology HTTP client inline (`ValueSet/$expand` and `ValueSet/$validate-code` in `valueSet.ts`, `CodeSystem/$lookup` in `addDisplayToCodings.ts`), with a 5 second timeout hardcoded at one of them. All three now go through a single seam, the new `terminologyRequest()` in `src/utils/terminologyRequest.ts`, so an adopter with their own authentication, retry, or caching policy can use the engine's terminology features instead of working around them.

The injection API: `terminologyServerStore.setRequestOptions({ fetchTerminologyCallback, requestTimeoutMs })`, in the store where the terminology server URL already lives. The callback type is `@aehrc/sdc-populate`'s existing `FetchTerminologyCallback`, re-exported from the renderer, so one implementation serves both packages. With nothing injected, the seam uses the same `fhirclient` transport and query strings as before; default behaviour is unchanged. `requestTimeoutMs` (default 5000) covers only the build-time batch `$expand` of `answerValueSet` bindings, the one place a timeout exists today.

The second commit, which wires `ItemRepopulateButton` to prefer the injected callback when handing a transport to `sdc-populate`, is separable: it is the only behaviour change to a shipped component in this PR and it has no test coverage. It is kept as its own commit so it can be dropped without affecting the seam.

Testing: 16 new unit tests covering the default path (exact pre-change query strings for all three operations), the injected path, error propagation, and the timeout. Full renderer suite, `tsc --noEmit`, and the build are green. Not exercised against a real terminology server.

Follow-up candidate, not part of this PR: the renderer now has two default transports (the `fhirclient` seam and the fetch-based `fetchTerminologyCallback` in `api/callback.ts`); consolidating on one is worth its own issue.
