### PR TITLE
Back the HAPI FHIR servers with RDS PostgreSQL

### DIFF
--- a/deployment/ehr-proxy/README.md
+++ b/deployment/ehr-proxy/README.md
@@ -13,6 +13,12 @@ From: https://github.com/hapifhir/hapi-fhir-jpaserver-starter
 
 Base URL: `https://proxy.smartforms.io/fhir/`
 
+The endpoint is backed by a dedicated RDS PostgreSQL instance (`db.t4g.micro`) created alongside it
+in the same construct. HAPI defaults to an in-memory H2 database when no datasource is configured,
+which means the server starts empty every time the Fargate task is replaced, so the datasource is
+configured explicitly. Credentials are generated into Secrets Manager and injected into the task as
+`SPRING_DATASOURCE_USERNAME` and `SPRING_DATASOURCE_PASSWORD`.
+
 ### smart-proxy
 A microservice running in Docker that acts as a SMART on FHIR plugin layered on top of the HAPI server.
 It requires the `FHIR_SERVER_R4` environment variable pointing to the HAPI server.

--- a/deployment/ehr-proxy/hapi-endpoint/lib/index.ts
+++ b/deployment/ehr-proxy/hapi-endpoint/lib/index.ts
@@ -1,14 +1,24 @@
 // import * as cdk from 'aws-cdk-lib';
+import { Duration, RemovalPolicy } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
+import { InstanceClass, InstanceSize, InstanceType, SubnetType } from 'aws-cdk-lib/aws-ec2';
 import {
   AwsLogDriver,
   Cluster,
   Compatibility,
   ContainerImage,
   FargateService,
+  Secret as EcsSecret,
   TaskDefinition
 } from 'aws-cdk-lib/aws-ecs';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
+import {
+  Credentials,
+  DatabaseInstance,
+  DatabaseInstanceEngine,
+  PostgresEngineVersion,
+  StorageType
+} from 'aws-cdk-lib/aws-rds';
 
 // import * as sqs from 'aws-cdk-lib/aws-sqs';
 
@@ -19,12 +29,39 @@ export interface HapiEndpointProps {
 export class HapiEndpoint extends Construct {
   containerName = 'ehr-proxy-hapi';
   containerPort = 8080;
+  databaseName = 'hapi';
   service: FargateService;
+  database: DatabaseInstance;
 
   constructor(scope: Construct, id: string, props: HapiEndpointProps) {
     super(scope, id);
 
     const { cluster } = props;
+
+    // Persistent storage for the HAPI FHIR server. Without it HAPI falls back to its default
+    // in-memory H2 database (jdbc:h2:mem:test_mem), so every task replacement silently discards
+    // all Patient, Practitioner, Questionnaire and QuestionnaireResponse data.
+    //
+    // db.t4g.micro gives the database the 1 GiB it previously had to borrow from the 2 GiB task,
+    // and its burstable CPU suits the intermittent demo and evaluation traffic this endpoint sees.
+    this.database = new DatabaseInstance(this, 'EhrProxyHapiDatabase', {
+      engine: DatabaseInstanceEngine.postgres({ version: PostgresEngineVersion.VER_18_3 }),
+      instanceType: InstanceType.of(InstanceClass.BURSTABLE4_GRAVITON, InstanceSize.MICRO),
+      autoMinorVersionUpgrade: true,
+      vpc: cluster.vpc,
+      vpcSubnets: { subnetType: SubnetType.PRIVATE_WITH_EGRESS },
+      databaseName: this.databaseName,
+      credentials: Credentials.fromGeneratedSecret('hapi'),
+      allocatedStorage: 20,
+      maxAllocatedStorage: 100,
+      storageType: StorageType.GP3,
+      storageEncrypted: true,
+      multiAz: false,
+      backupRetention: Duration.days(7),
+      deleteAutomatedBackups: false,
+      deletionProtection: true,
+      removalPolicy: RemovalPolicy.SNAPSHOT
+    });
 
     // Create a task definition that contains both the application and cache containers.
     const taskDefinition = new TaskDefinition(this, 'EhrProxyHapiTaskDefinition', {
@@ -40,7 +77,9 @@ export class HapiEndpoint extends Construct {
     // Create the cache container.
     taskDefinition.addContainer('EhrProxyHapiContainer', {
       containerName: this.containerName,
-      image: ContainerImage.fromRegistry('hapiproject/hapi:latest'),
+      // Pinned rather than tracked at `latest`: now that the database outlives the task, an
+      // unattended version bump would run schema migrations against real data.
+      image: ContainerImage.fromRegistry('hapiproject/hapi:v8.10.0-3'),
       portMappings: [{ containerPort: this.containerPort }],
       logging: AwsLogDriver.awsLogs({
         streamPrefix: 'ehr-proxy-hapi',
@@ -50,12 +89,29 @@ export class HapiEndpoint extends Construct {
         use_apache_address_strategy: 'true',
         'hapi.fhir.openapi_enabled': 'false',
         'hapi.fhir.server_address': fhirServerBaseUrl,
+        SPRING_DATASOURCE_URL: `jdbc:postgresql://${this.database.dbInstanceEndpointAddress}:${this.database.dbInstanceEndpointPort}/${this.databaseName}`,
+        SPRING_DATASOURCE_DRIVERCLASSNAME: 'org.postgresql.Driver',
+        SPRING_JPA_PROPERTIES_HIBERNATE_DIALECT:
+          'ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgresDialect'
+      },
+      secrets: {
+        SPRING_DATASOURCE_USERNAME: EcsSecret.fromSecretsManager(this.database.secret!, 'username'),
+        SPRING_DATASOURCE_PASSWORD: EcsSecret.fromSecretsManager(this.database.secret!, 'password')
       }
     });
 
     this.service = new FargateService(this, 'EhrProxyHapiService', {
       cluster,
-      taskDefinition
+      taskDefinition,
+      // Schema migration against a cold database pushes first boot past the target group's
+      // tolerance, which previously surfaced as tasks replaced for "Request timed out".
+      healthCheckGracePeriod: Duration.minutes(5)
     });
+
+    this.database.connections.allowDefaultPortFrom(
+      this.service,
+      'Allow the HAPI FHIR server to reach its database'
+    );
+    this.service.node.addDependency(this.database);
   }
 }

--- a/deployment/forms-server/README.md
+++ b/deployment/forms-server/README.md
@@ -12,6 +12,12 @@ From: https://github.com/hapifhir/hapi-fhir-jpaserver-starter
 
 Base URL: `https://smartforms.csiro.au/api/fhir/`
 
+The endpoint is backed by a dedicated RDS PostgreSQL instance (`db.t4g.small`) created alongside it
+in the same construct. HAPI defaults to an in-memory H2 database when no datasource is configured,
+which means the server starts empty every time the Fargate task is replaced, so the datasource is
+configured explicitly. Credentials are generated into Secrets Manager and injected into the task as
+`SPRING_DATASOURCE_USERNAME` and `SPRING_DATASOURCE_PASSWORD`.
+
 ### assemble-endpoint
 A microservice in Docker for Questionnaire [$assemble](https://build.fhir.org/ig/HL7/sdc/OperationDefinition-Questionnaire-assemble.html) operation.
 

--- a/deployment/forms-server/hapi-endpoint/lib/index.ts
+++ b/deployment/forms-server/hapi-endpoint/lib/index.ts
@@ -1,14 +1,24 @@
 // import * as cdk from 'aws-cdk-lib';
+import { Duration, RemovalPolicy } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
+import { InstanceClass, InstanceSize, InstanceType, SubnetType } from 'aws-cdk-lib/aws-ec2';
 import {
   AwsLogDriver,
   Cluster,
   Compatibility,
   ContainerImage,
   FargateService,
+  Secret as EcsSecret,
   TaskDefinition
 } from 'aws-cdk-lib/aws-ecs';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
+import {
+  Credentials,
+  DatabaseInstance,
+  DatabaseInstanceEngine,
+  PostgresEngineVersion,
+  StorageType
+} from 'aws-cdk-lib/aws-rds';
 
 // import * as sqs from 'aws-cdk-lib/aws-sqs';
 
@@ -19,12 +29,40 @@ export interface HapiEndpointProps {
 export class HapiEndpoint extends Construct {
   containerName = 'forms-server-hapi';
   containerPort = 8080;
+  databaseName = 'hapi';
   service: FargateService;
+  database: DatabaseInstance;
 
   constructor(scope: Construct, id: string, props: HapiEndpointProps) {
     super(scope, id);
 
     const { cluster } = props;
+
+    // Persistent storage for the HAPI FHIR server. Without it HAPI falls back to its default
+    // in-memory H2 database (jdbc:h2:mem:test_mem), so every task replacement silently discards
+    // the published Questionnaires and has to be repopulated by hand.
+    //
+    // db.t4g.small gives the database the 2 GiB it previously had to borrow from the 4 GiB task,
+    // keeping it in the same proportion to its task as the ehr-proxy database is to that one. This
+    // server holds the larger dataset of the two, and it backs the main smartforms.csiro.au app.
+    this.database = new DatabaseInstance(this, 'FormsServerHapiDatabase', {
+      engine: DatabaseInstanceEngine.postgres({ version: PostgresEngineVersion.VER_18_3 }),
+      instanceType: InstanceType.of(InstanceClass.BURSTABLE4_GRAVITON, InstanceSize.SMALL),
+      autoMinorVersionUpgrade: true,
+      vpc: cluster.vpc,
+      vpcSubnets: { subnetType: SubnetType.PRIVATE_WITH_EGRESS },
+      databaseName: this.databaseName,
+      credentials: Credentials.fromGeneratedSecret('hapi'),
+      allocatedStorage: 20,
+      maxAllocatedStorage: 100,
+      storageType: StorageType.GP3,
+      storageEncrypted: true,
+      multiAz: false,
+      backupRetention: Duration.days(7),
+      deleteAutomatedBackups: false,
+      deletionProtection: true,
+      removalPolicy: RemovalPolicy.SNAPSHOT
+    });
 
     // Create a task definition that contains both the application and cache containers.
     const taskDefinition = new TaskDefinition(this, 'FormsServerHapiTaskDefinition', {
@@ -36,7 +74,9 @@ export class HapiEndpoint extends Construct {
     // Create the cache container.
     taskDefinition.addContainer('FormsServerHapiContainer', {
       containerName: this.containerName,
-      image: ContainerImage.fromRegistry('hapiproject/hapi:latest'),
+      // Pinned rather than tracked at `latest`: now that the database outlives the task, an
+      // unattended version bump would run schema migrations against real data.
+      image: ContainerImage.fromRegistry('hapiproject/hapi:v8.10.0-3'),
       portMappings: [{ containerPort: this.containerPort }],
       logging: AwsLogDriver.awsLogs({
         streamPrefix: 'forms-server-hapi',
@@ -44,14 +84,31 @@ export class HapiEndpoint extends Construct {
       }),
       environment: {
         use_apache_address_strategy: 'true',
-        'hapi.fhir.openapi_enabled': 'false'
+        'hapi.fhir.openapi_enabled': 'false',
         // 'hapi.fhir.cr.enabled': 'true' // If you want to use the Clinical Reasoning module
+        SPRING_DATASOURCE_URL: `jdbc:postgresql://${this.database.dbInstanceEndpointAddress}:${this.database.dbInstanceEndpointPort}/${this.databaseName}`,
+        SPRING_DATASOURCE_DRIVERCLASSNAME: 'org.postgresql.Driver',
+        SPRING_JPA_PROPERTIES_HIBERNATE_DIALECT:
+          'ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgresDialect'
+      },
+      secrets: {
+        SPRING_DATASOURCE_USERNAME: EcsSecret.fromSecretsManager(this.database.secret!, 'username'),
+        SPRING_DATASOURCE_PASSWORD: EcsSecret.fromSecretsManager(this.database.secret!, 'password')
       }
     });
 
     this.service = new FargateService(this, 'FormsServerHapiService', {
       cluster,
-      taskDefinition
+      taskDefinition,
+      // Schema migration against a cold database pushes first boot past the target group's
+      // tolerance, which previously surfaced as tasks replaced for "Request timed out".
+      healthCheckGracePeriod: Duration.minutes(5)
     });
+
+    this.database.connections.allowDefaultPortFrom(
+      this.service,
+      'Allow the HAPI FHIR server to reach its database'
+    );
+    this.service.node.addDependency(this.database);
   }
 }


### PR DESCRIPTION
## Problem

Both HAPI FHIR servers store everything in RAM and lose it on every task replacement.

Neither `forms-server` nor `ehr-proxy` configured a datasource, so HAPI fell back to its default in-memory database. Confirmed from the running container logs:

```
jdbc:h2:mem:test_mem
```

The task definitions had `"volumes": []` and `"mountPoints": []`, and there was no RDS instance or EFS filesystem in the account backing either server. The data existed only in the Fargate task's memory.

This is the cause of the reported "the server gets wiped and someone has to repopulate it by hand". It is not intermittent corruption, it is total loss on any task replacement. ECS does this routinely. From the `ehr-proxy` service events:

```
2026-07-30T15:30:59  (task 8ced774a...) (port 8080) is unhealthy ... (reason Request timed out)
2026-07-30T15:26:53  Amazon ECS replaced 1 tasks due to an unhealthy status
```

A second symptom of the same root cause: both services track `hapiproject/hapi:latest`, and because they restarted at different times they had silently drifted to different HAPI versions (`ehr-proxy` on 8.4.0, `forms-server` on 8.10.0).

## Change

- Each HAPI endpoint gets a dedicated RDS PostgreSQL instance in the private subnets of its existing VPC.
- HAPI is pointed at it via `SPRING_DATASOURCE_URL` / `_DRIVERCLASSNAME` / `_USERNAME` / `_PASSWORD` and the `HapiFhirPostgresDialect`.
- Credentials are generated into Secrets Manager and injected as ECS task **secrets**, so they never appear in the task definition.
- The database security group accepts connections only from the service that owns it.
- The image is pinned to `hapiproject/hapi:v8.10.0-3`.
- A five minute health check grace period is added.

No change was needed to either app stack: the construct takes the VPC from `cluster.vpc`, so the diff is contained to the two `hapi-endpoint` constructs plus docs.

### Sizing

Each database gets the memory its in-memory predecessor was borrowing from the task, keeping the two in the same proportion to their tasks:

| | Task | Database | Storage |
|---|---|---|---|
| `ehr-proxy` | 1 vCPU / 2 GiB | `db.t4g.micro` (1 GiB) | 20 GiB GP3, autoscale to 100 |
| `forms-server` | 2 vCPU / 4 GiB | `db.t4g.small` (2 GiB) | 20 GiB GP3, autoscale to 100 |

Burstable Graviton suits the intermittent demo and evaluation traffic these serve. Both are single-AZ, which matches the stated lack of uptime requirements. Encrypted, 7 days of automated backups, deletion protection on, and `RemovalPolicy.SNAPSHOT`.

### Versions

- **PostgreSQL 18.3**, the current RDS default in `ap-southeast-2` and the major with the longest support runway. Minor upgrades are automatic.
- **HAPI `v8.10.0-3`**, the newest published tag. Verified byte-identical to `latest` by digest, so pinning changes nothing today but stops unattended migrations against real data later.

## Verification

CDK synth of both stacks succeeds and produces the expected resources. Beyond that, the exact container and env var configuration in this PR was run locally against PostgreSQL 18.3:

- HAPI 8.10.0-3 boots and completes schema migration on a cold database (~30s).
- `PUT Questionnaire` and `POST QuestionnaireResponse` both return 201.
- Indexed search (`QuestionnaireResponse?questionnaire=...`) returns the expected match.
- **The container was then destroyed and recreated, and all data was still present.** This is the case that fails today.
- Second boot logs zero schema warnings.

The initially chosen `HapiFhirPostgres94Dialect` was caught during this testing as deprecated in HAPI 8.10 and replaced with `HapiFhirPostgresDialect`.

## Deployment notes

- **The servers will come up empty.** The current contents live only in RAM and cannot be migrated. `forms-server` currently holds 141 Questionnaires and `ehr-proxy` holds 15 Questionnaires / 11 QuestionnaireResponses / 51 Patients / 20 Practitioners, all of which will need reloading after this deploys.
- First deploy takes roughly 10 to 15 minutes for the RDS instances to become available.
- Deletion protection is on, so a future `cdk destroy` will need it disabled manually. That is deliberate.

## Follow-up, not in this PR

- Seeding and reset automation, so repopulating is a command rather than a manual task. `aehrc/smart-forms-fhir-data` already holds starter bundles and `aehrc/sparked-test-data-loader` already solves the load/clear problem.
- The two `hapi-endpoint` constructs are near-identical and this PR adds more duplication between them. Factoring them into one shared construct is worth doing, but deliberately kept out of a change whose purpose is fixing data loss.