### PR TITLE
Repair the CDK deployment toolchain

### DIFF
--- a/deployment/ehr-proxy/ehr-proxy-app/package.json
+++ b/deployment/ehr-proxy/ehr-proxy-app/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@types/jest": "^29.5.12",
     "@types/node": "22.15.30",
-    "aws-cdk": "^2.1031.0",
+    "aws-cdk": "^2.1134.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.4.2",
     "ts-node": "^10.9.2",

--- a/deployment/ehr-proxy/ehr-proxy-app/tsconfig.json
+++ b/deployment/ehr-proxy/ehr-proxy-app/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["es2020", "dom"],
     "declaration": true,
     "strict": true,
+    "skipLibCheck": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
     "noImplicitThis": true,

--- a/deployment/ehr-proxy/smart-proxy/package.json
+++ b/deployment/ehr-proxy/smart-proxy/package.json
@@ -22,6 +22,6 @@
     "constructs": "^10.3.0"
   },
   "dependencies": {
-    "aws-cdk": "^2.1031.0"
+    "aws-cdk": "^2.1134.0"
   }
 }

--- a/deployment/ehr-proxy/smart-proxy/tsconfig.json
+++ b/deployment/ehr-proxy/smart-proxy/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["es2020", "dom"],
     "declaration": true,
     "strict": true,
+    "skipLibCheck": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
     "noImplicitThis": true,

--- a/deployment/forms-server/assemble-endpoint/package.json
+++ b/deployment/forms-server/assemble-endpoint/package.json
@@ -22,6 +22,6 @@
     "constructs": "^10.3.0"
   },
   "dependencies": {
-    "aws-cdk": "^2.1031.0"
+    "aws-cdk": "^2.1134.0"
   }
 }

--- a/deployment/forms-server/assemble-endpoint/tsconfig.json
+++ b/deployment/forms-server/assemble-endpoint/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["es2020", "dom"],
     "declaration": true,
     "strict": true,
+    "skipLibCheck": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
     "noImplicitThis": true,

--- a/deployment/forms-server/forms-server-app/package.json
+++ b/deployment/forms-server/forms-server-app/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@types/jest": "^29.5.12",
     "@types/node": "22.15.30",
-    "aws-cdk": "^2.1031.0",
+    "aws-cdk": "^2.1134.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.4.2",
     "ts-node": "^10.9.2",

--- a/deployment/forms-server/forms-server-app/tsconfig.json
+++ b/deployment/forms-server/forms-server-app/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["es2020", "dom"],
     "declaration": true,
     "strict": true,
+    "skipLibCheck": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
     "noImplicitThis": true,

--- a/deployment/forms-server/populate-endpoint/package.json
+++ b/deployment/forms-server/populate-endpoint/package.json
@@ -22,6 +22,6 @@
     "constructs": "^10.3.0"
   },
   "dependencies": {
-    "aws-cdk": "^2.1031.0"
+    "aws-cdk": "^2.1134.0"
   }
 }

--- a/deployment/forms-server/populate-endpoint/tsconfig.json
+++ b/deployment/forms-server/populate-endpoint/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["es2020", "dom"],
     "declaration": true,
     "strict": true,
+    "skipLibCheck": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
     "noImplicitThis": true,

--- a/deployment/shared/hapi-endpoint/package.json
+++ b/deployment/shared/hapi-endpoint/package.json
@@ -22,7 +22,7 @@
     "constructs": "^10.3.0"
   },
   "dependencies": {
-    "aws-cdk": "^2.1031.0"
+    "aws-cdk": "^2.1134.0"
   },
   "description": "HAPI FHIR server on Fargate backed by RDS PostgreSQL, shared by the forms-server and ehr-proxy stacks"
 }

--- a/deployment/shared/hapi-endpoint/tsconfig.json
+++ b/deployment/shared/hapi-endpoint/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["es2020", "dom"],
     "declaration": true,
     "strict": true,
+    "skipLibCheck": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
     "noImplicitThis": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1049,7 +1049,7 @@
       "devDependencies": {
         "@types/jest": "^29.5.12",
         "@types/node": "22.15.30",
-        "aws-cdk": "^2.1031.0",
+        "aws-cdk": "^2.1134.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.4.2",
         "ts-node": "^10.9.2",
@@ -1074,7 +1074,7 @@
       "name": "ehr-proxy-smart-proxy",
       "version": "0.1.0",
       "dependencies": {
-        "aws-cdk": "^2.1031.0"
+        "aws-cdk": "^2.1134.0"
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",
@@ -1108,7 +1108,7 @@
       "name": "forms-server-assemble-endpoint",
       "version": "0.1.0",
       "dependencies": {
-        "aws-cdk": "^2.1031.0"
+        "aws-cdk": "^2.1134.0"
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",
@@ -1154,7 +1154,7 @@
       "devDependencies": {
         "@types/jest": "^29.5.12",
         "@types/node": "22.15.30",
-        "aws-cdk": "^2.1031.0",
+        "aws-cdk": "^2.1134.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.4.2",
         "ts-node": "^10.9.2",
@@ -1179,7 +1179,7 @@
       "name": "forms-server-populate-endpoint",
       "version": "0.1.0",
       "dependencies": {
-        "aws-cdk": "^2.1031.0"
+        "aws-cdk": "^2.1134.0"
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",
@@ -1213,7 +1213,7 @@
       "name": "shared-hapi-endpoint",
       "version": "0.1.0",
       "dependencies": {
-        "aws-cdk": "^2.1031.0"
+        "aws-cdk": "^2.1134.0"
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",
@@ -15520,18 +15520,15 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1031.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1031.0.tgz",
-      "integrity": "sha512-iotbdOIvHoLCz1u7PUVDQbcpGpVqMk8HzAeOP4PGRqD9PoAEsCb3mwGTxHMrNGEGWdJXQxiTOGSaMmlwEvACxA==",
+      "version": "2.1134.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1134.0.tgz",
+      "integrity": "sha512-Fy/g+gdpMpkhAAoCNlZtX0s4mD7q58bHlDV6QfbnTeifmQ5cEge26c5rB+U4qKB/bDudxNuJjQk/mSSk0ysnug==",
       "license": "Apache-2.0",
       "bin": {
         "cdk": "bin/cdk"
       },
       "engines": {
         "node": ">= 18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
       }
     },
     "node_modules/aws-cdk-lib": {


### PR DESCRIPTION
## Problem

The deployment steps documented in `deployment/ehr-proxy/README.md` and `deployment/forms-server/README.md` cannot be followed from a clean checkout. Both `npm run build` and `cdk diff` fail, for two unrelated reasons.

**1. Compilation fails in all six deployment packages.**

```
../../../node_modules/aws-cdk-lib/core/lib/private/perf.d.ts(46,77):
  error TS2304: Cannot find name 'Disposable'.
```

The tsconfigs target ES2020 and never set `skipLibCheck`, so `tsc` type checks a dependency's `.d.ts` files against a `lib` that predates the symbols they use. `skipLibCheck` is the CDK project default and what the library expects.

**2. The CDK CLI cannot read its own library's output.**

```
This CDK CLI is not compatible with the CDK library used by your application.
(Cloud assembly schema version mismatch: Maximum schema version supported is
 48.x.x, but found 54.0.0. You need at least CLI version 2.1128.0.)
```

The CLI is pinned at `^2.1031.0` while `aws-cdk-lib` is `2.260.0`. Raised to `^2.1134.0`, the current release.

## Scope

Both problems predate the RDS work in #2065 and #2066. I confirmed this by checking out the commit before #2065 and reproducing the identical build error, and by reading the CLI and library versions out of that commit's lock file, which already pins the same incompatible pair.

The change is one line per tsconfig, the CLI range in six `package.json` files, and a lock file update whose only version change is:

```
node_modules/aws-cdk  2.1031.0 -> 2.1134.0
added: 0  removed: 0
```

## Verification

With only the repo's own toolchain, no workarounds:

- `npm run build` succeeds in all six deployment packages.
- `npx cdk diff` runs against the live stacks and correctly reports the pending #2065 changes (6 RDS-related additions per stack, no deletions).
- `npm ci`, `npm run lint` and `npm run prettier` all pass.

## Follow-up, not in this PR

The construct packages declare `aws-cdk` (the CLI) under `dependencies` rather than `devDependencies`, which pulls the whole CLI into anything consuming them. Worth tidying, but it changes the dependency graph and is unrelated to unbreaking the build.