### PR TITLE
refactor(write-back): switch bundle validation to opt-in (#2067 follow-up)

### DIFF
--- a/apps/smart-forms-app/src/contexts/SmartClientContext.tsx
+++ b/apps/smart-forms-app/src/contexts/SmartClientContext.tsx
@@ -23,7 +23,7 @@ import type { FhirContext } from '../features/smartAppLaunch/utils/launch.ts';
 
 export interface ExtraLaunchContext {
   disableWriteBackSelection: boolean;
-  disableBundleValidation: boolean;
+  enableBundleValidation: boolean;
 }
 
 export interface SmartClientState {
@@ -84,7 +84,7 @@ const initialSmartClientState: SmartClientState = {
   tokenReceivedTimestamp: null,
   extraLaunchContext: {
     disableWriteBackSelection: false,
-    disableBundleValidation: false
+    enableBundleValidation: false
   }
 };
 

--- a/apps/smart-forms-app/src/contexts/test/SmartClientContext.test.tsx
+++ b/apps/smart-forms-app/src/contexts/test/SmartClientContext.test.tsx
@@ -98,7 +98,7 @@ describe('SmartClientContext', () => {
       expect(mockContext.state.tokenReceivedTimestamp).toBeNull();
       expect(mockContext.state.extraLaunchContext).toEqual({
         disableWriteBackSelection: false,
-        disableBundleValidation: false
+        enableBundleValidation: false
       });
       expect(typeof mockContext.dispatch).toBe('function');
     });
@@ -362,13 +362,13 @@ describe('SmartClientContext', () => {
       act(() => {
         mockContext.dispatch({
           type: 'SET_EXTRA_LAUNCH_CONTEXT',
-          payload: { disableWriteBackSelection: true, disableBundleValidation: true }
+          payload: { disableWriteBackSelection: true, enableBundleValidation: true }
         });
       });
 
       expect(mockContext.state.extraLaunchContext).toEqual({
         disableWriteBackSelection: true,
-        disableBundleValidation: true
+        enableBundleValidation: true
       });
 
       // Other state should remain unchanged
@@ -384,20 +384,20 @@ describe('SmartClientContext', () => {
       act(() => {
         mockContext.dispatch({
           type: 'SET_EXTRA_LAUNCH_CONTEXT',
-          payload: { disableWriteBackSelection: true, disableBundleValidation: true }
+          payload: { disableWriteBackSelection: true, enableBundleValidation: true }
         });
       });
 
       act(() => {
         mockContext.dispatch({
           type: 'SET_EXTRA_LAUNCH_CONTEXT',
-          payload: { disableWriteBackSelection: false, disableBundleValidation: false }
+          payload: { disableWriteBackSelection: false, enableBundleValidation: false }
         });
       });
 
       expect(mockContext.state.extraLaunchContext).toEqual({
         disableWriteBackSelection: false,
-        disableBundleValidation: false
+        enableBundleValidation: false
       });
     });
   });

--- a/apps/smart-forms-app/src/features/prepopulate/test/usePopulate.test.tsx
+++ b/apps/smart-forms-app/src/features/prepopulate/test/usePopulate.test.tsx
@@ -177,7 +177,7 @@ describe('usePopulate', () => {
     tokenReceivedTimestamp: null,
     extraLaunchContext: {
       disableWriteBackSelection: false,
-      disableBundleValidation: false
+      enableBundleValidation: false
     },
     setSmartClient: jest.fn(),
     setCommonLaunchContexts: jest.fn(),

--- a/apps/smart-forms-app/src/features/renderer/components/RendererActions/SaveAsFinalAction.tsx
+++ b/apps/smart-forms-app/src/features/renderer/components/RendererActions/SaveAsFinalAction.tsx
@@ -145,9 +145,9 @@ function SaveAsFinalAction(props: SaveAsFinalActionProps) {
 
     // Validate before updating state — ensures WriteBackBundleSelectorDialog mounts with
     // invalidBundleEntryIndices already set, so its selectedKeys initializer excludes invalid entries
-    const validationResults = extraLaunchContext.disableBundleValidation
-      ? new Set<number>()
-      : await validateExtractedBundle(extractResult.extractedBundle, smartClient);
+    const validationResults = extraLaunchContext.enableBundleValidation
+      ? await validateExtractedBundle(extractResult.extractedBundle, smartClient)
+      : new Set<number>();
 
     // All four updates land in the same React 18 batch → single render → component mounts correctly
     setExtractedBundle(extractResult.extractedBundle);

--- a/apps/smart-forms-app/src/features/smartAppLaunch/components/Authorisation.tsx
+++ b/apps/smart-forms-app/src/features/smartAppLaunch/components/Authorisation.tsx
@@ -20,7 +20,7 @@ import { oauth2 } from 'fhirclient';
 import type { tokenResponseCustomised } from '../utils/launch.ts';
 import {
   DISABLE_WRITEBACK_SELECTION_CONTEXT_KEY,
-  DISABLE_BUNDLE_VALIDATION_CONTEXT_KEY,
+  ENABLE_BUNDLE_VALIDATION_CONTEXT_KEY,
   getQuestionnaireReferences,
   readCommonLaunchContexts,
   readQuestionnaireContext,
@@ -127,12 +127,12 @@ function Authorisation() {
           // Read extra launch context extensions from the token response
           const rawDisableWriteBackSelection =
             tokenResponse?.[DISABLE_WRITEBACK_SELECTION_CONTEXT_KEY];
-          const rawDisableBundleValidation = tokenResponse?.[DISABLE_BUNDLE_VALIDATION_CONTEXT_KEY];
+          const rawEnableBundleValidation = tokenResponse?.[ENABLE_BUNDLE_VALIDATION_CONTEXT_KEY];
           setExtraLaunchContext({
             disableWriteBackSelection:
               rawDisableWriteBackSelection === true || rawDisableWriteBackSelection === 'true',
-            disableBundleValidation:
-              rawDisableBundleValidation === true || rawDisableBundleValidation === 'true'
+            enableBundleValidation:
+              rawEnableBundleValidation === true || rawEnableBundleValidation === 'true'
           });
 
           // Get Questionnaire context from fhirContext array

--- a/apps/smart-forms-app/src/features/smartAppLaunch/utils/launch.ts
+++ b/apps/smart-forms-app/src/features/smartAppLaunch/utils/launch.ts
@@ -81,8 +81,8 @@ export interface FhirContext {
 export const DISABLE_WRITEBACK_SELECTION_CONTEXT_KEY =
   'https://smartforms.csiro.au/smart-app-launch/extra-context/disable-writeback-selection';
 
-export const DISABLE_BUNDLE_VALIDATION_CONTEXT_KEY =
-  'https://smartforms.csiro.au/smart-app-launch/extra-context/disable-bundle-validation';
+export const ENABLE_BUNDLE_VALIDATION_CONTEXT_KEY =
+  'https://smartforms.csiro.au/smart-app-launch/extra-context/enable-bundle-validation';
 
 export interface tokenResponseCustomised extends fhirclient.TokenResponse {
   fhirContext?: FhirContext[];
@@ -90,7 +90,7 @@ export interface tokenResponseCustomised extends fhirclient.TokenResponse {
   'https://smartforms.csiro.au/smart-app-launch/extra-context/disable-writeback-selection'?:
     | boolean
     | string;
-  'https://smartforms.csiro.au/smart-app-launch/extra-context/disable-bundle-validation'?:
+  'https://smartforms.csiro.au/smart-app-launch/extra-context/enable-bundle-validation'?:
     | boolean
     | string;
 }

--- a/apps/smart-forms-app/src/test/useSmartClient.test.ts
+++ b/apps/smart-forms-app/src/test/useSmartClient.test.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+/// <reference types="jest" />
 import { renderHook, act } from '@testing-library/react';
 import useSmartClient from '../hooks/useSmartClient';
 import type { SmartClientContextType } from '../contexts/SmartClientContext';
@@ -33,7 +34,7 @@ const mockContextValue: SmartClientContextType = {
     tokenReceivedTimestamp: null,
     extraLaunchContext: {
       disableWriteBackSelection: false,
-      disableBundleValidation: false
+      enableBundleValidation: false
     }
   },
   dispatch: mockDispatch
@@ -74,7 +75,7 @@ describe('useSmartClient', () => {
 
     expect(result.current.extraLaunchContext).toEqual({
       disableWriteBackSelection: false,
-      disableBundleValidation: false
+      enableBundleValidation: false
     });
   });
 
@@ -84,13 +85,13 @@ describe('useSmartClient', () => {
     act(() => {
       result.current.setExtraLaunchContext({
         disableWriteBackSelection: true,
-        disableBundleValidation: false
+        enableBundleValidation: false
       });
     });
 
     expect(mockDispatch).toHaveBeenCalledWith({
       type: 'SET_EXTRA_LAUNCH_CONTEXT',
-      payload: { disableWriteBackSelection: true, disableBundleValidation: false }
+      payload: { disableWriteBackSelection: true, enableBundleValidation: false }
     });
   });
 });

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -35,7 +35,7 @@ Smart Forms supports passing additional context to the app via the SMART App Lau
 | Key | Type | Description |
 |-----|------|-------------|
 | `https://smartforms.csiro.au/smart-app-launch/extra-context/disable-writeback-selection` | `boolean` | When `true`, skips the item selection step in the Save Final & Write Back dialog and writes back all items to the patient record. The string `"true"` is also accepted for launchers that serialize all values as strings. |
-| `https://smartforms.csiro.au/smart-app-launch/extra-context/disable-bundle-validation` | `boolean` | When `true`, skips post-extraction `$validate` calls against the FHIR server before the write-back dialog is shown. Useful if the server does not support `$validate` and you want to avoid the overhead. The string `"true"` is also accepted for launchers that serialize all values as strings. |
+| `https://smartforms.csiro.au/smart-app-launch/extra-context/enable-bundle-validation` | `boolean` | When `true`, enables post-extraction `$validate` calls against the FHIR server before the write-back dialog is shown. Invalid entries are excluded from selection. Validation is off by default; set this to `true` to opt in. The string `"true"` is also accepted for launchers that serialize all values as strings. |
 
 
 


### PR DESCRIPTION
## Summary

Follow-up to #2067. Switches `disableBundleValidation` to `enableBundleValidation` so that bundle validation is **off by default** and must be explicitly opted into by the EHR via SMART launch context.

- Renames `disableBundleValidation → enableBundleValidation` in `ExtraLaunchContext`
- Renames the extra launch context key URL from `disable-bundle-validation` to `enable-bundle-validation`
- Flips the default: validation only runs when the EHR passes `enable-bundle-validation: true` in the token response
- Updates documentation, tests, and all call sites

## Test plan

- [ ] Launching without the `enable-bundle-validation` key → no validation, dialog opens normally
- [ ] Launching with `enable-bundle-validation: true` → `$validate` runs, invalid entries shown with red border/disabled checkbox
- [ ] All existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)