### PR TITLE
Add a headless engine entrypoint and an exports map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18874,120 +18874,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/dependency-cruiser": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/dependency-cruiser/-/dependency-cruiser-18.2.0.tgz",
-      "integrity": "sha512-xMDoLD0no6pDInR8/4rIIqZ4mERDnsjezk8PkNORYSfBLvjCOogUxaruepmi1uQtZQlYUgdT2u7G3jTlgKqNjw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "8.18.0",
-        "acorn-jsx": "5.3.2",
-        "acorn-jsx-walk": "2.0.0",
-        "acorn-loose": "8.5.2",
-        "acorn-walk": "8.3.5",
-        "commander": "15.0.0",
-        "enhanced-resolve": "5.24.5",
-        "ignore": "7.0.6",
-        "interpret": "3.1.1",
-        "is-installed-globally": "1.0.0",
-        "json5": "2.2.3",
-        "picomatch": "4.0.5",
-        "prompts": "2.4.2",
-        "rechoir": "0.8.0",
-        "safe-regex": "2.1.1",
-        "semver": "7.8.5",
-        "tsconfig-paths-webpack-plugin": "4.2.0",
-        "watskeburt": "6.0.0"
-      },
-      "bin": {
-        "depcruise": "bin/dependency-cruise.mjs",
-        "depcruise-baseline": "bin/depcruise-baseline.mjs",
-        "depcruise-fmt": "bin/depcruise-fmt.mjs",
-        "depcruise-wrap-stream-in-html": "bin/wrap-stream-in-html.mjs",
-        "dependency-cruise": "bin/dependency-cruise.mjs",
-        "dependency-cruiser": "bin/dependency-cruise.mjs"
-      },
-      "engines": {
-        "node": "^22||^24||>=26"
-      }
-    },
-    "node_modules/dependency-cruiser/node_modules/acorn": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
-      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/dependency-cruiser/node_modules/commander": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
-      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=22.12.0"
-      }
-    },
-    "node_modules/dependency-cruiser/node_modules/ignore": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
-      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/dependency-cruiser/node_modules/is-installed-globally": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-1.0.0.tgz",
-      "integrity": "sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "global-directory": "^4.0.1",
-        "is-path-inside": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/dependency-cruiser/node_modules/is-path-inside": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
-      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/dependency-cruiser/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -38258,19 +38144,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/watskeburt": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/watskeburt/-/watskeburt-6.0.0.tgz",
-      "integrity": "sha512-jfiuDABaxSkC71T6oZ3vCS99roYkSHm/+As+G0Dz8taAHQb+SJBvLEm5RlsgG71XdfAj3rv7eudUBTgwcQUPlQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "watskeburt": "dist/run-cli.js"
-      },
-      "engines": {
-        "node": "^22.13||^24||>=26"
-      }
-    },
     "node_modules/wbuf": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
@@ -40221,7 +40094,7 @@
         "@types/react-dom": "^19.1.1",
         "chokidar": "^4.0.3",
         "concurrently": "^9.2.4",
-        "dependency-cruiser": "^18.1.1",
+        "dependency-cruiser": "^17.4.3",
         "eslint-plugin-storybook": "9.1.13",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^30.3.0",
@@ -40616,6 +40489,94 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="
     },
+    "packages/smart-forms-renderer/node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "packages/smart-forms-renderer/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "packages/smart-forms-renderer/node_modules/dependency-cruiser": {
+      "version": "17.4.3",
+      "resolved": "https://registry.npmjs.org/dependency-cruiser/-/dependency-cruiser-17.4.3.tgz",
+      "integrity": "sha512-L4GLuAvmXevWnPCIaFfOz6eD92c+yY+pDgVqgufrLDnW3xYA799CSZQlly2r2N13nhAlnZY6VzY7Rx5pHNvk2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "8.16.0",
+        "acorn-jsx": "5.3.2",
+        "acorn-jsx-walk": "2.0.0",
+        "acorn-loose": "8.5.2",
+        "acorn-walk": "8.3.5",
+        "commander": "14.0.3",
+        "enhanced-resolve": "5.22.1",
+        "ignore": "7.0.5",
+        "interpret": "3.1.1",
+        "is-installed-globally": "1.0.0",
+        "json5": "2.2.3",
+        "picomatch": "4.0.4",
+        "prompts": "2.4.2",
+        "rechoir": "0.8.0",
+        "safe-regex": "2.1.1",
+        "semver": "7.8.1",
+        "tsconfig-paths-webpack-plugin": "4.2.0",
+        "watskeburt": "5.0.3"
+      },
+      "bin": {
+        "depcruise": "bin/dependency-cruise.mjs",
+        "depcruise-baseline": "bin/depcruise-baseline.mjs",
+        "depcruise-fmt": "bin/depcruise-fmt.mjs",
+        "depcruise-wrap-stream-in-html": "bin/wrap-stream-in-html.mjs",
+        "dependency-cruise": "bin/dependency-cruise.mjs",
+        "dependency-cruiser": "bin/dependency-cruise.mjs"
+      },
+      "engines": {
+        "node": "^20.12||^22||>=24"
+      }
+    },
+    "packages/smart-forms-renderer/node_modules/dependency-cruiser/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/smart-forms-renderer/node_modules/enhanced-resolve": {
+      "version": "5.22.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.1.tgz",
+      "integrity": "sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "packages/smart-forms-renderer/node_modules/hast-util-whitespace": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-2.0.1.tgz",
@@ -40623,6 +40584,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "packages/smart-forms-renderer/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "packages/smart-forms-renderer/node_modules/inline-style-parser": {
@@ -40650,6 +40621,36 @@
       ],
       "engines": {
         "node": ">=4"
+      }
+    },
+    "packages/smart-forms-renderer/node_modules/is-installed-globally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-1.0.0.tgz",
+      "integrity": "sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-directory": "^4.0.1",
+        "is-path-inside": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/smart-forms-renderer/node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/smart-forms-renderer/node_modules/mdast-util-from-markdown": {
@@ -41074,6 +41075,19 @@
         }
       ]
     },
+    "packages/smart-forms-renderer/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "packages/smart-forms-renderer/node_modules/property-information": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.5.0.tgz",
@@ -41334,6 +41348,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "packages/smart-forms-renderer/node_modules/watskeburt": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/watskeburt/-/watskeburt-5.0.3.tgz",
+      "integrity": "sha512-g9CXukMjazlJJVQ3OHzXsnG25KFYgSgKMIyoJrD8ggr0DbS9UNF7OzIqWmmKKBMedkxj3T01uqEaGnn+y7QhMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "watskeburt": "dist/run-cli.js"
+      },
+      "engines": {
+        "node": "^20.12||^22.13||>=24.0"
       }
     },
     "services/assemble-express": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14872,10 +14872,44 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-jsx-walk": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx-walk/-/acorn-jsx-walk-2.0.0.tgz",
+      "integrity": "sha512-uuo6iJj4D4ygkdzd6jPtcxs8vZgDX9YFIkqczGImoypX2fQ4dVImmu3UzA4ynixCIMTrEOWW+95M2HuBaCEOVA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn-loose": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/acorn-loose/-/acorn-loose-8.5.2.tgz",
+      "integrity": "sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-loose/node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "license": "MIT",
       "dependencies": {
         "acorn": "^8.11.0"
       },
@@ -18840,6 +18874,120 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dependency-cruiser": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/dependency-cruiser/-/dependency-cruiser-18.2.0.tgz",
+      "integrity": "sha512-xMDoLD0no6pDInR8/4rIIqZ4mERDnsjezk8PkNORYSfBLvjCOogUxaruepmi1uQtZQlYUgdT2u7G3jTlgKqNjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "8.18.0",
+        "acorn-jsx": "5.3.2",
+        "acorn-jsx-walk": "2.0.0",
+        "acorn-loose": "8.5.2",
+        "acorn-walk": "8.3.5",
+        "commander": "15.0.0",
+        "enhanced-resolve": "5.24.5",
+        "ignore": "7.0.6",
+        "interpret": "3.1.1",
+        "is-installed-globally": "1.0.0",
+        "json5": "2.2.3",
+        "picomatch": "4.0.5",
+        "prompts": "2.4.2",
+        "rechoir": "0.8.0",
+        "safe-regex": "2.1.1",
+        "semver": "7.8.5",
+        "tsconfig-paths-webpack-plugin": "4.2.0",
+        "watskeburt": "6.0.0"
+      },
+      "bin": {
+        "depcruise": "bin/dependency-cruise.mjs",
+        "depcruise-baseline": "bin/depcruise-baseline.mjs",
+        "depcruise-fmt": "bin/depcruise-fmt.mjs",
+        "depcruise-wrap-stream-in-html": "bin/wrap-stream-in-html.mjs",
+        "dependency-cruise": "bin/dependency-cruise.mjs",
+        "dependency-cruiser": "bin/dependency-cruise.mjs"
+      },
+      "engines": {
+        "node": "^22||^24||>=26"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/is-installed-globally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-1.0.0.tgz",
+      "integrity": "sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-directory": "^4.0.1",
+        "is-path-inside": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -19485,9 +19633,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.24.3",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz",
-      "integrity": "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==",
+      "version": "5.24.5",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+      "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -21557,6 +21705,32 @@
         "tslib": "2"
       }
     },
+    "node_modules/global-directory": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
+      "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "4.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/global-directory/node_modules/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/global-dirs": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.1.tgz",
@@ -22664,6 +22838,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/interpret": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
+      "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/invariant": {
@@ -29675,9 +29859,9 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -32437,6 +32621,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rechoir": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+      "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve": "^1.20.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
     "node_modules/recma-build-jsx": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/recma-build-jsx/-/recma-build-jsx-1.0.0.tgz",
@@ -32589,6 +32786,16 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
       }
     },
     "node_modules/regexp.prototype.flags": {
@@ -33352,6 +33559,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
       }
     },
     "node_modules/safe-regex-test": {
@@ -35660,6 +35877,22 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.2.0.tgz",
+      "integrity": "sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.7.0",
+        "tapable": "^2.2.1",
+        "tsconfig-paths": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/tsconfig-paths/node_modules/strip-bom": {
@@ -38025,6 +38258,19 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/watskeburt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/watskeburt/-/watskeburt-6.0.0.tgz",
+      "integrity": "sha512-jfiuDABaxSkC71T6oZ3vCS99roYkSHm/+As+G0Dz8taAHQb+SJBvLEm5RlsgG71XdfAj3rv7eudUBTgwcQUPlQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "watskeburt": "dist/run-cli.js"
+      },
+      "engines": {
+        "node": "^22.13||^24||>=26"
+      }
+    },
     "node_modules/wbuf": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
@@ -39975,6 +40221,7 @@
         "@types/react-dom": "^19.1.1",
         "chokidar": "^4.0.3",
         "concurrently": "^9.2.4",
+        "dependency-cruiser": "^18.1.1",
         "eslint-plugin-storybook": "9.1.13",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^30.3.0",
@@ -41179,16 +41426,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/use-sync-external-store": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
-      "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     }
   }

--- a/packages/smart-forms-renderer/README.md
+++ b/packages/smart-forms-renderer/README.md
@@ -7,6 +7,21 @@ It acts as a reference implementation for the [SDC Form Filler](https://hl7.org/
 
 <h4><a href="https://smartforms.csiro.au/docs">Check out Questionnaire examples in Storybook 📚</a></h4>
 
+## Entry points
+
+| Import | Contains |
+| ------ | -------- |
+| `@aehrc/smart-forms-renderer` | The full renderer, including the Material UI component tree. |
+| `@aehrc/smart-forms-renderer/engine` | The form engine only: the stores, `buildForm`, response traversal, repopulation and observation-based extraction. No UI package loads at runtime, so it suits a host that renders the form itself. |
+
+`/engine` is a strict subset of the root barrel, so nothing is public by virtue of
+appearing there alone. Both are bundler targets: the package ships ES modules with
+extensionless specifiers and does not set `"type": "module"`, so it is not loadable by
+Node directly.
+
+Deep imports of internal `lib/...` paths still resolve, but they are a compatibility
+surface rather than API. Prefer the root barrel or `/engine`.
+
 View the changelog [here](https://github.com/aehrc/smart-forms/blob/main/CHANGELOG.md).
 
 We recently updated to v1.0.0 which includes some breaking changes. Please refer to the [migration guide](https://github.com/aehrc/smart-forms/blob/main/MIGRATION-v1.0.md) for more information.

--- a/packages/smart-forms-renderer/package.json
+++ b/packages/smart-forms-renderer/package.json
@@ -204,7 +204,7 @@
     "@types/react-dom": "^19.1.1",
     "chokidar": "^4.0.3",
     "concurrently": "^9.2.4",
-    "dependency-cruiser": "^18.1.1",
+    "dependency-cruiser": "^17.4.3",
     "eslint-plugin-storybook": "9.1.13",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^30.3.0",

--- a/packages/smart-forms-renderer/package.json
+++ b/packages/smart-forms-renderer/package.json
@@ -204,6 +204,7 @@
     "@types/react-dom": "^19.1.1",
     "chokidar": "^4.0.3",
     "concurrently": "^9.2.4",
+    "dependency-cruiser": "^18.1.1",
     "eslint-plugin-storybook": "9.1.13",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^30.3.0",

--- a/packages/smart-forms-renderer/package.json
+++ b/packages/smart-forms-renderer/package.json
@@ -3,6 +3,122 @@
   "version": "1.4.0",
   "description": "FHIR Structured Data Captured (SDC) rendering engine for Smart Forms",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
+    },
+    "./engine": {
+      "types": "./lib/engine.d.ts",
+      "default": "./lib/engine.js"
+    },
+    "./package.json": "./package.json",
+    "./lib": {
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
+    },
+    "./lib/components": {
+      "types": "./lib/components/index.d.ts",
+      "default": "./lib/components/index.js"
+    },
+    "./lib/components/FormComponents": {
+      "types": "./lib/components/FormComponents/index.d.ts",
+      "default": "./lib/components/FormComponents/index.js"
+    },
+    "./lib/components/FormComponents/BooleanItem": {
+      "types": "./lib/components/FormComponents/BooleanItem/index.d.ts",
+      "default": "./lib/components/FormComponents/BooleanItem/index.js"
+    },
+    "./lib/components/FormComponents/ChoiceItems": {
+      "types": "./lib/components/FormComponents/ChoiceItems/index.d.ts",
+      "default": "./lib/components/FormComponents/ChoiceItems/index.js"
+    },
+    "./lib/components/FormComponents/DateTimeItems": {
+      "types": "./lib/components/FormComponents/DateTimeItems/index.d.ts",
+      "default": "./lib/components/FormComponents/DateTimeItems/index.js"
+    },
+    "./lib/components/FormComponents/DateTimeItems/utils": {
+      "types": "./lib/components/FormComponents/DateTimeItems/utils/index.d.ts",
+      "default": "./lib/components/FormComponents/DateTimeItems/utils/index.js"
+    },
+    "./lib/components/FormComponents/DecimalItem": {
+      "types": "./lib/components/FormComponents/DecimalItem/index.d.ts",
+      "default": "./lib/components/FormComponents/DecimalItem/index.js"
+    },
+    "./lib/components/FormComponents/GridGroup": {
+      "types": "./lib/components/FormComponents/GridGroup/index.d.ts",
+      "default": "./lib/components/FormComponents/GridGroup/index.js"
+    },
+    "./lib/components/FormComponents/GroupItem": {
+      "types": "./lib/components/FormComponents/GroupItem/index.d.ts",
+      "default": "./lib/components/FormComponents/GroupItem/index.js"
+    },
+    "./lib/components/FormComponents/ItemParts": {
+      "types": "./lib/components/FormComponents/ItemParts/index.d.ts",
+      "default": "./lib/components/FormComponents/ItemParts/index.js"
+    },
+    "./lib/components/FormComponents/RepeatGroup": {
+      "types": "./lib/components/FormComponents/RepeatGroup/index.d.ts",
+      "default": "./lib/components/FormComponents/RepeatGroup/index.js"
+    },
+    "./lib/components/FormComponents/RepeatItem": {
+      "types": "./lib/components/FormComponents/RepeatItem/index.d.ts",
+      "default": "./lib/components/FormComponents/RepeatItem/index.js"
+    },
+    "./lib/components/FormComponents/SingleItem": {
+      "types": "./lib/components/FormComponents/SingleItem/index.d.ts",
+      "default": "./lib/components/FormComponents/SingleItem/index.js"
+    },
+    "./lib/components/FormComponents/StringItem": {
+      "types": "./lib/components/FormComponents/StringItem/index.d.ts",
+      "default": "./lib/components/FormComponents/StringItem/index.js"
+    },
+    "./lib/components/FormComponents/Tables": {
+      "types": "./lib/components/FormComponents/Tables/index.d.ts",
+      "default": "./lib/components/FormComponents/Tables/index.js"
+    },
+    "./lib/components/Renderer": {
+      "types": "./lib/components/Renderer/index.d.ts",
+      "default": "./lib/components/Renderer/index.js"
+    },
+    "./lib/hooks": {
+      "types": "./lib/hooks/index.d.ts",
+      "default": "./lib/hooks/index.js"
+    },
+    "./lib/interfaces": {
+      "types": "./lib/interfaces/index.d.ts",
+      "default": "./lib/interfaces/index.js"
+    },
+    "./lib/stores": {
+      "types": "./lib/stores/index.d.ts",
+      "default": "./lib/stores/index.js"
+    },
+    "./lib/theme": {
+      "types": "./lib/theme/index.d.ts",
+      "default": "./lib/theme/index.js"
+    },
+    "./lib/utils": {
+      "types": "./lib/utils/index.d.ts",
+      "default": "./lib/utils/index.js"
+    },
+    "./lib/*.js": {
+      "types": "./lib/*.d.ts",
+      "default": "./lib/*.js"
+    },
+    "./lib/*": {
+      "types": "./lib/*.d.ts",
+      "default": "./lib/*.js"
+    },
+    "./src/*": "./src/*"
+  },
+  "typesVersions": {
+    "*": {
+      "engine": [
+        "lib/engine.d.ts"
+      ]
+    }
+  },
   "scripts": {
     "compile": "tsc",
     "watch": "tsc -w",

--- a/packages/smart-forms-renderer/package.json
+++ b/packages/smart-forms-renderer/package.json
@@ -86,6 +86,10 @@
       "types": "./lib/hooks/index.d.ts",
       "default": "./lib/hooks/index.js"
     },
+    "./lib/i18n": {
+      "types": "./lib/i18n/index.d.ts",
+      "default": "./lib/i18n/index.js"
+    },
     "./lib/interfaces": {
       "types": "./lib/interfaces/index.d.ts",
       "default": "./lib/interfaces/index.js"

--- a/packages/smart-forms-renderer/src/engine.ts
+++ b/packages/smart-forms-renderer/src/engine.ts
@@ -29,10 +29,11 @@
  * specifiers and the package does not set `"type": "module"`, so every entrypoint including
  * this one is bundler-only. That is pre-existing and unchanged here.
  *
- * This entrypoint is the supported alternative. Its contents are the subset of the package's
- * public API that has no DOM or UI-library dependency, plus the vanilla Zustand stores that
- * hold form state. It intentionally re-exports nothing from `src/components`, `src/hooks` or
- * `src/theme`.
+ * This entrypoint is the supported alternative. Its contents are the subset of the root
+ * barrel's public API that has no DOM or UI-library dependency, plus the vanilla Zustand
+ * stores that hold form state. Every name exported here is also exported from the package
+ * root (a test enforces this), so nothing becomes public by appearing here alone. It
+ * intentionally re-exports nothing from `src/components`, `src/hooks` or `src/theme`.
  *
  * Two consequences of being headless are worth stating:
  * - Nothing here renders. `buildForm` and the stores drive form state; drawing it is the
@@ -51,9 +52,6 @@ export {
   useQuestionnaireResponseStore
 } from './stores/questionnaireResponseStore';
 
-export type { FormUpdateQueueStoreType, UpdateTask } from './stores/formUpdateQueueStore';
-export { formUpdateQueueStore, useFormUpdateQueueStore } from './stores/formUpdateQueueStore';
-
 export type { TerminologyServerStoreType } from './stores/terminologyServerStore';
 export { terminologyServerStore, useTerminologyServerStore } from './stores/terminologyServerStore';
 
@@ -71,33 +69,16 @@ export {
   destroyForm,
   getResponse,
   removeEmptyAnswersFromResponse,
-  removeInternalIdsFromResponse,
-  initialiseFhirClient,
-  answerHasValue,
-  qrItemHasItemsOrAnswer
+  removeInternalIdsFromResponse
 } from './utils/manageForm';
 export { initialiseQuestionnaireResponse } from './utils/initialise';
 
 // QuestionnaireResponse item construction and traversal
-export {
-  createEmptyQrItem,
-  createEmptyQrGroup,
-  updateQrItemsInGroup,
-  removeNoAnswerQrItem,
-  getQRItemId
-} from './utils/qrItem';
+export { createEmptyQrItem, createEmptyQrGroup, updateQrItemsInGroup } from './utils/qrItem';
 export { mapQItemsIndex, getQrItemsIndex } from './utils/mapItem';
 
 // Questionnaire item inspection
-export type { CollapsibleType } from './utils/qItem';
-export {
-  isRepeatItemAndNotCheckbox,
-  isCheckbox,
-  isHiddenByEnableWhen,
-  isItemHidden,
-  getGroupCollapsible,
-  getXHtmlStringFromQuestionnaire
-} from './utils/qItem';
+export { isRepeatItemAndNotCheckbox, isHiddenByEnableWhen } from './utils/qItem';
 export { isSpecificItemControl, getDecimalPrecision } from './utils/extensions';
 export { getQuestionnaireItem, getSectionHeading } from './utils/misc';
 
@@ -110,12 +91,8 @@ export { generateItemsToRepopulate } from './utils/repopulateItems';
 export { repopulateResponse } from './utils/repopulateIntoResponse';
 
 // Observation-based extraction
-export type { Extractable } from './utils/extractObservation';
 export {
   extractObservationBased,
   canBeObservationExtracted,
-  buildBundleFromObservationArray,
-  mapQItemsExtractable,
-  createObservation,
-  generateUniqueId
+  buildBundleFromObservationArray
 } from './utils/extractObservation';

--- a/packages/smart-forms-renderer/src/engine.ts
+++ b/packages/smart-forms-renderer/src/engine.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2025 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Headless entrypoint for the SDC engine, published as `@aehrc/smart-forms-renderer/engine`.
+ *
+ * The package root (`@aehrc/smart-forms-renderer`) is a DOM renderer: importing it pulls in
+ * Material UI, Emotion, react-dom, react-markdown and the drag-and-drop libraries. Consumers
+ * that only need the form engine cannot use that barrel, so they have been deep-importing
+ * internal `lib/...` paths instead.
+ *
+ * Scope of "headless" here: no DOM and no UI library in the runtime graph, which is what makes
+ * the engine usable from a React Native host or a test. It does not mean the package is
+ * loadable by Node directly. The build emits `module: ES2020` with extensionless relative
+ * specifiers and the package does not set `"type": "module"`, so every entrypoint including
+ * this one is bundler-only. That is pre-existing and unchanged here.
+ *
+ * This entrypoint is the supported alternative. Its contents are the subset of the package's
+ * public API that has no DOM or UI-library dependency, plus the vanilla Zustand stores that
+ * hold form state. It intentionally re-exports nothing from `src/components`, `src/hooks` or
+ * `src/theme`.
+ *
+ * Two consequences of being headless are worth stating:
+ * - Nothing here renders. `buildForm` and the stores drive form state; drawing it is the
+ *   host's job.
+ * - `RendererConfig` is exported as a type only, because `BuildFormParams` accepts it. Its
+ *   values describe DOM layout and have no effect without the DOM renderer.
+ */
+
+// Form state stores (vanilla Zustand stores plus their React selector hooks)
+export type { QuestionnaireStoreType } from './stores/questionnaireStore';
+export { questionnaireStore, useQuestionnaireStore } from './stores/questionnaireStore';
+
+export type { QuestionnaireResponseStoreType } from './stores/questionnaireResponseStore';
+export {
+  questionnaireResponseStore,
+  useQuestionnaireResponseStore
+} from './stores/questionnaireResponseStore';
+
+export type { FormUpdateQueueStoreType, UpdateTask } from './stores/formUpdateQueueStore';
+export { formUpdateQueueStore, useFormUpdateQueueStore } from './stores/formUpdateQueueStore';
+
+export type { TerminologyServerStoreType } from './stores/terminologyServerStore';
+export { terminologyServerStore, useTerminologyServerStore } from './stores/terminologyServerStore';
+
+export type { SmartConfigStoreType } from './stores/smartConfigStore';
+export { smartConfigStore, useSmartConfigStore } from './stores/smartConfigStore';
+
+// Type only: `BuildFormParams.rendererConfigOptions` is typed as `RendererConfig`
+export type { RendererConfig } from './stores/rendererConfigStore';
+
+// Form lifecycle
+export type { BuildFormParams, RepopulateFormParams } from './utils/manageForm';
+export {
+  buildForm,
+  repopulateForm,
+  destroyForm,
+  getResponse,
+  removeEmptyAnswersFromResponse,
+  removeInternalIdsFromResponse,
+  initialiseFhirClient,
+  answerHasValue,
+  qrItemHasItemsOrAnswer
+} from './utils/manageForm';
+export { initialiseQuestionnaireResponse } from './utils/initialise';
+
+// QuestionnaireResponse item construction and traversal
+export {
+  createEmptyQrItem,
+  createEmptyQrGroup,
+  updateQrItemsInGroup,
+  removeNoAnswerQrItem,
+  getQRItemId
+} from './utils/qrItem';
+export { mapQItemsIndex, getQrItemsIndex } from './utils/mapItem';
+
+// Questionnaire item inspection
+export type { CollapsibleType } from './utils/qItem';
+export {
+  isRepeatItemAndNotCheckbox,
+  isCheckbox,
+  isHiddenByEnableWhen,
+  isItemHidden,
+  getGroupCollapsible,
+  getXHtmlStringFromQuestionnaire
+} from './utils/qItem';
+export { isSpecificItemControl, getDecimalPrecision } from './utils/extensions';
+export { getQuestionnaireItem, getSectionHeading } from './utils/misc';
+
+// Answer parsing
+export { parseDecimalStringToFloat, parseDecimalStringWithPrecision } from './utils/parseInputs';
+
+// Repopulation
+export type { ItemToRepopulate } from './utils/repopulateItems';
+export { generateItemsToRepopulate } from './utils/repopulateItems';
+export { repopulateResponse } from './utils/repopulateIntoResponse';
+
+// Observation-based extraction
+export type { Extractable } from './utils/extractObservation';
+export {
+  extractObservationBased,
+  canBeObservationExtracted,
+  buildBundleFromObservationArray,
+  mapQItemsExtractable,
+  createObservation,
+  generateUniqueId
+} from './utils/extractObservation';

--- a/packages/smart-forms-renderer/src/hooks/useRenderingExtensions.ts
+++ b/packages/smart-forms-renderer/src/hooks/useRenderingExtensions.ts
@@ -23,22 +23,12 @@ import {
   isItemRepopulatable
 } from '../utils/extensions';
 import { getTextDisplayFlyover } from './useParseXhtml';
-import type { QuestionnaireItem, QuestionnaireItemAnswerOption } from 'fhir/r4';
+import type { QuestionnaireItem } from 'fhir/r4';
 import { structuredDataCapture } from 'fhir-sdc-helpers';
-import type { JSX } from 'react';
 import { useMemo } from 'react';
+import type { RenderingExtensions } from '../interfaces/renderingExtensions.interface';
 
-export interface RenderingExtensions {
-  displayUnit: string;
-  displayPrompt: string;
-  displayInstructions: string;
-  displayFlyover: string | JSX.Element | JSX.Element[];
-  readOnly: boolean;
-  entryFormat: string;
-  required: boolean;
-  quantityUnit: QuestionnaireItemAnswerOption | null;
-  isRepopulatable: boolean;
-}
+export type { RenderingExtensions } from '../interfaces/renderingExtensions.interface';
 
 function useRenderingExtensions(qItem: QuestionnaireItem): RenderingExtensions {
   return useMemo(

--- a/packages/smart-forms-renderer/src/interfaces/overrideComponent.interface.ts
+++ b/packages/smart-forms-renderer/src/interfaces/overrideComponent.interface.ts
@@ -17,7 +17,7 @@
 
 import type { QuestionnaireItem, QuestionnaireResponseItem } from 'fhir/r4';
 import type { QrRepeatGroup } from './repeatGroup.interface';
-import type { RenderingExtensions } from '../hooks/useRenderingExtensions';
+import type { RenderingExtensions } from './renderingExtensions.interface';
 import type { JSX } from 'react';
 
 export interface QItemOverrideComponentProps {

--- a/packages/smart-forms-renderer/src/interfaces/renderingExtensions.interface.ts
+++ b/packages/smart-forms-renderer/src/interfaces/renderingExtensions.interface.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { QuestionnaireItemAnswerOption } from 'fhir/r4';
+import type { JSX } from 'react';
+
+/**
+ * Rendering extensions read off a questionnaire item, as returned by `useRenderingExtensions`.
+ *
+ * Defined here rather than in `hooks/useRenderingExtensions` so that type-only consumers (such
+ * as `QItemOverrideComponentProps`, which the headless `/engine` entrypoint reaches) do not
+ * pull that hook's runtime imports into their type closure.
+ */
+export interface RenderingExtensions {
+  displayUnit: string;
+  displayPrompt: string;
+  displayInstructions: string;
+  displayFlyover: string | JSX.Element | JSX.Element[];
+  readOnly: boolean;
+  entryFormat: string;
+  required: boolean;
+  quantityUnit: QuestionnaireItemAnswerOption | null;
+  isRepopulatable: boolean;
+}

--- a/packages/smart-forms-renderer/src/stores/rendererConfigStore.ts
+++ b/packages/smart-forms-renderer/src/stores/rendererConfigStore.ts
@@ -18,7 +18,7 @@
 import { createStore } from 'zustand/vanilla';
 import { createSelectors } from './selector';
 import type { QuestionnaireItem } from 'fhir/r4';
-import type { UseResponsiveProps } from '../hooks';
+import type { UseResponsiveProps } from '../hooks/useResponsive';
 import type { Breakpoints } from '@mui/material';
 import type { RendererStrings } from '../i18n/rendererStrings';
 import { defaultRendererStrings, resolveRendererStrings } from '../i18n/rendererStrings';

--- a/packages/smart-forms-renderer/src/test/engineEntrypoint.test.ts
+++ b/packages/smart-forms-renderer/src/test/engineEntrypoint.test.ts
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2025 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * `src/engine.ts` is the published headless entrypoint (`@aehrc/smart-forms-renderer/engine`).
+ * Its contract is that it works without a DOM, so no UI library may enter its transitive
+ * import graph. These tests walk that graph statically and fail if one does, which is what
+ * stops the entrypoint regressing the next time a util reaches for a component or a hook.
+ */
+
+const SRC_DIR = path.resolve(__dirname, '..');
+const ENGINE_ENTRYPOINT = path.join(SRC_DIR, 'engine.ts');
+
+/** Packages that would make the engine graph DOM-bound or pull in a UI tree. */
+const FORBIDDEN_PACKAGES = [
+  '@emotion/react',
+  '@emotion/styled',
+  '@fontsource/inter',
+  '@fontsource/material-icons',
+  '@fontsource/roboto',
+  '@mui/icons-material',
+  '@mui/lab',
+  '@mui/material',
+  '@mui/x-date-pickers',
+  '@tanstack/react-query',
+  'html-react-parser',
+  'react-beautiful-dnd',
+  'react-dnd',
+  'react-dnd-html5-backend',
+  'react-dom',
+  'react-markdown',
+  'style-to-js',
+  'usehooks-ts'
+];
+
+const CANDIDATE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx'];
+
+/**
+ * Matches the module specifier of any static `import`/`export ... from` declaration, capturing
+ * whether the declaration was type-only (`import type` / `export type`).
+ */
+const SPECIFIER_REGEX = /(?:^|\n)\s*(?:import|export)\s+(type\s+)?[\s\S]*?from\s+['"]([^'"]+)['"]/g;
+
+/** Matches a bare `import 'x'` side effect declaration. */
+const BARE_IMPORT_REGEX = /(?:^|\n)\s*import\s+['"]([^'"]+)['"]/g;
+
+interface Specifier {
+  specifier: string;
+
+  /**
+   * True for `import type` / `export type` declarations, which TypeScript erases entirely, so
+   * they never reach a bundle. They still bind a consumer at typecheck time, which is why they
+   * are tracked separately rather than ignored. Inline `import { type Foo }` specifiers are not
+   * detected and count as value imports, which errs on the strict side.
+   */
+  typeOnly: boolean;
+}
+
+function readSpecifiers(filePath: string): Specifier[] {
+  const source = fs.readFileSync(filePath, 'utf8');
+  const specifiers: Specifier[] = [];
+
+  SPECIFIER_REGEX.lastIndex = 0;
+  let match = SPECIFIER_REGEX.exec(source);
+  while (match !== null) {
+    specifiers.push({ specifier: match[2], typeOnly: match[1] !== undefined });
+    match = SPECIFIER_REGEX.exec(source);
+  }
+
+  BARE_IMPORT_REGEX.lastIndex = 0;
+  match = BARE_IMPORT_REGEX.exec(source);
+  while (match !== null) {
+    specifiers.push({ specifier: match[1], typeOnly: false });
+    match = BARE_IMPORT_REGEX.exec(source);
+  }
+
+  return specifiers;
+}
+
+function resolveRelative(fromFile: string, specifier: string): string | null {
+  const base = path.resolve(path.dirname(fromFile), specifier);
+
+  for (const extension of CANDIDATE_EXTENSIONS) {
+    const candidate = base + extension;
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+      return candidate;
+    }
+  }
+
+  for (const extension of CANDIDATE_EXTENSIONS) {
+    const candidate = path.join(base, 'index' + extension);
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+interface EngineGraph {
+  /** Every source file reachable from `src/engine.ts`, as a path relative to `src`. */
+  files: string[];
+
+  /** Every bare (non-relative) specifier reachable from `src/engine.ts`, with its importer. */
+  packageImports: { specifier: string; importer: string; typeOnly: boolean }[];
+}
+
+/**
+ * Two graphs matter, and they answer different questions.
+ *
+ * - `followTypeOnly: false` is the **runtime** graph: what actually loads, and therefore what
+ *   can reach a bundle. Type-only edges are erased by TypeScript, so following one would report
+ *   a module as loaded when only its types are used.
+ * - `followTypeOnly: true` is the **type surface**: what a consumer must be able to resolve in
+ *   order to typecheck against the entrypoint. A type-only edge is load-bearing here, because
+ *   the published `.d.ts` closure still refers through it.
+ *
+ * Asserting only the first is how a type-only barrel import can silently couple the engine's
+ * public types to a UI library without any test noticing.
+ */
+function collectEngineGraph(followTypeOnly: boolean): EngineGraph {
+  const visited = new Set<string>([ENGINE_ENTRYPOINT]);
+  const queue = [ENGINE_ENTRYPOINT];
+  const packageImports: { specifier: string; importer: string; typeOnly: boolean }[] = [];
+  const unresolved: string[] = [];
+
+  while (queue.length > 0) {
+    const current = queue.shift() as string;
+    const importer = path.relative(SRC_DIR, current);
+
+    for (const { specifier, typeOnly } of readSpecifiers(current)) {
+      if (specifier.startsWith('.')) {
+        const resolved = resolveRelative(current, specifier);
+        if (resolved === null) {
+          unresolved.push(importer + ' -> ' + specifier);
+          continue;
+        }
+
+        if (typeOnly && !followTypeOnly) {
+          continue;
+        }
+
+        if (!visited.has(resolved)) {
+          visited.add(resolved);
+          queue.push(resolved);
+        }
+        continue;
+      }
+
+      packageImports.push({ specifier, importer, typeOnly });
+    }
+  }
+
+  // A specifier this walk cannot resolve is a hole in the check, so surface it rather than pass.
+  expect(unresolved).toEqual([]);
+
+  return {
+    files: [...visited].map((file) => path.relative(SRC_DIR, file)).sort(),
+    packageImports
+  };
+}
+
+describe('headless engine entrypoint', () => {
+  const graph = collectEngineGraph(false);
+  const typeSurface = collectEngineGraph(true);
+
+  it('reaches at least the stores and utils it re-exports', () => {
+    expect(graph.files).toContain('engine.ts');
+    expect(graph.files).toContain('stores/questionnaireStore.ts');
+    expect(graph.files).toContain('utils/manageForm.ts');
+    expect(graph.files).toContain('utils/extractObservation.ts');
+  });
+
+  const isForbidden = (specifier: string) =>
+    FORBIDDEN_PACKAGES.some(
+      (forbidden) => specifier === forbidden || specifier.startsWith(forbidden + '/')
+    );
+
+  it('does not import any UI library at runtime', () => {
+    const offenders = graph.packageImports
+      .filter(({ specifier, typeOnly }) => !typeOnly && isForbidden(specifier))
+      .map(({ specifier, importer }) => importer + ' imports ' + specifier);
+
+    expect([...new Set(offenders)].sort()).toEqual([]);
+  });
+
+  /**
+   * The entrypoint's **type surface** is wider than its runtime graph, and a consumer feels the
+   * difference: these packages must be resolvable to typecheck against `/engine`, even though
+   * none of them load at runtime.
+   *
+   * The root cause is one type-only edge. `RendererConfig` (exported here, because
+   * `BuildFormParams` accepts it) keys its breakpoint values by Material UI's `Breakpoint`, and
+   * reaches `UseResponsiveProps` through the `../hooks` barrel, which pulls the rest of that
+   * barrel's type closure with it.
+   *
+   * Keeping the Material UI breakpoint types is deliberate: `Breakpoint` is augmentable through
+   * `BreakpointOverrides` so a consumer can pass a custom breakpoint, which `useResponsive`
+   * documents as supported. Narrowing it to a fixed union would remove that.
+   *
+   * The rest is incidental, and narrowing the `../hooks` barrel import to the specific module
+   * would shrink this list. That is worth doing and is not done here.
+   *
+   * Pinned rather than banned so the set cannot grow unnoticed. Anything added here is a
+   * decision, not something a consumer should discover.
+   */
+  it('pins the UI packages a consumer needs in order to typecheck', () => {
+    const offenders = typeSurface.packageImports
+      .filter(({ specifier }) => isForbidden(specifier))
+      .map(({ specifier }) => specifier);
+
+    expect([...new Set(offenders)].sort()).toEqual([
+      '@mui/material',
+      '@mui/material/styles',
+      '@mui/material/useMediaQuery',
+      '@tanstack/react-query',
+      'html-react-parser',
+      'html-react-parser/lib/attributes-to-props'
+    ]);
+  });
+
+  it('does not reach any component or theme module', () => {
+    const offenders = graph.files.filter(
+      (file) => file.startsWith('components/') || file.startsWith('theme/')
+    );
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/smart-forms-renderer/src/test/engineEntrypoint.test.ts
+++ b/packages/smart-forms-renderer/src/test/engineEntrypoint.test.ts
@@ -15,18 +15,54 @@
  * limitations under the License.
  */
 
+import { execFileSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
+import ts from 'typescript';
 
 /**
  * `src/engine.ts` is the published headless entrypoint (`@aehrc/smart-forms-renderer/engine`).
  * Its contract is that it works without a DOM, so no UI library may enter its transitive
- * import graph. These tests walk that graph statically and fail if one does, which is what
- * stops the entrypoint regressing the next time a util reaches for a component or a hook.
+ * runtime import graph. These tests cruise that graph with dependency-cruiser and fail if one
+ * does, which is what stops the entrypoint regressing the next time a util reaches for a
+ * component or a hook.
+ *
+ * dependency-cruiser ships as ESM only, and this jest setup is CommonJS, so the tests drive
+ * its CLI (JSON reporter) instead of importing its API.
  */
 
+const PACKAGE_ROOT = path.resolve(__dirname, '../..');
+
+/**
+ * dependency-cruiser's exports map does not expose its bin scripts to `require.resolve`, so
+ * locate the `depcruise` shim npm links into `node_modules/.bin`, walking up from the package
+ * to wherever the workspace hoisted it.
+ */
+function resolveDepcruiseBin(): string {
+  let directory = PACKAGE_ROOT;
+  for (;;) {
+    const candidate = path.join(directory, 'node_modules', '.bin', 'depcruise');
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+    const parent = path.dirname(directory);
+    if (parent === directory) {
+      throw new Error('Could not find the depcruise binary in any node_modules/.bin.');
+    }
+    directory = parent;
+  }
+}
+
+const DEPCRUISE_BIN = resolveDepcruiseBin();
+
+/** The slice of dependency-cruiser's JSON output these tests read. */
+interface CruisedModule {
+  source: string;
+  dependencies: { module: string }[];
+}
 const SRC_DIR = path.resolve(__dirname, '..');
 const ENGINE_ENTRYPOINT = path.join(SRC_DIR, 'engine.ts');
+const ROOT_BARREL = path.join(SRC_DIR, 'index.ts');
 
 /** Packages that would make the engine graph DOM-bound or pull in a UI tree. */
 const FORBIDDEN_PACKAGES = [
@@ -50,197 +86,151 @@ const FORBIDDEN_PACKAGES = [
   'usehooks-ts'
 ];
 
-const CANDIDATE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx'];
+const isForbidden = (specifier: string) =>
+  FORBIDDEN_PACKAGES.some(
+    (forbidden) => specifier === forbidden || specifier.startsWith(forbidden + '/')
+  );
 
 /**
- * Matches the module specifier of any static `import`/`export ... from` declaration, capturing
- * whether the declaration was type-only (`import type` / `export type`).
- */
-const SPECIFIER_REGEX = /(?:^|\n)\s*(?:import|export)\s+(type\s+)?[\s\S]*?from\s+['"]([^'"]+)['"]/g;
-
-/** Matches a bare `import 'x'` side effect declaration. */
-const BARE_IMPORT_REGEX = /(?:^|\n)\s*import\s+['"]([^'"]+)['"]/g;
-
-interface Specifier {
-  specifier: string;
-
-  /**
-   * True for `import type` / `export type` declarations, which TypeScript erases entirely, so
-   * they never reach a bundle. They still bind a consumer at typecheck time, which is why they
-   * are tracked separately rather than ignored. Inline `import { type Foo }` specifiers are not
-   * detected and count as value imports, which errs on the strict side.
-   */
-  typeOnly: boolean;
-}
-
-function readSpecifiers(filePath: string): Specifier[] {
-  const source = fs.readFileSync(filePath, 'utf8');
-  const specifiers: Specifier[] = [];
-
-  SPECIFIER_REGEX.lastIndex = 0;
-  let match = SPECIFIER_REGEX.exec(source);
-  while (match !== null) {
-    specifiers.push({ specifier: match[2], typeOnly: match[1] !== undefined });
-    match = SPECIFIER_REGEX.exec(source);
-  }
-
-  BARE_IMPORT_REGEX.lastIndex = 0;
-  match = BARE_IMPORT_REGEX.exec(source);
-  while (match !== null) {
-    specifiers.push({ specifier: match[1], typeOnly: false });
-    match = BARE_IMPORT_REGEX.exec(source);
-  }
-
-  return specifiers;
-}
-
-function resolveRelative(fromFile: string, specifier: string): string | null {
-  const base = path.resolve(path.dirname(fromFile), specifier);
-
-  for (const extension of CANDIDATE_EXTENSIONS) {
-    const candidate = base + extension;
-    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
-      return candidate;
-    }
-  }
-
-  for (const extension of CANDIDATE_EXTENSIONS) {
-    const candidate = path.join(base, 'index' + extension);
-    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
-      return candidate;
-    }
-  }
-
-  return null;
-}
-
-interface EngineGraph {
-  /** Every source file reachable from `src/engine.ts`, as a path relative to `src`. */
-  files: string[];
-
-  /** Every bare (non-relative) specifier reachable from `src/engine.ts`, with its importer. */
-  packageImports: { specifier: string; importer: string; typeOnly: boolean }[];
-}
-
-/**
- * Two graphs matter, and they answer different questions.
+ * Cruises the engine entrypoint's import graph. Two graphs matter, and they answer different
+ * questions:
  *
- * - `followTypeOnly: false` is the **runtime** graph: what actually loads, and therefore what
- *   can reach a bundle. Type-only edges are erased by TypeScript, so following one would report
- *   a module as loaded when only its types are used.
- * - `followTypeOnly: true` is the **type surface**: what a consumer must be able to resolve in
- *   order to typecheck against the entrypoint. A type-only edge is load-bearing here, because
- *   the published `.d.ts` closure still refers through it.
- *
- * Asserting only the first is how a type-only barrel import can silently couple the engine's
- * public types to a UI library without any test noticing.
+ * - `tsPreCompilationDeps: false` is the **runtime** graph: what actually loads, and therefore
+ *   what can reach a bundle. TypeScript erases type-only imports, so they are excluded.
+ * - `tsPreCompilationDeps: true` is the **type surface**: what a consumer must be able to
+ *   resolve in order to typecheck against the entrypoint, because the published `.d.ts`
+ *   closure still refers through type-only edges.
  */
-function collectEngineGraph(followTypeOnly: boolean): EngineGraph {
-  const visited = new Set<string>([ENGINE_ENTRYPOINT]);
-  const queue = [ENGINE_ENTRYPOINT];
-  const packageImports: { specifier: string; importer: string; typeOnly: boolean }[] = [];
-  const unresolved: string[] = [];
+function cruiseEngine(tsPreCompilationDeps: boolean): CruisedModule[] {
+  const args = [
+    '--no-config',
+    '--output-type',
+    'json',
+    '--do-not-follow',
+    'node_modules',
+    ...(tsPreCompilationDeps ? ['--ts-pre-compilation-deps'] : []),
+    path.relative(PACKAGE_ROOT, ENGINE_ENTRYPOINT)
+  ];
 
-  while (queue.length > 0) {
-    const current = queue.shift() as string;
-    const importer = path.relative(SRC_DIR, current);
+  const stdout = execFileSync(DEPCRUISE_BIN, args, {
+    cwd: PACKAGE_ROOT,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024
+  });
 
-    for (const { specifier, typeOnly } of readSpecifiers(current)) {
-      if (specifier.startsWith('.')) {
-        const resolved = resolveRelative(current, specifier);
-        if (resolved === null) {
-          unresolved.push(importer + ' -> ' + specifier);
-          continue;
-        }
+  return (JSON.parse(stdout) as { modules: CruisedModule[] }).modules;
+}
 
-        if (typeOnly && !followTypeOnly) {
-          continue;
-        }
+/** The bare (non-relative) specifiers imported by the cruised source files. */
+function packageImports(modules: CruisedModule[]): string[] {
+  const specifiers = modules
+    .filter((module) => !module.source.includes('node_modules'))
+    .flatMap((module) => module.dependencies.map((dependency) => dependency.module))
+    .filter((specifier) => !specifier.startsWith('.'));
 
-        if (!visited.has(resolved)) {
-          visited.add(resolved);
-          queue.push(resolved);
-        }
-        continue;
-      }
-
-      packageImports.push({ specifier, importer, typeOnly });
-    }
-  }
-
-  // A specifier this walk cannot resolve is a hole in the check, so surface it rather than pass.
-  expect(unresolved).toEqual([]);
-
-  return {
-    files: [...visited].map((file) => path.relative(SRC_DIR, file)).sort(),
-    packageImports
-  };
+  return [...new Set(specifiers)].sort();
 }
 
 describe('headless engine entrypoint', () => {
-  const graph = collectEngineGraph(false);
-  const typeSurface = collectEngineGraph(true);
+  let runtimeModules: CruisedModule[];
+  let typeSurfaceModules: CruisedModule[];
 
-  it('reaches at least the stores and utils it re-exports', () => {
-    expect(graph.files).toContain('engine.ts');
-    expect(graph.files).toContain('stores/questionnaireStore.ts');
-    expect(graph.files).toContain('utils/manageForm.ts');
-    expect(graph.files).toContain('utils/extractObservation.ts');
+  beforeAll(() => {
+    runtimeModules = cruiseEngine(false);
+    typeSurfaceModules = cruiseEngine(true);
   });
 
-  const isForbidden = (specifier: string) =>
-    FORBIDDEN_PACKAGES.some(
-      (forbidden) => specifier === forbidden || specifier.startsWith(forbidden + '/')
-    );
+  it('reaches at least the stores and utils it re-exports', () => {
+    const sources = runtimeModules.map((module) => module.source);
+
+    expect(sources).toContain('src/engine.ts');
+    expect(sources).toContain('src/stores/questionnaireStore.ts');
+    expect(sources).toContain('src/utils/manageForm.ts');
+    expect(sources).toContain('src/utils/extractObservation.ts');
+  });
 
   it('does not import any UI library at runtime', () => {
-    const offenders = graph.packageImports
-      .filter(({ specifier, typeOnly }) => !typeOnly && isForbidden(specifier))
-      .map(({ specifier, importer }) => importer + ' imports ' + specifier);
+    const offenders = packageImports(runtimeModules).filter(isForbidden);
 
-    expect([...new Set(offenders)].sort()).toEqual([]);
+    expect(offenders).toEqual([]);
   });
 
   /**
-   * The entrypoint's **type surface** is wider than its runtime graph, and a consumer feels the
-   * difference: these packages must be resolvable to typecheck against `/engine`, even though
-   * none of them load at runtime.
-   *
-   * The root cause is one type-only edge. `RendererConfig` (exported here, because
-   * `BuildFormParams` accepts it) keys its breakpoint values by Material UI's `Breakpoint`, and
-   * reaches `UseResponsiveProps` through the `../hooks` barrel, which pulls the rest of that
-   * barrel's type closure with it.
-   *
-   * Keeping the Material UI breakpoint types is deliberate: `Breakpoint` is augmentable through
+   * The entrypoint's **type surface** is wider than its runtime graph: Material UI must be
+   * resolvable to typecheck against `/engine`, even though none of it loads at runtime. The
+   * cause is deliberate. `RendererConfig` (exported here, because `BuildFormParams` accepts
+   * it) keys its breakpoint values by Material UI's `Breakpoint`, which is augmentable through
    * `BreakpointOverrides` so a consumer can pass a custom breakpoint, which `useResponsive`
    * documents as supported. Narrowing it to a fixed union would remove that.
-   *
-   * The rest is incidental, and narrowing the `../hooks` barrel import to the specific module
-   * would shrink this list. That is worth doing and is not done here.
    *
    * Pinned rather than banned so the set cannot grow unnoticed. Anything added here is a
    * decision, not something a consumer should discover.
    */
   it('pins the UI packages a consumer needs in order to typecheck', () => {
-    const offenders = typeSurface.packageImports
-      .filter(({ specifier }) => isForbidden(specifier))
-      .map(({ specifier }) => specifier);
+    const offenders = packageImports(typeSurfaceModules).filter(isForbidden);
 
-    expect([...new Set(offenders)].sort()).toEqual([
+    expect(offenders).toEqual([
       '@mui/material',
       '@mui/material/styles',
-      '@mui/material/useMediaQuery',
-      '@tanstack/react-query',
-      'html-react-parser',
-      'html-react-parser/lib/attributes-to-props'
+      '@mui/material/useMediaQuery'
     ]);
   });
 
   it('does not reach any component or theme module', () => {
-    const offenders = graph.files.filter(
-      (file) => file.startsWith('components/') || file.startsWith('theme/')
-    );
+    const offenders = runtimeModules
+      .map((module) => module.source)
+      .filter((source) => source.startsWith('src/components/') || source.startsWith('src/theme/'));
 
     expect(offenders).toEqual([]);
+  });
+});
+
+/**
+ * Collects the exported names (values and types) of a barrel that consists of named re-export
+ * declarations. Star re-exports are rejected because their names cannot be read off the file,
+ * which would make the subset comparison below silently unsound.
+ */
+function namedExports(filePath: string): Set<string> {
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    fs.readFileSync(filePath, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true
+  );
+
+  const names = new Set<string>();
+  for (const statement of sourceFile.statements) {
+    if (!ts.isExportDeclaration(statement)) {
+      continue;
+    }
+
+    if (!statement.exportClause || !ts.isNamedExports(statement.exportClause)) {
+      throw new Error(
+        `${path.relative(SRC_DIR, filePath)} contains a star re-export. This test can only ` +
+          'compare named exports; list the names explicitly or rework the comparison.'
+      );
+    }
+
+    for (const element of statement.exportClause.elements) {
+      names.add(element.name.text);
+    }
+  }
+
+  return names;
+}
+
+describe('engine entrypoint surface', () => {
+  /**
+   * The engine barrel is a subset of the root barrel by design: appearing in `/engine` must
+   * never be what makes a symbol public. This catches the drift where an export is added to
+   * one barrel and not the other.
+   */
+  it('exports nothing the root barrel does not export', () => {
+    const engineExports = namedExports(ENGINE_ENTRYPOINT);
+    const rootExports = namedExports(ROOT_BARREL);
+
+    const onlyInEngine = [...engineExports].filter((name) => !rootExports.has(name)).sort();
+
+    expect(onlyInEngine).toEqual([]);
   });
 });

--- a/packages/smart-forms-renderer/src/test/packageExports.test.ts
+++ b/packages/smart-forms-renderer/src/test/packageExports.test.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * The package's `exports` map has no directory-index fallback: `./lib/*` mapping to
+ * `./lib/*.js` cannot resolve a directory barrel like `lib/stores` via its `index.js`, so
+ * every directory barrel must be enumerated explicitly. Nothing else keeps that enumeration
+ * in sync with the source tree: add a new directory with an `index.ts` and its barrel
+ * silently stops resolving for consumers. This test is the sync guard.
+ */
+
+const PACKAGE_ROOT = path.resolve(__dirname, '../..');
+const SRC_DIR = path.resolve(__dirname, '..');
+
+/** Directories tsconfig/.npmignore keep out of `lib/`, so they need no exports entry. */
+const UNPUBLISHED_DIRECTORIES = new Set(['stories', 'test', 'tests']);
+
+/** Every directory under `src/` (as a relative path) that has an `index.ts`/`index.tsx` barrel. */
+function collectBarrelDirectories(directory: string): string[] {
+  const barrels: string[] = [];
+
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (UNPUBLISHED_DIRECTORIES.has(entry.name)) {
+        continue;
+      }
+      barrels.push(...collectBarrelDirectories(path.join(directory, entry.name)));
+      continue;
+    }
+
+    if (entry.name === 'index.ts' || entry.name === 'index.tsx') {
+      barrels.push(path.relative(SRC_DIR, directory));
+    }
+  }
+
+  return barrels.sort();
+}
+
+describe('package.json exports map', () => {
+  const packageJson = JSON.parse(fs.readFileSync(path.join(PACKAGE_ROOT, 'package.json'), 'utf8'));
+  const exportsMap: Record<string, unknown> = packageJson.exports;
+
+  it('declares the root, lib and engine entrypoints', () => {
+    expect(exportsMap['.']).toBeDefined();
+    expect(exportsMap['./lib']).toBeDefined();
+    expect(exportsMap['./engine']).toBeDefined();
+  });
+
+  it('enumerates every published directory barrel under lib/', () => {
+    // The root barrel is `src/index.ts` itself, covered by the "." and "./lib" entries above.
+    const barrelDirectories = collectBarrelDirectories(SRC_DIR).filter(
+      (directory) => directory !== ''
+    );
+
+    const missing = barrelDirectories.filter(
+      (directory) => exportsMap[`./lib/${directory}`] === undefined
+    );
+
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #2059

Server-side and React Native consumers need the form engine (stores, `buildForm`, populate and extract plumbing) without the DOM-bound UI tree. This adds `@aehrc/smart-forms-renderer/engine`, a headless entrypoint whose runtime import graph contains no UI package, and the package's first `exports` map. The two ship together because the clean `/engine` specifier only exists through the map.

The engine barrel is a strict subset of the root barrel: nothing becomes public by appearing in `/engine` alone, and a test enforces the subset. `engineEntrypoint.test.ts` cruises the graph with dependency-cruiser: no UI library may load at runtime, and the type surface a consumer must resolve to typecheck is pinned to three `@mui/material` entries, needed because `RendererConfig` keys breakpoints by MUI's augmentable `Breakpoint` type. Getting the pin that small meant moving the `RenderingExtensions` interface into `interfaces/` and importing `UseResponsiveProps` from its own module rather than the hooks barrel, so type edges no longer drag the hooks layer (and with it `html-react-parser`) into the closure.

A second guard, `packageExports.test.ts`, keeps the exports map in sync with the source tree: every directory barrel under `src/` must have a `./lib/<dir>` entry, since the map has no directory-index fallback.

For review: `src/engine.ts` (the surface), the `exports` map in `package.json`, and the two test files. Stacked on #2061 (base branch is `issue/2058`).

Testing: full renderer jest suite green (94 suites, 2201 tests). Every published `./lib` subpath was resolution-checked under node16, bundler, and node10 settings when the map was authored; the guard test keeps it in sync from here.

Not verified: Metro (React Native) resolution and an `npm pack` install into a real consumer.
