### PR TITLE
Add dispatch-only CDK deployment and weekly drift check workflows

### DIFF
--- a/.github/actions/cdk-setup/action.yml
+++ b/.github/actions/cdk-setup/action.yml
@@ -1,0 +1,49 @@
+name: CDK setup
+description: >-
+  Shared setup for the CDK workflows: Node.js, the deployment role check, npm dependencies,
+  the deployment package builds, and AWS credentials.
+
+inputs:
+  role-arn:
+    description: ARN of the IAM role GitHub Actions assumes to run CDK
+    required: true
+  aws-region:
+    description: AWS region to operate in
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Use Node.js 20.x
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: npm
+
+    - name: Check the deployment role is configured
+      shell: bash
+      run: |
+        if [ -z "${{ inputs.role-arn }}" ]; then
+          echo "::error::Repository variable AWS_CDK_DEPLOY_ROLE_ARN is not set."
+          echo "::error::It must name a role that trusts repo:aehrc/smart-forms and can assume the"
+          echo "::error::cdk-hnb659fds-* bootstrap roles in account 209248795938."
+          exit 1
+        fi
+
+    - name: Install dependencies
+      shell: bash
+      run: npm ci
+
+    - name: Build deployment packages
+      shell: bash
+      run: |
+        npm run build -w shared-hapi-endpoint
+        npm run build -w ehr-proxy-smart-proxy
+        npm run build -w forms-server-assemble-endpoint
+        npm run build -w forms-server-populate-endpoint
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ inputs.role-arn }}
+        aws-region: ${{ inputs.aws-region }}

--- a/.github/scripts/cdk-stacks.sh
+++ b/.github/scripts/cdk-stacks.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Map the CDK deployment workflow's stack input to stack names and their app directories.
+#
+#   cdk-stacks.sh both                  -> EhrProxyAppStack FormsServerAppStack
+#   cdk-stacks.sh EhrProxyAppStack      -> EhrProxyAppStack
+#   cdk-stacks.sh --dir EhrProxyAppStack -> deployment/ehr-proxy/ehr-proxy-app
+set -euo pipefail
+
+if [ "${1:-}" = "--dir" ]; then
+  case "${2:-}" in
+    EhrProxyAppStack) echo 'deployment/ehr-proxy/ehr-proxy-app' ;;
+    FormsServerAppStack) echo 'deployment/forms-server/forms-server-app' ;;
+    *) echo "unknown stack: ${2:-}" >&2; exit 1 ;;
+  esac
+  exit 0
+fi
+
+case "${1:-both}" in
+  both) echo 'EhrProxyAppStack FormsServerAppStack' ;;
+  EhrProxyAppStack | FormsServerAppStack) echo "$1" ;;
+  *) echo "unknown stack: ${1:-}" >&2; exit 1 ;;
+esac

--- a/.github/workflows/cdk_deploy.yml
+++ b/.github/workflows/cdk_deploy.yml
@@ -1,8 +1,7 @@
 name: CDK Infrastructure Deployment
 
-# Deliberately dispatch only. These stacks back the demo and evaluation environments, and an
-# unattended deploy replaces the HAPI tasks, which briefly takes the FHIR servers offline. Deploying
-# is therefore always a decision someone makes, never a side effect of merging.
+# Deliberately dispatch only: deploying briefly takes the FHIR servers offline, so it is always
+# someone's decision, never a side effect of merging. See deployment/README.md.
 on:
   workflow_dispatch:
     inputs:
@@ -30,40 +29,13 @@ jobs:
   diff:
     name: Diff ${{ inputs.stack }}
     runs-on: ubuntu-latest
-    outputs:
-      has_changes: ${{ steps.diff.outputs.has_changes }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js 20.x
-        uses: actions/setup-node@v4
+      - name: Set up Node, build the deployment packages, configure AWS
+        uses: ./.github/actions/cdk-setup
         with:
-          node-version: 20
-          cache: npm
-
-      - name: Check the deployment role is configured
-        run: |
-          if [ -z "${{ vars.AWS_CDK_DEPLOY_ROLE_ARN }}" ]; then
-            echo "::error::Repository variable AWS_CDK_DEPLOY_ROLE_ARN is not set."
-            echo "::error::It must name a role that trusts repo:aehrc/smart-forms and can assume the"
-            echo "::error::cdk-hnb659fds-* bootstrap roles in account 209248795938."
-            exit 1
-          fi
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build deployment packages
-        run: |
-          npm run build -w shared-hapi-endpoint
-          npm run build -w ehr-proxy-smart-proxy
-          npm run build -w forms-server-assemble-endpoint
-          npm run build -w forms-server-populate-endpoint
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ vars.AWS_CDK_DEPLOY_ROLE_ARN }}
+          role-arn: ${{ vars.AWS_CDK_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       # The default change set method is used rather than --method=template on purpose. A
@@ -71,18 +43,13 @@ jobs:
       # graph, which is how a circular dependency between the HAPI service and its database once
       # reached a deploy attempt undetected.
       - name: cdk diff
-        id: diff
         run: |
           set -o pipefail
-          changes=0
           for stack in $(.github/scripts/cdk-stacks.sh '${{ inputs.stack }}'); do
             dir=$(.github/scripts/cdk-stacks.sh --dir "$stack")
             echo "::group::cdk diff $stack"
             ( cd "$dir" && npx cdk diff "$stack" 2>&1 ) | tee "/tmp/diff-$stack.txt"
             echo "::endgroup::"
-            if grep -qE "Number of stacks with differences: [1-9]" "/tmp/diff-$stack.txt"; then
-              changes=1
-            fi
             {
               echo "### \`$stack\`"
               echo '```'
@@ -91,39 +58,21 @@ jobs:
               echo '```'
             } >> "$GITHUB_STEP_SUMMARY"
           done
-          echo "has_changes=$changes" >> "$GITHUB_OUTPUT"
 
   deploy:
     name: Deploy ${{ inputs.stack }}
     needs: diff
     if: inputs.action == 'deploy'
     runs-on: ubuntu-latest
-    # Access control lives here. Configure `aws-production` in Settings > Environments with the
-    # reviewers allowed to deploy. An `if: github.actor == ...` check is not a security boundary.
+    # Access control lives here, in the environment's required reviewers. See deployment/README.md.
     environment: aws-production
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js 20.x
-        uses: actions/setup-node@v4
+      - name: Set up Node, build the deployment packages, configure AWS
+        uses: ./.github/actions/cdk-setup
         with:
-          node-version: 20
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build deployment packages
-        run: |
-          npm run build -w shared-hapi-endpoint
-          npm run build -w ehr-proxy-smart-proxy
-          npm run build -w forms-server-assemble-endpoint
-          npm run build -w forms-server-populate-endpoint
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ vars.AWS_CDK_DEPLOY_ROLE_ARN }}
+          role-arn: ${{ vars.AWS_CDK_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: cdk deploy

--- a/.github/workflows/cdk_deploy.yml
+++ b/.github/workflows/cdk_deploy.yml
@@ -1,0 +1,151 @@
+name: CDK Infrastructure Deployment
+
+# Deliberately dispatch only. These stacks back the demo and evaluation environments, and an
+# unattended deploy replaces the HAPI tasks, which briefly takes the FHIR servers offline. Deploying
+# is therefore always a decision someone makes, never a side effect of merging.
+on:
+  workflow_dispatch:
+    inputs:
+      stack:
+        description: 'Which stack to act on'
+        type: choice
+        required: true
+        default: 'both'
+        options: ['both', 'EhrProxyAppStack', 'FormsServerAppStack']
+      action:
+        description: 'diff shows the pending changes, deploy applies them'
+        type: choice
+        required: true
+        default: 'diff'
+        options: ['diff', 'deploy']
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  AWS_REGION: ap-southeast-2
+
+jobs:
+  diff:
+    name: Diff ${{ inputs.stack }}
+    runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.diff.outputs.has_changes }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Check the deployment role is configured
+        run: |
+          if [ -z "${{ vars.AWS_CDK_DEPLOY_ROLE_ARN }}" ]; then
+            echo "::error::Repository variable AWS_CDK_DEPLOY_ROLE_ARN is not set."
+            echo "::error::It must name a role that trusts repo:aehrc/smart-forms and can assume the"
+            echo "::error::cdk-hnb659fds-* bootstrap roles in account 209248795938."
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build deployment packages
+        run: |
+          npm run build -w shared-hapi-endpoint
+          npm run build -w ehr-proxy-smart-proxy
+          npm run build -w forms-server-assemble-endpoint
+          npm run build -w forms-server-populate-endpoint
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_CDK_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      # The default change set method is used rather than --method=template on purpose. A
+      # template-only diff compares JSON without asking CloudFormation to validate the resource
+      # graph, which is how a circular dependency between the HAPI service and its database once
+      # reached a deploy attempt undetected.
+      - name: cdk diff
+        id: diff
+        run: |
+          set -o pipefail
+          changes=0
+          for stack in $(.github/scripts/cdk-stacks.sh '${{ inputs.stack }}'); do
+            dir=$(.github/scripts/cdk-stacks.sh --dir "$stack")
+            echo "::group::cdk diff $stack"
+            ( cd "$dir" && npx cdk diff "$stack" 2>&1 ) | tee "/tmp/diff-$stack.txt"
+            echo "::endgroup::"
+            if grep -qE "Number of stacks with differences: [1-9]" "/tmp/diff-$stack.txt"; then
+              changes=1
+            fi
+            {
+              echo "### \`$stack\`"
+              echo '```'
+              grep -E "^\[[+~-]\]|Number of stacks|IAM Statement Changes|Security Group Changes" \
+                "/tmp/diff-$stack.txt" | head -60 || echo "no resource-level changes"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          done
+          echo "has_changes=$changes" >> "$GITHUB_OUTPUT"
+
+  deploy:
+    name: Deploy ${{ inputs.stack }}
+    needs: diff
+    if: inputs.action == 'deploy'
+    runs-on: ubuntu-latest
+    # Access control lives here. Configure `aws-production` in Settings > Environments with the
+    # reviewers allowed to deploy. An `if: github.actor == ...` check is not a security boundary.
+    environment: aws-production
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build deployment packages
+        run: |
+          npm run build -w shared-hapi-endpoint
+          npm run build -w ehr-proxy-smart-proxy
+          npm run build -w forms-server-assemble-endpoint
+          npm run build -w forms-server-populate-endpoint
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_CDK_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: cdk deploy
+        run: |
+          for stack in $(.github/scripts/cdk-stacks.sh '${{ inputs.stack }}'); do
+            dir=$(.github/scripts/cdk-stacks.sh --dir "$stack")
+            echo "::group::cdk deploy $stack"
+            ( cd "$dir" && npx cdk deploy "$stack" --require-approval never )
+            echo "::endgroup::"
+          done
+
+      # The HAPI servers hold demo data in their databases and are not repopulated by deploying.
+      # This is a liveness check, not a data check.
+      - name: Check the FHIR endpoints are serving
+        run: |
+          fail=0
+          for url in https://proxy.smartforms.io/fhir/metadata \
+                     https://smartforms.csiro.au/api/fhir/metadata; do
+            code=$(curl -s -o /dev/null -w '%{http_code}' --retry 10 --retry-delay 15 \
+                     --retry-all-errors -m 20 "$url" || echo 000)
+            echo "$url -> $code"
+            echo "- \`$url\` -> $code" >> "$GITHUB_STEP_SUMMARY"
+            [ "$code" = "200" ] || fail=1
+          done
+          exit $fail

--- a/.github/workflows/cdk_drift_check.yml
+++ b/.github/workflows/cdk_drift_check.yml
@@ -1,0 +1,154 @@
+name: CDK Infrastructure Drift Check
+
+# Nothing deploys these stacks automatically, so what is on main and what is running in AWS can
+# drift apart silently. They were last deployed in 2025 and sat behind main for months without
+# anyone noticing. This reports that gap rather than waiting for someone to trip over it.
+on:
+  schedule:
+    # 09:00 Monday, Australian eastern time.
+    - cron: '0 23 * * 0'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+
+env:
+  AWS_REGION: ap-southeast-2
+
+jobs:
+  drift:
+    name: Compare main against the deployed stacks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Check the deployment role is configured
+        run: |
+          if [ -z "${{ vars.AWS_CDK_DEPLOY_ROLE_ARN }}" ]; then
+            echo "::error::Repository variable AWS_CDK_DEPLOY_ROLE_ARN is not set."
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build deployment packages
+        run: |
+          npm run build -w shared-hapi-endpoint
+          npm run build -w ehr-proxy-smart-proxy
+          npm run build -w forms-server-assemble-endpoint
+          npm run build -w forms-server-populate-endpoint
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_CDK_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      # --method=template here, unlike the deploy workflow. This job only asks whether main and the
+      # deployed stack differ, which a template comparison answers without needing permission to
+      # create change sets. Validating a change you are about to apply is a different question, and
+      # that job uses the accurate change set method.
+      - name: cdk diff
+        id: drift
+        run: |
+          set -o pipefail
+          drifted=''
+          for stack in EhrProxyAppStack FormsServerAppStack; do
+            dir=$(.github/scripts/cdk-stacks.sh --dir "$stack")
+            echo "::group::cdk diff $stack"
+            ( cd "$dir" && npx cdk diff "$stack" --method=template 2>&1 ) | tee "/tmp/$stack.txt"
+            echo "::endgroup::"
+            if grep -qE "Number of stacks with differences: [1-9]" "/tmp/$stack.txt"; then
+              drifted="$drifted $stack"
+            fi
+          done
+          drifted="${drifted# }"
+          echo "stacks=$drifted" >> "$GITHUB_OUTPUT"
+          {
+            if [ -n "$drifted" ]; then
+              echo "## Drift detected in:$drifted"
+            else
+              echo "## No drift. Deployed stacks match main."
+            fi
+            for stack in EhrProxyAppStack FormsServerAppStack; do
+              echo "<details><summary>$stack</summary>"
+              echo
+              echo '```'
+              grep -E "^\[[+~-]\]|Number of stacks" "/tmp/$stack.txt" | head -50 \
+                || echo 'no differences'
+              echo '```'
+              echo '</details>'
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open or update the drift issue
+        if: steps.drift.outputs.stacks != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const stacks = '${{ steps.drift.outputs.stacks }}'.trim().split(/\s+/);
+            const title = 'CDK drift: deployed stacks differ from main';
+            const run = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}` +
+                        `/actions/runs/${context.runId}`;
+            const body = [
+              `The deployed CloudFormation stacks no longer match \`main\`.`,
+              '',
+              `Drifted: ${stacks.map((s) => `\`${s}\``).join(', ')}`,
+              '',
+              `Nothing deploys these stacks automatically, so this is expected after a merge that`,
+              `touches \`deployment/\` and has not been rolled out yet. Deploy with the`,
+              `**CDK Infrastructure Deployment** workflow.`,
+              '',
+              `See the [drift check run](${run}) for the full diff.`,
+              '',
+              `_Updated ${new Date().toISOString()}_`,
+            ].join('\n');
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo,
+              state: 'open', labels: 'cdk-drift',
+            });
+
+            if (existing.data.length > 0) {
+              await github.rest.issues.update({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: existing.data[0].number, body,
+              });
+              core.info(`Updated issue #${existing.data[0].number}`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner: context.repo.owner, repo: context.repo.repo,
+                title, body, labels: ['cdk-drift'],
+              });
+              core.info(`Opened issue #${created.data.number}`);
+            }
+
+      - name: Close the drift issue once the stacks match
+        if: steps.drift.outputs.stacks == ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo,
+              state: 'open', labels: 'cdk-drift',
+            });
+            for (const issue of existing.data) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: issue.number,
+                body: 'Deployed stacks now match `main`. Closing.',
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: issue.number, state: 'closed',
+              });
+            }

--- a/.github/workflows/cdk_drift_check.yml
+++ b/.github/workflows/cdk_drift_check.yml
@@ -1,8 +1,7 @@
 name: CDK Infrastructure Drift Check
 
-# Nothing deploys these stacks automatically, so what is on main and what is running in AWS can
-# drift apart silently. They were last deployed in 2025 and sat behind main for months without
-# anyone noticing. This reports that gap rather than waiting for someone to trip over it.
+# Nothing deploys these stacks automatically, so main and the deployed stacks can drift apart
+# silently. This reports that gap. See deployment/README.md.
 on:
   schedule:
     # 09:00 Monday, Australian eastern time.
@@ -24,33 +23,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js 20.x
-        uses: actions/setup-node@v4
+      - name: Set up Node, build the deployment packages, configure AWS
+        uses: ./.github/actions/cdk-setup
         with:
-          node-version: 20
-          cache: npm
-
-      - name: Check the deployment role is configured
-        run: |
-          if [ -z "${{ vars.AWS_CDK_DEPLOY_ROLE_ARN }}" ]; then
-            echo "::error::Repository variable AWS_CDK_DEPLOY_ROLE_ARN is not set."
-            exit 1
-          fi
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build deployment packages
-        run: |
-          npm run build -w shared-hapi-endpoint
-          npm run build -w ehr-proxy-smart-proxy
-          npm run build -w forms-server-assemble-endpoint
-          npm run build -w forms-server-populate-endpoint
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ vars.AWS_CDK_DEPLOY_ROLE_ARN }}
+          role-arn: ${{ vars.AWS_CDK_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       # --method=template here, unlike the deploy workflow. This job only asks whether main and the
@@ -62,7 +38,7 @@ jobs:
         run: |
           set -o pipefail
           drifted=''
-          for stack in EhrProxyAppStack FormsServerAppStack; do
+          for stack in $(.github/scripts/cdk-stacks.sh both); do
             dir=$(.github/scripts/cdk-stacks.sh --dir "$stack")
             echo "::group::cdk diff $stack"
             ( cd "$dir" && npx cdk diff "$stack" --method=template 2>&1 ) | tee "/tmp/$stack.txt"
@@ -79,7 +55,7 @@ jobs:
             else
               echo "## No drift. Deployed stacks match main."
             fi
-            for stack in EhrProxyAppStack FormsServerAppStack; do
+            for stack in $(.github/scripts/cdk-stacks.sh both); do
               echo "<details><summary>$stack</summary>"
               echo
               echo '```'

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,71 @@
+# Deployment
+
+CDK applications for the Smart Forms AWS infrastructure in account `209248795938`, `ap-southeast-2`.
+
+| Stack | App directory | Serves |
+| --- | --- | --- |
+| `FormsServerAppStack` | `forms-server/forms-server-app` | `https://smartforms.csiro.au/api/fhir` |
+| `EhrProxyAppStack` | `ehr-proxy/ehr-proxy-app` | `https://proxy.smartforms.io/fhir` |
+
+Both run a HAPI FHIR server on Fargate backed by its own RDS PostgreSQL instance, built from the
+shared `shared/hapi-endpoint` construct. See that package's README for why the database is not
+optional and why its construct ids are passed in explicitly.
+
+## Deploying
+
+Use the **CDK Infrastructure Deployment** workflow (Actions > Run workflow). It is dispatch only:
+these stacks back demo and evaluation environments, and deploying replaces the HAPI tasks, which
+briefly takes the FHIR servers offline. That should always be someone's decision, not a side effect
+of merging.
+
+Inputs are the stack (`both` by default) and the action (`diff` by default). The `diff` job always
+runs first and prints the pending changes to the run summary, so whoever approves the deploy can see
+what they are approving.
+
+To deploy from a workstation instead, follow the steps in `forms-server/README.md` or
+`ehr-proxy/README.md`.
+
+## Drift
+
+Nothing deploys these stacks automatically, so `main` and the running infrastructure can diverge
+without anyone noticing. They sat un-deployed from 2025-08 until 2026-07 for exactly that reason.
+
+The **CDK Infrastructure Drift Check** workflow runs weekly, compares both stacks against `main`,
+and opens (or updates) an issue labelled `cdk-drift` when they differ. It closes the issue once they
+match again. Drift right after a merge that touches `deployment/` is expected, and just means the
+change has not been rolled out yet.
+
+## Required setup
+
+Both workflows authenticate to AWS with GitHub OIDC and need one repository variable:
+
+| Variable | Value |
+| --- | --- |
+| `AWS_CDK_DEPLOY_ROLE_ARN` | ARN of an IAM role that GitHub Actions assumes to run CDK |
+
+The account already has the GitHub OIDC provider and the standard `cdk-hnb659fds-*` bootstrap roles.
+What does not exist yet is a role for CDK deployment from CI. `SmartFormsReactAppDeployment` is not
+it: that role is scoped to the React app's S3 deployment, and widening it would be worse than
+adding a dedicated role.
+
+The new role needs a trust policy accepting `repo:aehrc/smart-forms:*` from
+`token.actions.githubusercontent.com` (mirroring `SmartFormsReactAppDeployment`), and permission to
+assume the bootstrap roles:
+
+```json
+{
+  "Effect": "Allow",
+  "Action": "sts:AssumeRole",
+  "Resource": [
+    "arn:aws:iam::209248795938:role/cdk-hnb659fds-deploy-role-209248795938-ap-southeast-2",
+    "arn:aws:iam::209248795938:role/cdk-hnb659fds-file-publishing-role-209248795938-ap-southeast-2",
+    "arn:aws:iam::209248795938:role/cdk-hnb659fds-image-publishing-role-209248795938-ap-southeast-2",
+    "arn:aws:iam::209248795938:role/cdk-hnb659fds-lookup-role-209248795938-ap-southeast-2"
+  ]
+}
+```
+
+Deploys additionally run in the `aws-production` GitHub environment. Configure it under
+Settings > Environments with the reviewers permitted to deploy. That environment is the access
+control; a check like `if: github.actor == ...` is trivially bypassable and is not a security
+boundary. Until the environment exists, the `deploy` job cannot run, while `diff` still works.


### PR DESCRIPTION
## Why

The CDK stacks have no automation: deploying means building the packages locally and running `cdk deploy` by hand, and nothing compares `main` against what is actually running. Both stacks sat un-deployed from 2025-08 until 2026-07 without anyone noticing.

## What

**`cdk_deploy.yml`** is `workflow_dispatch` only, since deploying replaces the HAPI tasks and briefly takes the FHIR servers offline. Inputs are the stack (`both` by default) and the action (`diff` or `deploy`, defaulting to `diff`), so an accidental run changes nothing. The `diff` job always runs first and writes the pending changes to the run summary, so the approver sees what they are approving. After deploying, it polls both FHIR endpoints until they serve 200.

**`cdk_drift_check.yml`** runs weekly and on demand, reports whether either stack differs from `main`, and opens, updates, or closes an issue labelled `cdk-drift` accordingly.

Setup common to both lives in a `cdk-setup` composite action, and `.github/scripts/cdk-stacks.sh` maps the stack input to stack names and app directories.

## Two decisions worth reviewing

Access control is the `aws-production` GitHub environment with required reviewers, not an actor check, which is trivially bypassable. Until the environment is configured the `deploy` job cannot run, while `diff` still works.

The two jobs diff differently on purpose. Deployment uses the change set method so CloudFormation validates the resource graph; a template-only comparison is what let the circular dependency fixed in #2069 reach a deploy attempt undetected. The drift check only asks whether the stacks differ at all, which `--method=template` answers without permission to create change sets.

## Not included

The IAM role the workflows assume (repository variable `AWS_CDK_DEPLOY_ROLE_ARN`) does not exist yet and should be created deliberately by someone with account ownership. The trust policy and permissions it needs are documented in `deployment/README.md`.
