### PR TITLE
feat(write-back): post-extraction bundle validation via $validate (#1983)

### DIFF
--- a/apps/smart-forms-app/src/contexts/SmartClientContext.tsx
+++ b/apps/smart-forms-app/src/contexts/SmartClientContext.tsx
@@ -21,6 +21,11 @@ import type { Encounter, FhirResource, Patient, Practitioner, Questionnaire } fr
 import type Client from 'fhirclient/lib/Client';
 import type { FhirContext } from '../features/smartAppLaunch/utils/launch.ts';
 
+export interface ExtraLaunchContext {
+  disableWriteBackSelection: boolean;
+  disableBundleValidation: boolean;
+}
+
 export interface SmartClientState {
   smartClient: Client | null;
   patient: Patient | null;
@@ -30,7 +35,7 @@ export interface SmartClientState {
   resolvedFhirContextReferences: Record<string, FhirResource> | null;
   launchQuestionnaire: Questionnaire | null;
   tokenReceivedTimestamp: number | null;
-  disableWriteBackSelection: boolean;
+  extraLaunchContext: ExtraLaunchContext;
 }
 
 export type SmartClientActions =
@@ -42,7 +47,7 @@ export type SmartClientActions =
   | { type: 'SET_QUESTIONNAIRE_CONTEXT'; payload: Questionnaire }
   | { type: 'SET_FHIR_CONTEXT'; payload: FhirContext[] }
   | { type: 'SET_RESOLVED_FHIR_CONTEXT_REFERENCES'; payload: Record<string, FhirResource> }
-  | { type: 'SET_DISABLE_WRITEBACK_SELECTION'; payload: boolean };
+  | { type: 'SET_EXTRA_LAUNCH_CONTEXT'; payload: ExtraLaunchContext };
 
 function smartClientReducer(state: SmartClientState, action: SmartClientActions): SmartClientState {
   switch (action.type) {
@@ -61,8 +66,8 @@ function smartClientReducer(state: SmartClientState, action: SmartClientActions)
       return { ...state, fhirContext: action.payload };
     case 'SET_RESOLVED_FHIR_CONTEXT_REFERENCES':
       return { ...state, resolvedFhirContextReferences: action.payload };
-    case 'SET_DISABLE_WRITEBACK_SELECTION':
-      return { ...state, disableWriteBackSelection: action.payload };
+    case 'SET_EXTRA_LAUNCH_CONTEXT':
+      return { ...state, extraLaunchContext: action.payload };
     default:
       return state;
   }
@@ -77,7 +82,10 @@ const initialSmartClientState: SmartClientState = {
   fhirContext: null,
   resolvedFhirContextReferences: null,
   tokenReceivedTimestamp: null,
-  disableWriteBackSelection: false
+  extraLaunchContext: {
+    disableWriteBackSelection: false,
+    disableBundleValidation: false
+  }
 };
 
 export interface SmartClientContextType {

--- a/apps/smart-forms-app/src/contexts/test/SmartClientContext.test.tsx
+++ b/apps/smart-forms-app/src/contexts/test/SmartClientContext.test.tsx
@@ -96,7 +96,10 @@ describe('SmartClientContext', () => {
       expect(mockContext.state.launchQuestionnaire).toBeNull();
       expect(mockContext.state.fhirContext).toBeNull();
       expect(mockContext.state.tokenReceivedTimestamp).toBeNull();
-      expect(mockContext.state.disableWriteBackSelection).toBe(false);
+      expect(mockContext.state.extraLaunchContext).toEqual({
+        disableWriteBackSelection: false,
+        disableBundleValidation: false
+      });
       expect(typeof mockContext.dispatch).toBe('function');
     });
 
@@ -350,40 +353,52 @@ describe('SmartClientContext', () => {
     });
   });
 
-  describe('SET_DISABLE_WRITEBACK_SELECTION action', () => {
-    it('should set disableWriteBackSelection to true', () => {
+  describe('SET_EXTRA_LAUNCH_CONTEXT action', () => {
+    it('should set extraLaunchContext', () => {
       renderWithProvider((context) => {
         mockContext = context;
       });
 
       act(() => {
         mockContext.dispatch({
-          type: 'SET_DISABLE_WRITEBACK_SELECTION',
-          payload: true
+          type: 'SET_EXTRA_LAUNCH_CONTEXT',
+          payload: { disableWriteBackSelection: true, disableBundleValidation: true }
         });
       });
 
-      expect(mockContext.state.disableWriteBackSelection).toBe(true);
+      expect(mockContext.state.extraLaunchContext).toEqual({
+        disableWriteBackSelection: true,
+        disableBundleValidation: true
+      });
 
       // Other state should remain unchanged
       expect(mockContext.state.smartClient).toBeNull();
       expect(mockContext.state.patient).toBeNull();
     });
 
-    it('should set disableWriteBackSelection back to false', () => {
+    it('should reset extraLaunchContext back to defaults', () => {
       renderWithProvider((context) => {
         mockContext = context;
       });
 
       act(() => {
-        mockContext.dispatch({ type: 'SET_DISABLE_WRITEBACK_SELECTION', payload: true });
+        mockContext.dispatch({
+          type: 'SET_EXTRA_LAUNCH_CONTEXT',
+          payload: { disableWriteBackSelection: true, disableBundleValidation: true }
+        });
       });
 
       act(() => {
-        mockContext.dispatch({ type: 'SET_DISABLE_WRITEBACK_SELECTION', payload: false });
+        mockContext.dispatch({
+          type: 'SET_EXTRA_LAUNCH_CONTEXT',
+          payload: { disableWriteBackSelection: false, disableBundleValidation: false }
+        });
       });
 
-      expect(mockContext.state.disableWriteBackSelection).toBe(false);
+      expect(mockContext.state.extraLaunchContext).toEqual({
+        disableWriteBackSelection: false,
+        disableBundleValidation: false
+      });
     });
   });
 

--- a/apps/smart-forms-app/src/features/prepopulate/test/usePopulate.test.tsx
+++ b/apps/smart-forms-app/src/features/prepopulate/test/usePopulate.test.tsx
@@ -175,13 +175,16 @@ describe('usePopulate', () => {
     resolvedFhirContextReferences: null,
     launchQuestionnaire: null,
     tokenReceivedTimestamp: null,
-    disableWriteBackSelection: false,
+    extraLaunchContext: {
+      disableWriteBackSelection: false,
+      disableBundleValidation: false
+    },
     setSmartClient: jest.fn(),
     setCommonLaunchContexts: jest.fn(),
     setQuestionnaireLaunchContext: jest.fn(),
     setFhirContext: jest.fn(),
     setResolvedFhirContextReferences: jest.fn(),
-    setDisableWriteBackSelection: jest.fn(),
+    setExtraLaunchContext: jest.fn(),
     ...overrides
   });
 

--- a/apps/smart-forms-app/src/features/renderer/components/RendererActions/RendererSaveAsFinalWriteBackDialog.tsx
+++ b/apps/smart-forms-app/src/features/renderer/components/RendererActions/RendererSaveAsFinalWriteBackDialog.tsx
@@ -36,15 +36,22 @@ export interface RendererSaveAsFinalWriteBackDialogProps {
   dialogOpen: boolean;
   isAmendment: boolean;
   extractedBundle: Bundle;
+  invalidBundleEntryIndices?: Set<number>;
   onCloseDialog: () => unknown;
   onDialogExited: () => unknown;
 }
 
 function RendererSaveAsFinalWriteBackDialog(props: RendererSaveAsFinalWriteBackDialogProps) {
-  const { dialogOpen, isAmendment, extractedBundle, onCloseDialog, onDialogExited } = props;
+  const {
+    dialogOpen,
+    isAmendment,
+    extractedBundle,
+    invalidBundleEntryIndices,
+    onCloseDialog,
+    onDialogExited
+  } = props;
 
-  const { smartClient, patient, user, launchQuestionnaire, disableWriteBackSelection } =
-    useSmartClient();
+  const { smartClient, patient, user, launchQuestionnaire, extraLaunchContext } = useSmartClient();
 
   const sourceQuestionnaire = useQuestionnaireStore.use.sourceQuestionnaire();
   const updatableResponse = useQuestionnaireResponseStore.use.updatableResponse();
@@ -175,7 +182,8 @@ function RendererSaveAsFinalWriteBackDialog(props: RendererSaveAsFinalWriteBackD
       isSaving={isSaving}
       isAmendment={isAmendment}
       extractedBundle={extractedBundle}
-      disableWriteBackSelection={disableWriteBackSelection}
+      invalidBundleEntryIndices={invalidBundleEntryIndices}
+      disableWriteBackSelection={extraLaunchContext.disableWriteBackSelection}
       onCloseDialog={handleClose}
       onWriteBackBundle={async (bundleToWriteBack, savingWriteBackMode) => {
         if (savingWriteBackMode === 'saving-only') {

--- a/apps/smart-forms-app/src/features/renderer/components/RendererActions/SaveAsFinalAction.tsx
+++ b/apps/smart-forms-app/src/features/renderer/components/RendererActions/SaveAsFinalAction.tsx
@@ -30,6 +30,7 @@ import { extractResultIsOperationOutcome, inAppExtract } from '@aehrc/sdc-templa
 import type { Bundle, QuestionnaireResponse } from 'fhir/r4';
 import RendererSaveAsFinalOnlyDialog from './RendererSaveAsFinalOnlyDialog.tsx';
 import RendererSaveAsFinalWriteBackDialog from './RendererSaveAsFinalWriteBackDialog.tsx';
+import { validateExtractedBundle } from '../../../writeBack/utils/validateExtractedBundle.ts';
 import { populateQuestionnaire } from '@aehrc/sdc-populate';
 import { fetchResourceCallback } from '../../../prepopulate/utils/callback.ts';
 import { useSnackbar } from 'notistack';
@@ -45,11 +46,14 @@ interface SaveAsFinalActionProps extends SpeedDialActionProps {
 function SaveAsFinalAction(props: SaveAsFinalActionProps) {
   const { isSpeedDial, onCloseSpeedDial, ...speedDialActionProps } = props;
 
-  const { smartClient, patient, user, encounter } = useSmartClient();
+  const { smartClient, patient, user, encounter, extraLaunchContext } = useSmartClient();
 
   const [saveAsFinalDialogOpen, setSaveAsFinalDialogOpen] = useState(false);
   const [isExtracting, setExtracting] = useState(false);
   const [extractedBundle, setExtractedBundle] = useState<Bundle | null>(null);
+  const [invalidBundleEntryIndices, setInvalidBundleEntryIndices] = useState<Set<number> | null>(
+    null
+  );
 
   const sourceQuestionnaire = useQuestionnaireStore.use.sourceQuestionnaire();
   const tabs = useQuestionnaireStore.use.tabs();
@@ -139,7 +143,15 @@ function SaveAsFinalAction(props: SaveAsFinalActionProps) {
       return;
     }
 
+    // Validate before updating state — ensures WriteBackBundleSelectorDialog mounts with
+    // invalidBundleEntryIndices already set, so its selectedKeys initializer excludes invalid entries
+    const validationResults = extraLaunchContext.disableBundleValidation
+      ? new Set<number>()
+      : await validateExtractedBundle(extractResult.extractedBundle, smartClient);
+
+    // All four updates land in the same React 18 batch → single render → component mounts correctly
     setExtractedBundle(extractResult.extractedBundle);
+    setInvalidBundleEntryIndices(validationResults.size > 0 ? validationResults : null);
     setExtracting(false);
 
     // Open dialog after extraction is complete
@@ -188,6 +200,7 @@ function SaveAsFinalAction(props: SaveAsFinalActionProps) {
     // Reset extract-related states back to false
     setExtracting(false);
     setExtractedBundle(null);
+    setInvalidBundleEntryIndices(null);
   }
 
   // Check if an in-progress QR has been saved before via versionId
@@ -235,6 +248,7 @@ function SaveAsFinalAction(props: SaveAsFinalActionProps) {
             dialogOpen={saveAsFinalDialogOpen}
             isAmendment={isAmendment}
             extractedBundle={extractedBundle}
+            invalidBundleEntryIndices={invalidBundleEntryIndices ?? undefined}
             onCloseDialog={handleCloseDialog}
             onDialogExited={handleDialogExited}
           />

--- a/apps/smart-forms-app/src/features/smartAppLaunch/components/Authorisation.tsx
+++ b/apps/smart-forms-app/src/features/smartAppLaunch/components/Authorisation.tsx
@@ -20,6 +20,7 @@ import { oauth2 } from 'fhirclient';
 import type { tokenResponseCustomised } from '../utils/launch.ts';
 import {
   DISABLE_WRITEBACK_SELECTION_CONTEXT_KEY,
+  DISABLE_BUNDLE_VALIDATION_CONTEXT_KEY,
   getQuestionnaireReferences,
   readCommonLaunchContexts,
   readQuestionnaireContext,
@@ -81,7 +82,7 @@ function Authorisation() {
     setQuestionnaireLaunchContext,
     setFhirContext,
     setResolvedFhirContextReferences,
-    setDisableWriteBackSelection
+    setExtraLaunchContext
   } = useSmartClient();
 
   const { enqueueSnackbar } = useSnackbar();
@@ -123,12 +124,16 @@ function Authorisation() {
             setFhirContext(fhirContext);
           }
 
-          // Read disable-writeback-selection extra context from the token response
+          // Read extra launch context extensions from the token response
           const rawDisableWriteBackSelection =
             tokenResponse?.[DISABLE_WRITEBACK_SELECTION_CONTEXT_KEY];
-          const disableWriteBackSelection =
-            rawDisableWriteBackSelection === true || rawDisableWriteBackSelection === 'true';
-          setDisableWriteBackSelection(disableWriteBackSelection);
+          const rawDisableBundleValidation = tokenResponse?.[DISABLE_BUNDLE_VALIDATION_CONTEXT_KEY];
+          setExtraLaunchContext({
+            disableWriteBackSelection:
+              rawDisableWriteBackSelection === true || rawDisableWriteBackSelection === 'true',
+            disableBundleValidation:
+              rawDisableBundleValidation === true || rawDisableBundleValidation === 'true'
+          });
 
           // Get Questionnaire context from fhirContext array
           // the set questionnaire launch context if available

--- a/apps/smart-forms-app/src/features/smartAppLaunch/utils/launch.ts
+++ b/apps/smart-forms-app/src/features/smartAppLaunch/utils/launch.ts
@@ -81,10 +81,16 @@ export interface FhirContext {
 export const DISABLE_WRITEBACK_SELECTION_CONTEXT_KEY =
   'https://smartforms.csiro.au/smart-app-launch/extra-context/disable-writeback-selection';
 
+export const DISABLE_BUNDLE_VALIDATION_CONTEXT_KEY =
+  'https://smartforms.csiro.au/smart-app-launch/extra-context/disable-bundle-validation';
+
 export interface tokenResponseCustomised extends fhirclient.TokenResponse {
   fhirContext?: FhirContext[];
   intent?: string;
   'https://smartforms.csiro.au/smart-app-launch/extra-context/disable-writeback-selection'?:
+    | boolean
+    | string;
+  'https://smartforms.csiro.au/smart-app-launch/extra-context/disable-bundle-validation'?:
     | boolean
     | string;
 }

--- a/apps/smart-forms-app/src/features/writeBack/components/WriteBackBundleSelectorDialog.tsx
+++ b/apps/smart-forms-app/src/features/writeBack/components/WriteBackBundleSelectorDialog.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import {
+  Alert,
   Box,
   Button,
   Dialog,
@@ -26,6 +27,7 @@ interface WriteBackBundleSelectorProps {
   isSaving: SavingWriteBackMode;
   isAmendment?: boolean;
   extractedBundle: Bundle;
+  invalidBundleEntryIndices?: Set<number>;
   disableWriteBackSelection?: boolean;
   onCloseDialog: () => void;
   onWriteBackBundle: (bundleToWriteBack: Bundle, savingWriteBackMode: SavingWriteBackMode) => void;
@@ -38,6 +40,7 @@ function WriteBackBundleSelectorDialog(props: WriteBackBundleSelectorProps) {
     isSaving,
     isAmendment,
     extractedBundle,
+    invalidBundleEntryIndices,
     disableWriteBackSelection = false,
     onCloseDialog,
     onWriteBackBundle,
@@ -66,7 +69,18 @@ function WriteBackBundleSelectorDialog(props: WriteBackBundleSelectorProps) {
     [allBundleEntries]
   );
 
-  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(allValidKeys);
+  // Valid keys that can actually be selected (excludes $validate failures)
+  const selectableKeys: Set<string> = useMemo(() => {
+    const keys = new Set(allValidKeys);
+    if (invalidBundleEntryIndices) {
+      for (const index of invalidBundleEntryIndices) {
+        keys.delete(createSelectionKey(index));
+      }
+    }
+    return keys;
+  }, [allValidKeys, invalidBundleEntryIndices]);
+
+  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(selectableKeys);
 
   function isEntrySelected(
     bundleEntryIndex: number,
@@ -146,7 +160,7 @@ function WriteBackBundleSelectorDialog(props: WriteBackBundleSelectorProps) {
   }
 
   function handleSelectAll() {
-    setSelectedKeys(allValidKeys);
+    setSelectedKeys(selectableKeys);
   }
 
   function handleUnselectAll() {
@@ -165,7 +179,8 @@ function WriteBackBundleSelectorDialog(props: WriteBackBundleSelectorProps) {
     );
   }
 
-  const allValidKeysSelected = selectedKeys.size === allValidKeys.size;
+  const allSelectableKeysSelected =
+    selectableKeys.size > 0 && selectedKeys.size === selectableKeys.size;
 
   // Button texts based on if view mode is in renderer or playground
   const writeBackButtonText =
@@ -192,19 +207,60 @@ function WriteBackBundleSelectorDialog(props: WriteBackBundleSelectorProps) {
       </StandardDialogTitle>
 
       <DialogContent dividers={!disableWriteBackSelection}>
+        {invalidBundleEntryIndices && invalidBundleEntryIndices.size > 0 ? (
+          <Alert severity="warning" sx={{ mb: 2 }}>
+            {invalidBundleEntryIndices.size}{' '}
+            {invalidBundleEntryIndices.size === 1 ? 'entry has' : 'entries have'} validation errors
+            and will not be written back.
+          </Alert>
+        ) : null}
+
         {disableWriteBackSelection ? (
-          <DialogContentText>
-            Are you sure you want to save this response as {isAmendment ? 'an amendment' : 'final'}{' '}
-            and write back all items to the patient record?
-          </DialogContentText>
+          <>
+            {invalidBundleEntryIndices && invalidBundleEntryIndices.size > 0 ? (
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, mb: 2 }}>
+                {Array.from(invalidBundleEntryIndices).map((index) => (
+                  <WriteBackBundleSelectorItem
+                    key={index}
+                    bundleEntry={allBundleEntries[index]}
+                    bundleEntryIndex={index}
+                    selectedKeys={selectedKeys}
+                    allValidKeys={allValidKeys}
+                    populatedResourceMap={populatedResourceMap}
+                    isInvalid={true}
+                    isEntrySelected={isEntrySelected}
+                    onToggleCheckbox={handleToggleCheckbox}
+                  />
+                ))}
+              </Box>
+            ) : null}
+
+            {selectedKeys.size > 0 ? (
+              <DialogContentText>
+                Are you sure you want to save this response as{' '}
+                {isAmendment ? 'an amendment' : 'final'} and write back{' '}
+                {invalidBundleEntryIndices && invalidBundleEntryIndices.size > 0
+                  ? `${selectedKeys.size} valid ${selectedKeys.size === 1 ? 'entry' : 'entries'}`
+                  : 'all items'}{' '}
+                to the patient record?
+              </DialogContentText>
+            ) : (
+              <DialogContentText>
+                All items have validation errors and will not be written back. Are you sure you want
+                to save this response as {isAmendment ? 'an amendment' : 'final'} only?
+              </DialogContentText>
+            )}
+          </>
         ) : (
           <>
-            <Button
-              onClick={allValidKeysSelected ? handleUnselectAll : handleSelectAll}
-              variant="outlined"
-              size="small">
-              {allValidKeysSelected ? 'Unselect All' : 'Select All'}
-            </Button>
+            {selectableKeys.size > 0 ? (
+              <Button
+                onClick={allSelectableKeysSelected ? handleUnselectAll : handleSelectAll}
+                variant="outlined"
+                size="small">
+                {allSelectableKeysSelected ? 'Unselect All' : 'Select All'}
+              </Button>
+            ) : null}
 
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 2 }}>
               {allBundleEntries.map((bundleEntry, bundleEntryIndex) => {
@@ -216,6 +272,7 @@ function WriteBackBundleSelectorDialog(props: WriteBackBundleSelectorProps) {
                     selectedKeys={selectedKeys}
                     allValidKeys={allValidKeys}
                     populatedResourceMap={populatedResourceMap}
+                    isInvalid={invalidBundleEntryIndices?.has(bundleEntryIndex) ?? false}
                     isEntrySelected={isEntrySelected}
                     onToggleCheckbox={handleToggleCheckbox}
                   />
@@ -237,7 +294,7 @@ function WriteBackBundleSelectorDialog(props: WriteBackBundleSelectorProps) {
           }}>
           {disableWriteBackSelection ? null : (
             <Typography component="div" variant="body2" color="text.secondary">
-              {selectedKeys.size} of {allValidKeys.size} valid entries selected
+              {selectedKeys.size} of {selectableKeys.size} valid entries selected
             </Typography>
           )}
 

--- a/apps/smart-forms-app/src/features/writeBack/components/WriteBackBundleSelectorItem.tsx
+++ b/apps/smart-forms-app/src/features/writeBack/components/WriteBackBundleSelectorItem.tsx
@@ -14,6 +14,7 @@ interface WriteBackBundleSelectorItemProps {
   selectedKeys: Set<string>;
   allValidKeys: Set<string>;
   populatedResourceMap: Map<string, FhirResource>;
+  isInvalid: boolean;
   isEntrySelected: (
     bundleEntryIndex: number,
     operationEntryIndex?: number
@@ -29,6 +30,7 @@ function WriteBackBundleSelectorItem(props: WriteBackBundleSelectorItemProps) {
     allValidKeys,
     isEntrySelected,
     populatedResourceMap,
+    isInvalid,
     onToggleCheckbox
   } = props;
 
@@ -82,13 +84,14 @@ function WriteBackBundleSelectorItem(props: WriteBackBundleSelectorItemProps) {
     <Box
       sx={{
         border: 1,
-        borderColor: 'grey.300',
+        borderColor: isInvalid ? 'error.main' : 'grey.300',
         borderRadius: 1,
         p: 2
       }}>
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-        {/* If resource is Parameters but is not a FHIRPatch, grey out the checkbox */}
-        {resource.resourceType === 'Parameters' && !parametersIsFhirPatch(resource) ? (
+        {/* Disable checkbox when entry failed $validate, or when Parameters is not a valid FHIRPatch */}
+        {isInvalid ||
+        (resource.resourceType === 'Parameters' && !parametersIsFhirPatch(resource)) ? (
           <Box sx={{ cursor: 'not-allowed' }}>
             <Checkbox
               checked={checkboxIsChecked}

--- a/apps/smart-forms-app/src/features/writeBack/utils/validateExtractedBundle.ts
+++ b/apps/smart-forms-app/src/features/writeBack/utils/validateExtractedBundle.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Bundle, OperationOutcome } from 'fhir/r4';
+import type Client from 'fhirclient/lib/Client';
+import { HEADERS } from '../../../api/headers.ts';
+import { responseIsOperationOutcome } from '../../../utils/operationOutcome.ts';
+
+/**
+ * Calls $validate for each bundle entry and returns a set of entry indices that have
+ * error/fatal issues. Resources are sent wrapped in a Parameters envelope, which is valid
+ * for all resource types including FHIRPatch (Parameters) entries.
+ * If the server does not support $validate, the entry is treated as valid (best-effort).
+ */
+export async function validateExtractedBundle(
+  bundle: Bundle,
+  smartClient: Client
+): Promise<Set<number>> {
+  const invalidEntryIndices = new Set<number>();
+  const entries = bundle.entry ?? [];
+
+  await Promise.all(
+    entries.map(async (entry, index) => {
+      const resource = entry.resource;
+      if (!resource || !entry.request) return;
+
+      try {
+        const response = await smartClient.request({
+          url: `${resource.resourceType}/$validate`,
+          method: 'POST',
+          headers: HEADERS,
+          body: JSON.stringify({
+            resourceType: 'Parameters',
+            parameter: [{ name: 'resource', resource }]
+          })
+        });
+
+        if (responseIsOperationOutcome(response) && outcomeHasErrors(response)) {
+          console.warn(
+            `$validate errors for ${resource.resourceType} at bundle index ${index}:`,
+            response
+          );
+          invalidEntryIndices.add(index);
+        }
+      } catch (e) {
+        console.warn(
+          `$validate not supported or failed for ${resource.resourceType} — skipping validation`,
+          e
+        );
+      }
+    })
+  );
+
+  return invalidEntryIndices;
+}
+
+function outcomeHasErrors(outcome: OperationOutcome): boolean {
+  return outcome.issue?.some((i) => i.severity === 'error' || i.severity === 'fatal') ?? false;
+}

--- a/apps/smart-forms-app/src/hooks/useSmartClient.ts
+++ b/apps/smart-forms-app/src/hooks/useSmartClient.ts
@@ -21,6 +21,7 @@ import type { Encounter, FhirResource, Patient, Practitioner, Questionnaire } fr
 import { useSmartConfigStore } from '@aehrc/smart-forms-renderer';
 import type Client from 'fhirclient/lib/Client';
 import type { FhirContext } from '../features/smartAppLaunch/utils/launch.ts';
+import type { ExtraLaunchContext } from '../contexts/SmartClientContext.tsx';
 
 function useSmartClient() {
   const { state, dispatch } = useContext(SmartClientContext);
@@ -93,10 +94,10 @@ function useSmartClient() {
     setResolvedFhirContextReferences(resolvedFhirContextReferences);
   }
 
-  function setDisableWriteBackSelection(disableWriteBackSelection: boolean) {
+  function setExtraLaunchContext(extraLaunchContext: ExtraLaunchContext) {
     dispatch({
-      type: 'SET_DISABLE_WRITEBACK_SELECTION',
-      payload: disableWriteBackSelection
+      type: 'SET_EXTRA_LAUNCH_CONTEXT',
+      payload: extraLaunchContext
     });
   }
 
@@ -107,7 +108,7 @@ function useSmartClient() {
   const launchQuestionnaire = state.launchQuestionnaire;
   const fhirContext = state.fhirContext;
   const tokenReceivedTimestamp = state.tokenReceivedTimestamp;
-  const disableWriteBackSelection = state.disableWriteBackSelection;
+  const extraLaunchContext = state.extraLaunchContext;
 
   return {
     smartClient,
@@ -117,13 +118,13 @@ function useSmartClient() {
     launchQuestionnaire,
     fhirContext,
     tokenReceivedTimestamp,
-    disableWriteBackSelection,
+    extraLaunchContext,
     setSmartClient,
     setCommonLaunchContexts,
     setQuestionnaireLaunchContext,
     setFhirContext: setFhirContextArray,
     setResolvedFhirContextReferences: setResolvedFhirContext,
-    setDisableWriteBackSelection
+    setExtraLaunchContext
   };
 }
 

--- a/apps/smart-forms-app/src/test/useSmartClient.test.ts
+++ b/apps/smart-forms-app/src/test/useSmartClient.test.ts
@@ -31,7 +31,10 @@ const mockContextValue: SmartClientContextType = {
     fhirContext: null,
     resolvedFhirContextReferences: null,
     tokenReceivedTimestamp: null,
-    disableWriteBackSelection: false
+    extraLaunchContext: {
+      disableWriteBackSelection: false,
+      disableBundleValidation: false
+    }
   },
   dispatch: mockDispatch
 };
@@ -66,35 +69,28 @@ describe('useSmartClient', () => {
     jest.clearAllMocks();
   });
 
-  it('returns disableWriteBackSelection from context state', () => {
+  it('returns extraLaunchContext from context state', () => {
     const { result } = renderHook(() => useSmartClient());
 
-    expect(result.current.disableWriteBackSelection).toBe(false);
-  });
-
-  it('setDisableWriteBackSelection dispatches SET_DISABLE_WRITEBACK_SELECTION with true', () => {
-    const { result } = renderHook(() => useSmartClient());
-
-    act(() => {
-      result.current.setDisableWriteBackSelection(true);
-    });
-
-    expect(mockDispatch).toHaveBeenCalledWith({
-      type: 'SET_DISABLE_WRITEBACK_SELECTION',
-      payload: true
+    expect(result.current.extraLaunchContext).toEqual({
+      disableWriteBackSelection: false,
+      disableBundleValidation: false
     });
   });
 
-  it('setDisableWriteBackSelection dispatches SET_DISABLE_WRITEBACK_SELECTION with false', () => {
+  it('setExtraLaunchContext dispatches SET_EXTRA_LAUNCH_CONTEXT', () => {
     const { result } = renderHook(() => useSmartClient());
 
     act(() => {
-      result.current.setDisableWriteBackSelection(false);
+      result.current.setExtraLaunchContext({
+        disableWriteBackSelection: true,
+        disableBundleValidation: false
+      });
     });
 
     expect(mockDispatch).toHaveBeenCalledWith({
-      type: 'SET_DISABLE_WRITEBACK_SELECTION',
-      payload: false
+      type: 'SET_EXTRA_LAUNCH_CONTEXT',
+      payload: { disableWriteBackSelection: true, disableBundleValidation: false }
     });
   });
 });

--- a/apps/smart-forms-app/src/test/validateExtractedBundle.test.ts
+++ b/apps/smart-forms-app/src/test/validateExtractedBundle.test.ts
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// <reference types="jest" />
+import { validateExtractedBundle } from '../features/writeBack/utils/validateExtractedBundle';
+import type { Bundle, BundleEntry, FhirResource, OperationOutcome, Parameters } from 'fhir/r4';
+import type Client from 'fhirclient/lib/Client';
+
+function makeClient(requestFn: (opts: unknown) => Promise<unknown>): Client {
+  return { request: requestFn } as unknown as Client;
+}
+
+type TestBundleEntry = Omit<BundleEntry, 'resource'> & { resource?: unknown };
+
+function makeBundle(entries: TestBundleEntry[]): Bundle {
+  return { resourceType: 'Bundle', type: 'transaction', entry: entries as Bundle['entry'] };
+}
+
+const errorOutcome: OperationOutcome = {
+  resourceType: 'OperationOutcome',
+  issue: [{ severity: 'error', code: 'invalid', diagnostics: 'Missing required field' }]
+};
+
+const warningOutcome: OperationOutcome = {
+  resourceType: 'OperationOutcome',
+  issue: [{ severity: 'warning', code: 'incomplete', diagnostics: 'Recommended field missing' }]
+};
+
+const okOutcome: OperationOutcome = {
+  resourceType: 'OperationOutcome',
+  issue: [{ severity: 'information', code: 'informational', diagnostics: 'All OK' }]
+};
+
+describe('validateExtractedBundle', () => {
+  it('returns empty map for bundle with no entries', async () => {
+    const client = makeClient(jest.fn());
+    const result = await validateExtractedBundle(makeBundle([]), client);
+    expect(result.size).toBe(0);
+  });
+
+  it('returns empty map for bundle with undefined entries', async () => {
+    const client = makeClient(jest.fn());
+    const result = await validateExtractedBundle(
+      { resourceType: 'Bundle', type: 'transaction' },
+      client
+    );
+    expect(result.size).toBe(0);
+  });
+
+  it('skips entries with no resource', async () => {
+    const requestFn = jest.fn();
+    const client = makeClient(requestFn);
+    const bundle = makeBundle([{ request: { method: 'POST', url: 'Condition' } }]);
+    await validateExtractedBundle(bundle, client);
+    expect(requestFn).not.toHaveBeenCalled();
+  });
+
+  it('skips entries with no request', async () => {
+    const requestFn = jest.fn();
+    const client = makeClient(requestFn);
+    const bundle = makeBundle([{ resource: { resourceType: 'Condition' } }]);
+    await validateExtractedBundle(bundle, client);
+    expect(requestFn).not.toHaveBeenCalled();
+  });
+
+  it('wraps all entries in a $validate Parameters envelope', async () => {
+    const requestFn = jest.fn().mockResolvedValue(okOutcome);
+    const client = makeClient(requestFn);
+    const resource = { resourceType: 'Condition', subject: { reference: 'Patient/1' } };
+    const bundle = makeBundle([
+      {
+        resource: resource as unknown as FhirResource,
+        request: { method: 'POST', url: 'Condition' }
+      }
+    ]);
+    await validateExtractedBundle(bundle, client);
+    const sentBody = JSON.parse(requestFn.mock.calls[0][0].body);
+    expect(sentBody.resourceType).toBe('Parameters');
+    expect(sentBody.parameter[0].name).toBe('resource');
+    expect(sentBody.parameter[0].resource).toEqual(resource);
+  });
+
+  it('wraps FHIRPatch (Parameters) entries in a $validate Parameters envelope', async () => {
+    const requestFn = jest.fn().mockResolvedValue(okOutcome);
+    const client = makeClient(requestFn);
+    const patchResource: Parameters = {
+      resourceType: 'Parameters',
+      parameter: [
+        {
+          name: 'operation',
+          part: [
+            { name: 'type', valueCode: 'add' },
+            { name: 'path', valueString: 'Condition' },
+            { name: 'value', resource: { resourceType: 'Condition' } as unknown as FhirResource }
+          ]
+        }
+      ]
+    };
+    const bundle = makeBundle([
+      { resource: patchResource, request: { method: 'PATCH', url: 'Condition/123' } }
+    ]);
+    await validateExtractedBundle(bundle, client);
+    const sentBody = JSON.parse(requestFn.mock.calls[0][0].body);
+    expect(sentBody.resourceType).toBe('Parameters');
+    expect(sentBody.parameter[0].name).toBe('resource');
+    expect(sentBody.parameter[0].resource).toEqual(patchResource);
+  });
+
+  it('treats server not supporting $validate as valid (catch)', async () => {
+    const client = makeClient(jest.fn().mockRejectedValue(new Error('Not supported')));
+    const bundle = makeBundle([
+      { resource: { resourceType: 'Condition' }, request: { method: 'POST', url: 'Condition' } }
+    ]);
+    const result = await validateExtractedBundle(bundle, client);
+    expect(result.size).toBe(0);
+  });
+
+  it('returns entry in map when $validate returns OperationOutcome with errors', async () => {
+    const client = makeClient(jest.fn().mockResolvedValue(errorOutcome));
+    const bundle = makeBundle([
+      { resource: { resourceType: 'Condition' }, request: { method: 'POST', url: 'Condition' } }
+    ]);
+    const result = await validateExtractedBundle(bundle, client);
+    expect(result.size).toBe(1);
+    expect(result.has(0)).toBe(true);
+  });
+
+  it('does not include entry when $validate returns only warnings', async () => {
+    const client = makeClient(jest.fn().mockResolvedValue(warningOutcome));
+    const bundle = makeBundle([
+      { resource: { resourceType: 'Condition' }, request: { method: 'POST', url: 'Condition' } }
+    ]);
+    const result = await validateExtractedBundle(bundle, client);
+    expect(result.size).toBe(0);
+  });
+
+  it('does not include entry when $validate returns informational outcome', async () => {
+    const client = makeClient(jest.fn().mockResolvedValue(okOutcome));
+    const bundle = makeBundle([
+      { resource: { resourceType: 'Condition' }, request: { method: 'POST', url: 'Condition' } }
+    ]);
+    const result = await validateExtractedBundle(bundle, client);
+    expect(result.size).toBe(0);
+  });
+
+  it('returns correct index for second entry when first is valid', async () => {
+    const requestFn = jest
+      .fn()
+      .mockResolvedValueOnce(okOutcome)
+      .mockResolvedValueOnce(errorOutcome);
+    const client = makeClient(requestFn);
+    const bundle = makeBundle([
+      { resource: { resourceType: 'Condition' }, request: { method: 'POST', url: 'Condition' } },
+      {
+        resource: { resourceType: 'MedicationStatement' },
+        request: { method: 'POST', url: 'MedicationStatement' }
+      }
+    ]);
+    const result = await validateExtractedBundle(bundle, client);
+    expect(result.size).toBe(1);
+    expect(result.has(0)).toBe(false);
+    expect(result.has(1)).toBe(true);
+  });
+
+  it('validates entries in parallel — all requests fired before any resolves', async () => {
+    const callOrder: number[] = [];
+    const requestFn = jest.fn().mockImplementation(({ url }: { url: string }) => {
+      const index = url.includes('Condition') ? 0 : 1;
+      callOrder.push(index);
+      return Promise.resolve(okOutcome);
+    });
+    const client = makeClient(requestFn);
+    const bundle = makeBundle([
+      { resource: { resourceType: 'Condition' }, request: { method: 'POST', url: 'Condition' } },
+      {
+        resource: { resourceType: 'MedicationStatement' },
+        request: { method: 'POST', url: 'MedicationStatement' }
+      }
+    ]);
+    await validateExtractedBundle(bundle, client);
+    expect(requestFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('handles mixed valid and invalid entries across multiple resources', async () => {
+    const requestFn = jest
+      .fn()
+      .mockResolvedValueOnce(okOutcome)
+      .mockResolvedValueOnce(errorOutcome)
+      .mockResolvedValueOnce(errorOutcome);
+    const client = makeClient(requestFn);
+    const bundle = makeBundle([
+      { resource: { resourceType: 'Condition' }, request: { method: 'POST', url: 'Condition' } },
+      {
+        resource: { resourceType: 'MedicationStatement' },
+        request: { method: 'POST', url: 'MedicationStatement' }
+      },
+      { resource: { resourceType: 'Observation' }, request: { method: 'POST', url: 'Observation' } }
+    ]);
+    const result = await validateExtractedBundle(bundle, client);
+    expect(result.size).toBe(2);
+    expect(result.has(1)).toBe(true);
+    expect(result.has(2)).toBe(true);
+  });
+});

--- a/documentation/docs/api/smart-forms-renderer/functions/RepeatItem.md
+++ b/documentation/docs/api/smart-forms-renderer/functions/RepeatItem.md
@@ -3,6 +3,8 @@
 > **RepeatItem**(`props`): `Element`
 
 Main component to render a repeating, non-group Questionnaire item.
+Repeat answer instances (including empty ones) are tracked in local state, similar to
+RepeatGroup and GroupTable - only answers with values are emitted to the QuestionnaireResponse.
 
 ## Parameters
 

--- a/documentation/docs/api/smart-forms-renderer/index.md
+++ b/documentation/docs/api/smart-forms-renderer/index.md
@@ -93,7 +93,7 @@
 | [rendererThemeComponentOverrides](functions/rendererThemeComponentOverrides.md) | - |
 | [RendererThemeProvider](functions/RendererThemeProvider.md) | Default theme used by the renderer using Material UI. You can customise your own theme by defining a new ThemeProvider. |
 | [RepeatGroup](functions/RepeatGroup.md) | Main component to render a repeating, group Questionnaire item. Store and manages the state of multiple instances of GroupItem in a repeating group. |
-| [RepeatItem](functions/RepeatItem.md) | Main component to render a repeating, non-group Questionnaire item. |
+| [RepeatItem](functions/RepeatItem.md) | Main component to render a repeating, non-group Questionnaire item. Repeat answer instances (including empty ones) are tracked in local state, similar to RepeatGroup and GroupTable - only answers with values are emitted to the QuestionnaireResponse. |
 | [repopulateForm](functions/repopulateForm.md) | Re-populate the form with a provided (already filled) QuestionnaireResponse. |
 | [repopulateResponse](functions/repopulateResponse.md) | Re-populate checked items in the re-population dialog into the current QuestionnaireResponse |
 | [SingleItem](functions/SingleItem.md) | Main component to render a repeating, non-group Questionnaire item. Store and manages the state of multiple instances of SingleItem in a repeating item. |

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -35,6 +35,7 @@ Smart Forms supports passing additional context to the app via the SMART App Lau
 | Key | Type | Description |
 |-----|------|-------------|
 | `https://smartforms.csiro.au/smart-app-launch/extra-context/disable-writeback-selection` | `boolean` | When `true`, skips the item selection step in the Save Final & Write Back dialog and writes back all items to the patient record. The string `"true"` is also accepted for launchers that serialize all values as strings. |
+| `https://smartforms.csiro.au/smart-app-launch/extra-context/disable-bundle-validation` | `boolean` | When `true`, skips post-extraction `$validate` calls against the FHIR server before the write-back dialog is shown. Useful if the server does not support `$validate` and you want to avoid the overhead. The string `"true"` is also accepted for launchers that serialize all values as strings. |
 
 
 


### PR DESCRIPTION
## Summary

- Validates each extracted bundle entry against the FHIR server's `$validate` operation before showing the write-back dialog
- Invalid entries are shown with a disabled checkbox and red border, and excluded from initial selection; a warning alert summarises the count
- Validation is skipped via a new `disable-bundle-validation` SMART launch context key
- Refactors `disableWriteBackSelection` and `disableBundleValidation` into a combined `ExtraLaunchContext` object (per SMART App Launch spec §2.2.6.2)

## How to test

> **Prerequisites:** Smart Forms running locally on `localhost:5173`, connected to `https://proxy.smartforms.io/v/r4/fhir`
>
> The test questionnaire (Dev Bundle Validation 715) has no required fields at the form level, but the extracted `MedicationStatement` resource requires a `medication[x]` field — so adding a medication entry without specifying the medication name will trigger a `$validate` error on write-back.

### 1. Bundle validation active (default)

Launch: [Dev Bundle Validation 715 — validation enabled, selection enabled](https://ehr.smartforms.io/?fhir_version=r4&launch_url=http%3A%2F%2Flocalhost%3A5173%2Flaunch&app_name=localhost%3A5173&tab=0&launch=WzAsInBhdC1yZXBvcCIsInBoYXJtYWNpc3QiLCIiLDAsMCwwLCJsYXVuY2ggb3BlbmlkIGZoaXJVc2VyIG9ubGluZV9hY2Nlc3MgcGF0aWVudC9BbGxlcmd5SW50b2xlcmFuY2UuY3VzIHBhdGllbnQvQ29uZGl0aW9uLmN1cyBwYXRpZW50L0VuY291bnRlci5yIHBhdGllbnQvSW1tdW5pemF0aW9uLmNzIHBhdGllbnQvTWVkaWNhdGlvbi5yIHBhdGllbnQvTWVkaWNhdGlvblN0YXRlbWVudC5jdXMgcGF0aWVudC9PYnNlcnZhdGlvbi5jcyBwYXRpZW50L1BhdGllbnQuciBwYXRpZW50L1F1ZXN0aW9ubmFpcmVSZXNwb25zZS5jcnVzIHVzZXIvUHJhY3RpdGlvbmVyLnIgbGF1bmNoL3F1ZXN0aW9ubmFpcmU_cm9sZT1odHRwOi8vbnMuZWxlY3Ryb25pY2hlYWx0aC5uZXQuYXUvc21hcnQvcm9sZS9uZXciLCJodHRwOi8vbG9jYWxob3N0OjUxNzMvIiwiYTU3ZDkwZTMtNWY2OS00YjkyLWFhMmUtMjk5MjE4MDg2M2MxIiwiIiwiIiwiIiwiIiwwLDEsIlt7XCJyb2xlXCI6XCJodHRwOi8vbnMuZWxlY3Ryb25pY2hlYWx0aC5uZXQuYXUvc21hcnQvcm9sZS9uZXdcIixcInR5cGVcIjpcIlF1ZXN0aW9ubmFpcmVcIixcImNhbm9uaWNhbFwiOlwiaHR0cHM6Ly9zbWFydGZvcm1zLmNzaXJvLmF1L2Rldi9RdWVzdGlvbm5haXJlL0RldkJ1bmRsZVZhbGlkYXRpb243MTV8MC40LjAtYXNzZW1ibGVkXCJ9XSIsImh0dHBzOi8vcHJveHkuc21hcnRmb3Jtcy5pby92L3I0L2ZoaXIiLGZhbHNlLCJbe1wia2V5XCI6XCJodHRwczovL3NtYXJ0Zm9ybXMuY3Npcm8uYXUvc21hcnQtYXBwLWxhdW5jaC9leHRyYS1jb250ZXh0L2Rpc2FibGUtYnVuZGxlLXZhbGlkYXRpb25cIixcInZhbHVlXCI6XCJmYWxzZVwifSx7XCJrZXlcIjpcImh0dHBzOi8vc21hcnRmb3Jtcy5jc2lyby5hdS9zbWFydC1hcHAtbGF1bmNoL2V4dHJhLWNvbnRleHQvZGlzYWJsZS13cml0ZWJhY2stc2VsZWN0aW9uXCIsXCJ2YWx1ZVwiOlwiZmFsc2VcIn1dIl0&jwks_tab=0&validation=1)

1. Go to the **Medications** tab → **New medications** section
2. Add a new medication entry, fill in some fields but **leave the medication name blank**
3. Click **Save as final and write back**
4. Expected: write-back dialog opens with a warning alert ("1 entry has validation errors and will not be written back"), the MedicationStatement entry shows a red border with a disabled checkbox

### 2. Bundle validation + `disableWriteBackSelection: true`

Launch: [Dev Bundle Validation 715 — validation enabled, selection disabled](https://ehr.smartforms.io/?fhir_version=r4&launch_url=http%3A%2F%2Flocalhost%3A5173%2Flaunch&app_name=localhost%3A5173&tab=0&launch=WzAsInBhdC1yZXBvcCIsInBoYXJtYWNpc3QiLCIiLDAsMCwwLCJsYXVuY2ggb3BlbmlkIGZoaXJVc2VyIG9ubGluZV9hY2Nlc3MgcGF0aWVudC9BbGxlcmd5SW50b2xlcmFuY2UuY3VzIHBhdGllbnQvQ29uZGl0aW9uLmN1cyBwYXRpZW50L0VuY291bnRlci5yIHBhdGllbnQvSW1tdW5pemF0aW9uLmNzIHBhdGllbnQvTWVkaWNhdGlvbi5yIHBhdGllbnQvTWVkaWNhdGlvblN0YXRlbWVudC5jdXMgcGF0aWVudC9PYnNlcnZhdGlvbi5jcyBwYXRpZW50L1BhdGllbnQuciBwYXRpZW50L1F1ZXN0aW9ubmFpcmVSZXNwb25zZS5jcnVzIHVzZXIvUHJhY3RpdGlvbmVyLnIgbGF1bmNoL3F1ZXN0aW9ubmFpcmU_cm9sZT1odHRwOi8vbnMuZWxlY3Ryb25pY2hlYWx0aC5uZXQuYXUvc21hcnQvcm9sZS9uZXciLCJodHRwOi8vbG9jYWxob3N0OjUxNzMvIiwiYTU3ZDkwZTMtNWY2OS00YjkyLWFhMmUtMjk5MjE4MDg2M2MxIiwiIiwiIiwiIiwiIiwwLDEsIlt7XCJyb2xlXCI6XCJodHRwOi8vbnMuZWxlY3Ryb25pY2hlYWx0aC5uZXQuYXUvc21hcnQvcm9sZS9uZXdcIixcInR5cGVcIjpcIlF1ZXN0aW9ubmFpcmVcIixcImNhbm9uaWNhbFwiOlwiaHR0cHM6Ly9zbWFydGZvcm1zLmNzaXJvLmF1L2Rldi9RdWVzdGlvbm5haXJlL0RldkJ1bmRsZVZhbGlkYXRpb243MTV8MC40LjAtYXNzZW1ibGVkXCJ9XSIsImh0dHBzOi8vcHJveHkuc21hcnRmb3Jtcy5pby92L3I0L2ZoaXIiLGZhbHNlLCJbe1wia2V5XCI6XCJodHRwczovL3NtYXJ0Zm9ybXMuY3Npcm8uYXUvc21hcnQtYXBwLWxhdW5jaC9leHRyYS1jb250ZXh0L2Rpc2FibGUtYnVuZGxlLXZhbGlkYXRpb25cIixcInZhbHVlXCI6XCJmYWxzZVwifSx7XCJrZXlcIjpcImh0dHBzOi8vc21hcnRmb3Jtcy5jc2lyby5hdS9zbWFydC1hcHAtbGF1bmNoL2V4dHJhLWNvbnRleHQvZGlzYWJsZS13cml0ZWJhY2stc2VsZWN0aW9uXCIsXCJ2YWx1ZVwiOlwidHJ1ZVwifV0iXQ&jwks_tab=0&validation=1)

Same steps as above. Expected: confirmation dialog (no selection UI) shows the invalid entry with a red border, and the confirmation text references only the valid entries being written back.

### 3. Bundle validation disabled (`disableBundleValidation: true`)

Launch: [Dev Bundle Validation 715 — validation disabled](https://ehr.smartforms.io/?fhir_version=r4&launch_url=http%3A%2F%2Flocalhost%3A5173%2Flaunch&app_name=localhost%3A5173&tab=0&launch=WzAsInBhdC1yZXBvcCIsInBoYXJtYWNpc3QiLCIiLDAsMCwwLCJsYXVuY2ggb3BlbmlkIGZoaXJVc2VyIG9ubGluZV9hY2Nlc3MgcGF0aWVudC9BbGxlcmd5SW50b2xlcmFuY2UuY3VzIHBhdGllbnQvQ29uZGl0aW9uLmN1cyBwYXRpZW50L0VuY291bnRlci5yIHBhdGllbnQvSW1tdW5pemF0aW9uLmNzIHBhdGllbnQvTWVkaWNhdGlvbi5yIHBhdGllbnQvTWVkaWNhdGlvblN0YXRlbWVudC5jdXMgcGF0aWVudC9PYnNlcnZhdGlvbi5jcyBwYXRpZW50L1BhdGllbnQuciBwYXRpZW50L1F1ZXN0aW9ubmFpcmVSZXNwb25zZS5jcnVzIHVzZXIvUHJhY3RpdGlvbmVyLnIgbGF1bmNoL3F1ZXN0aW9ubmFpcmU_cm9sZT1odHRwOi8vbnMuZWxlY3Ryb25pY2hlYWx0aC5uZXQuYXUvc21hcnQvcm9sZS9uZXciLCJodHRwOi8vbG9jYWxob3N0OjUxNzMvIiwiYTU3ZDkwZTMtNWY2OS00YjkyLWFhMmUtMjk5MjE4MDg2M2MxIiwiIiwiIiwiIiwiIiwwLDEsIlt7XCJyb2xlXCI6XCJodHRwOi8vbnMuZWxlY3Ryb25pY2hlYWx0aC5uZXQuYXUvc21hcnQvcm9sZS9uZXdcIixcInR5cGVcIjpcIlF1ZXN0aW9ubmFpcmVcIixcImNhbm9uaWNhbFwiOlwiaHR0cHM6Ly9zbWFydGZvcm1zLmNzaXJvLmF1L2Rldi9RdWVzdGlvbm5haXJlL0RldkJ1bmRsZVZhbGlkYXRpb243MTV8MC40LjAtYXNzZW1ibGVkXCJ9XSIsImh0dHBzOi8vcHJveHkuc21hcnRmb3Jtcy5pby92L3I0L2ZoaXIiLGZhbHNlLCJbe1wia2V5XCI6XCJodHRwczovL3NtYXJ0Zm9ybXMuY3Npcm8uYXUvc21hcnQtYXBwLWxhdW5jaC9leHRyYS1jb250ZXh0L2Rpc2FibGUtYnVuZGxlLXZhbGlkYXRpb25cIixcInZhbHVlXCI6XCJ0cnVlXCJ9LHtcImtleVwiOlwiaHR0cHM6Ly9zbWFydGZvcm1zLmNzaXJvLmF1L3NtYXJ0LWFwcC1sYXVuY2gvZXh0cmEtY29udGV4dC9kaXNhYmxlLXdyaXRlYmFjay1zZWxlY3Rpb25cIixcInZhbHVlXCI6XCJmYWxzZVwifV0iXQ&jwks_tab=0&validation=1)

Same steps as above. Expected: write-back dialog opens with no validation warning — the MedicationStatement entry is selectable even though the medication name is missing.

## Test plan

- [ ] Scenario 1: validation active, selection enabled — invalid entry shows red border + disabled checkbox + warning alert
- [ ] Scenario 2: validation active, selection disabled — confirmation dialog shows invalid entry, writeback proceeds with valid entries only
- [ ] Scenario 3: validation disabled — no warning shown, all entries selectable
- [ ] All 13 unit tests in `validateExtractedBundle.test.ts` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)