### PR TITLE
fix(sdc-populate): fully specify dayjs plugin import to unbreak the docs build

### DIFF
--- a/.github/workflows/build_test_lint.yml
+++ b/.github/workflows/build_test_lint.yml
@@ -43,6 +43,31 @@ jobs:
       - name: Build application
         run: cd apps/demo-renderer-app && npm run build
 
+  build-documentation:
+    name: Build Documentation
+    runs-on: ubuntu-latest
+    # Mirrors the Docusaurus build in deploy_docs.yml so webpack-only resolution errors are caught
+    # before merge. Vite (apps, Storybook) is more lenient than webpack, so those jobs miss them.
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js 20.18
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.18
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build workspace packages (monorepo dependencies)
+        run: |
+          npm run build -w packages/sdc-assemble
+          npm run build -w packages/sdc-populate
+          npm run build -w packages/sdc-template-extract
+          npm run build -w packages/smart-forms-renderer
+
+      - name: Build documentation website
+        run: npm run build -w documentation
+
   jest-smart-forms-app-tests:
     name: Jest Tests - Smart Forms App
     runs-on: ubuntu-latest

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/constructResponse.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/constructResponse.ts
@@ -34,7 +34,7 @@ import type {
 } from '../interfaces/expressions.interface';
 import { filterValueSetAnswersRecursive, resolveValueSetPromises } from './processValueSets';
 import dayjs from 'dayjs';
-import customParseFormat from 'dayjs/plugin/customParseFormat';
+import customParseFormat from 'dayjs/plugin/customParseFormat.js';
 import fhirpath from 'fhirpath';
 // Need to specifically import from 'index.js' to get it working with ts
 import fhirpath_r4_model from 'fhirpath/fhir-context/r4/index.js';


### PR DESCRIPTION
## Problem

The `deploy_docs.yml` run on `main` after PR #2056 failed at the **Build documentation website** step ([run 32442665838](https://github.com/aehrc/smart-forms/actions/runs/32442665838)):

```
Module not found: Error: Can't resolve 'dayjs/plugin/customParseFormat' in
'/home/runner/work/smart-forms/smart-forms/packages/sdc-populate/dist'
Did you mean 'customParseFormat.js'?
```

The Storybook job passed, so the docs site on S3 is stale rather than broken. Nothing was deployed.

## Cause

Three things line up:

- **`sdc-populate` is `"type": "module"`.** Webpack 5 therefore treats `dist/index.js` as strict ESM and enables `fullySpecified`, which stops it guessing a missing `.js` extension.
- **`dayjs` 1.11.x ships no `exports` map.** The subpath only resolves with the extension present.
- **PR #2056 replaced `moment` with `dayjs`.** `moment` has a single entry point and no deep subpath import, so this never came up before.

## Changes

- **`constructResponse.ts`** — import `dayjs/plugin/customParseFormat.js` with the extension. This matches the `fhirpath/fhir-context/r4/index.js` import a few lines below, which carries the same workaround. Fixing it at the source also fixes the published package for any downstream webpack consumer, rather than only our docs site.
- **`build_test_lint.yml`** — add a `Build Documentation` job mirroring the Docusaurus build in `deploy_docs.yml`. The apps and Storybook use Vite, which resolves extensionless deep imports happily, so this class of failure only surfaced after merge. Adds roughly 70 seconds to PR CI.

No version bump or release. This is a build fix only.

## Verification

Run locally on this branch:

- `npx tsc --noEmit -p packages/sdc-populate/tsconfig.json` — passes.
- `npm run build -w packages/sdc-populate` — both bundles emit the fully specified specifier.
- `npm run test -w packages/sdc-populate` — 185 tests across 20 suites pass.
- `npm run build -w documentation` — succeeds. The only remaining warning is the pre-existing `extensibility.html` broken link.
- `npm run lint` — 0 errors, 344 pre-existing warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)