### PR TITLE
fix(sdc-template-extract): merge templateExtractValue into the array element its path names

### DIFF
--- a/packages/sdc-template-extract/CHANGELOG.md
+++ b/packages/sdc-template-extract/CHANGELOG.md
@@ -5,6 +5,10 @@ This log documents changes for [@aehrc/sdc-template-extract](https://www.npmjs.c
 
 Changelog only includes changes from version 1.0.6 onwards.
 
+## sdc-template-extract [Unreleased]
+#### Fixed
+- A `templateExtractValue` whose value path names an element that already exists in the template's array (e.g. `Immunization.protocolApplied[0].doseNumberPositiveInt`) now populates that element instead of appending a separate, half-populated one. Arrays nested inside a merged object are merged by index rather than concatenated.
+
 ## sdc-template-extract [1.0.15] - 2026-01-13
 #### Fixed
 - Fixed issues relating to the extraction of arrays, including issue [#1777](https://github.com/aehrc/smart-forms/issues/1777).

--- a/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/extract.test.ts
+++ b/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/extract.test.ts
@@ -3,6 +3,7 @@ import type { OutputParameters, ReturnParameter } from '../interfaces';
 import { createInputParameters } from '../utils/createInputParameters';
 import type {
   Bundle,
+  Immunization,
   Observation,
   Parameters,
   QuestionnaireResponseItem,
@@ -20,6 +21,7 @@ import { extractedRegularMedicationsModified } from './resources/extracted/extra
 import { extractedRegularMedicationsWithPatchAdd } from './resources/extracted/extractedRegularMedicationsWithPatchAdd';
 import { extractedComplexTemplateExtract } from './resources/extracted/extractedComplexTemplateExtract';
 import { extractedSepsisRisk } from './resources/extracted/extractedSepsisRisk';
+import { extractedArrayElementMergeImmunization } from './resources/extracted/extractedArrayElementMerge';
 
 // QuestionnaireResponses
 import { QRAllergiesAdverseReactions } from './resources/questionnaireResponses/QRAllergiesAdverseReactions';
@@ -32,6 +34,7 @@ import { QRRegularMedicationsModified } from './resources/questionnaireResponses
 import { QRRegularMedicationsWithPatchAdd } from './resources/questionnaireResponses/QRRegularMedicationsWithPatchAdd';
 import { QRComplexTemplateExtract } from './resources/questionnaireResponses/QRComplexTemplateExtract';
 import { QRSepsisRisk } from './resources/questionnaireResponses/QRSepsisRisk';
+import { QRArrayElementMerge } from './resources/questionnaireResponses/QRArrayElementMerge';
 
 // Questionnaires
 import { QAllergiesAdverseReactions } from './resources/questionnaires/QAllergiesAdverseReactions';
@@ -44,6 +47,7 @@ import { QRegularMedicationsModified } from './resources/questionnaires/QRegular
 import { QRegularMedicationsWithPatchAdd } from './resources/questionnaires/QRegularMedicationsWithPatchAdd';
 import { QComplexTemplateExtract } from './resources/questionnaires/QComplexTemplateExtract';
 import { QSepsisRisk } from './resources/questionnaires/QSepsisRisk';
+import { QArrayElementMerge } from './resources/questionnaires/QArrayElementMerge';
 import { parametersIsFhirPatch } from '../utils/typePredicates';
 
 // Mock the fetchQuestionnaire callback function
@@ -558,3 +562,32 @@ function stripObservationSubjectReferenceAndDates(resource: any): any {
   const { subject, effectiveDateTime, issued, ...rest } = resource ?? {};
   return rest;
 }
+
+describe('extract ArrayElementMerge', () => {
+  // A templateExtractValue whose value path names an element that already exists in the template's
+  // array (`protocolApplied[0].doseNumberPositiveInt`) must populate THAT element, next to the
+  // static `targetDisease` declared beside it.
+  it('merges an evaluated value into the existing array element named by its value path', async () => {
+    const result = await extract(
+      createInputParameters(QRArrayElementMerge, QArrayElementMerge, undefined),
+      mockFetchQuestionnaire,
+      mockFetchQuestionnaireConfig
+    );
+
+    const returnParam = (result as OutputParameters).parameter.find(
+      (p): p is ReturnParameter => p.name === 'return'
+    );
+
+    const extracted = returnParam?.resource as Bundle;
+    // The template is a Bundle, so the extracted document Bundle is the first entry's resource
+    const extractedBundle = extracted.entry?.[0]?.resource as Bundle;
+    const extractedImmunization = extractedBundle.entry?.[0]?.resource as Immunization;
+
+    // The evaluated dose must not be appended as a second protocolApplied element
+    expect(extractedImmunization.protocolApplied).toHaveLength(1);
+    expect(extractedImmunization.protocolApplied?.[0]?.doseNumberPositiveInt).toBe(2);
+    expect(extractedImmunization.protocolApplied?.[0]?.targetDisease).toBeDefined();
+
+    expect(extractedImmunization).toEqual(extractedArrayElementMergeImmunization);
+  });
+});

--- a/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/resources/extracted/extractedArrayElementMerge.ts
+++ b/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/resources/extracted/extractedArrayElementMerge.ts
@@ -1,0 +1,40 @@
+import type { Immunization } from 'fhir/r4';
+
+/**
+ * Expected `Immunization` for QArrayElementMerge/QRArrayElementMerge.
+ *
+ * `protocolApplied` has exactly ONE element: the evaluated `doseNumberPositiveInt` is merged into
+ * the element the value path names (index 0), alongside the static `targetDisease` declared in the
+ * template — rather than being appended as a second, half-populated element.
+ */
+export const extractedArrayElementMergeImmunization: Immunization = {
+  resourceType: 'Immunization',
+  status: 'completed',
+  vaccineCode: {
+    coding: [
+      {
+        system: 'http://snomed.info/sct',
+        code: '1290624003'
+      }
+    ]
+  },
+  patient: {
+    reference: 'Patient/example'
+  },
+  occurrenceDateTime: '2025-01-01',
+  protocolApplied: [
+    {
+      targetDisease: [
+        {
+          coding: [
+            {
+              system: 'http://snomed.info/sct',
+              code: '67924001'
+            }
+          ]
+        }
+      ],
+      doseNumberPositiveInt: 2
+    }
+  ]
+};

--- a/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/resources/questionnaireResponses/QRArrayElementMerge.ts
+++ b/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/resources/questionnaireResponses/QRArrayElementMerge.ts
@@ -1,0 +1,25 @@
+import type { QuestionnaireResponse } from 'fhir/r4';
+
+export const QRArrayElementMerge: QuestionnaireResponse = {
+  resourceType: 'QuestionnaireResponse',
+  id: 'QR-ArrayElementMerge',
+  status: 'completed',
+  questionnaire: 'https://smartforms.csiro.au/docs/tests/ArrayElementMerge',
+  item: [
+    {
+      linkId: 'immunisation',
+      text: 'Immunisation',
+      item: [
+        {
+          linkId: 'doses',
+          text: 'Total number of doses',
+          answer: [
+            {
+              valueInteger: 2
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};

--- a/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/resources/questionnaires/QArrayElementMerge.ts
+++ b/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/resources/questionnaires/QArrayElementMerge.ts
@@ -80,7 +80,8 @@ export const QArrayElementMerge: Questionnaire = {
                   extension: [
                     {
                       url: 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-templateExtractValue',
-                      valueString: "%resource.descendants().where(linkId='doses').answer.value.first()"
+                      valueString:
+                        "%resource.descendants().where(linkId='doses').answer.value.first()"
                     }
                   ]
                 }

--- a/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/resources/questionnaires/QArrayElementMerge.ts
+++ b/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/resources/questionnaires/QArrayElementMerge.ts
@@ -1,0 +1,121 @@
+import type { Questionnaire } from 'fhir/r4';
+
+/**
+ * Minimal questionnaire reproducing a `templateExtractValue` that targets a field of an element
+ * which ALREADY EXISTS in the template's array, underneath a `templateExtractContext`.
+ *
+ * The template is a Bundle whose `entry[0]` is context-gated, which is how a whole resource is made
+ * conditional. The engine deletes that gated entry and re-inserts it per context result, seeding it
+ * from the static template and then merging each evaluated value into it.
+ *
+ * Inside the gated entry, `protocolApplied[0]` is declared statically with a `targetDisease`, and
+ * the value expression writes `protocolApplied[0].doseNumberPositiveInt`. Because the value path
+ * names index 0, the evaluated value belongs in that same element, next to `targetDisease`.
+ */
+export const QArrayElementMerge: Questionnaire = {
+  resourceType: 'Questionnaire',
+  id: 'ArrayElementMerge',
+  url: 'https://smartforms.csiro.au/docs/tests/ArrayElementMerge',
+  name: 'ArrayElementMerge',
+  title: 'Array element merge',
+  status: 'draft',
+  experimental: true,
+  subjectType: ['Patient'],
+  contained: [
+    {
+      resourceType: 'Bundle',
+      id: 'BundleTemplate',
+      type: 'transaction',
+      entry: [
+        {
+          extension: [
+            {
+              url: 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-templateExtractContext',
+              valueString: "iif(item.where(linkId='doses').answer.value.exists(), true, {})"
+            }
+          ],
+          fullUrl: 'urn:uuid:0f9b1a2c-3d4e-5f60-7182-93a4b5c6d7e8',
+          // @ts-ignore - TS2353: `_fullUrl` carries the identity value directive. A context-gated
+          // entry is seeded with a shallow spread of its first evaluated value, so the first value
+          // must be one at depth 1 (here `fullUrl` overwritten with itself), otherwise a value
+          // under `resource.…` would replace the whole static resource.
+          _fullUrl: {
+            extension: [
+              {
+                url: 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-templateExtractValue',
+                valueString: "'urn:uuid:0f9b1a2c-3d4e-5f60-7182-93a4b5c6d7e8'"
+              }
+            ]
+          },
+          resource: {
+            resourceType: 'Immunization',
+            status: 'completed',
+            vaccineCode: {
+              coding: [
+                {
+                  system: 'http://snomed.info/sct',
+                  code: '1290624003'
+                }
+              ]
+            },
+            patient: {
+              reference: 'Patient/example'
+            },
+            occurrenceDateTime: '2025-01-01',
+            protocolApplied: [
+              {
+                targetDisease: [
+                  {
+                    coding: [
+                      {
+                        system: 'http://snomed.info/sct',
+                        code: '67924001'
+                      }
+                    ]
+                  }
+                ],
+                // @ts-ignore - TS2353: `_doseNumberPositiveInt` is the primitive extension sibling,
+                // which carries the templateExtractValue directive. Only present in templates.
+                _doseNumberPositiveInt: {
+                  extension: [
+                    {
+                      url: 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-templateExtractValue',
+                      valueString: "%resource.descendants().where(linkId='doses').answer.value.first()"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  item: [
+    {
+      extension: [
+        {
+          url: 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-templateExtract',
+          extension: [
+            {
+              url: 'template',
+              valueReference: {
+                reference: '#BundleTemplate'
+              }
+            }
+          ]
+        }
+      ],
+      linkId: 'immunisation',
+      text: 'Immunisation',
+      type: 'group',
+      item: [
+        {
+          linkId: 'doses',
+          text: 'Total number of doses',
+          type: 'integer'
+        }
+      ]
+    }
+  ]
+};

--- a/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/utils/templateInsert.ts
+++ b/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/utils/templateInsert.ts
@@ -5,6 +5,27 @@ import { buildValuesToInsert } from './buildValueToInsert';
 import { getStaticTemplateDataAtPath } from './staticTemplateData';
 import deepmerge from 'deepmerge';
 
+/**
+ * Merges two arrays by index rather than by concatenation (deepmerge's default).
+ *
+ * Value paths address array elements positionally (e.g. `protocolApplied[0].doseNumberPositiveInt`),
+ * so an incoming array must be merged into the element at the same index. Elements beyond the
+ * target's length are appended, preserving the previous behaviour for genuinely new entries.
+ */
+function mergeArrayByIndex(target: any[], source: any[], options: any): any[] {
+  const destination = target.slice();
+  source.forEach((item, index) => {
+    if (typeof destination[index] === 'undefined') {
+      destination[index] = options.cloneUnlessOtherwiseSpecified(item, options);
+    } else if (options.isMergeableObject(item)) {
+      destination[index] = deepmerge(target[index], item, options);
+    } else if (target.indexOf(item) === -1) {
+      destination.push(item);
+    }
+  });
+  return destination;
+}
+
 export function removeTemplateExtractValueExtension(
   entryPath: string,
   valuePath: string,
@@ -177,8 +198,14 @@ export function walkTemplateAndInsertValue(
 
   // Existing node is an object, and we are inserting an object, merge them
   if (typeof existingNode === 'object' && typeof valueToInsert === 'object') {
-    // Deep merge required to handle arrays within objects
-    current[finalSegment] = deepmerge(existingNode, valueToInsert);
+    // Deep merge required to handle arrays within objects.
+    // Arrays nested inside those objects are merged BY INDEX, not concatenated: a value path such
+    // as `Immunization.protocolApplied[0].doseNumberPositiveInt` targets a specific element of an
+    // existing template array, so concatenating would append a second, half-populated element
+    // instead of populating the one the path names.
+    current[finalSegment] = deepmerge(existingNode, valueToInsert, {
+      arrayMerge: mergeArrayByIndex
+    });
     return;
   }
 


### PR DESCRIPTION
Fixes #2092

## Problem

A `templateExtractValue` whose value path names an element that **already exists** in the template's array does not populate that element. The evaluated value is appended as a separate, half-populated element instead.

Given a template with `protocolApplied[0]` declared statically:

```json
"protocolApplied": [{ "targetDisease": [{ "coding": [{ "code": "67924001" }] }] }]
```

and a value expression writing `protocolApplied[0].doseNumberPositiveInt`:

```
expected  "protocolApplied": [{ "targetDisease": [...], "doseNumberPositiveInt": 2 }]
actual    "protocolApplied": [{ "targetDisease": [...] }, { "doseNumberPositiveInt": 2 }]
```

The value path names index 0, so the value belongs in that element. Splitting it also breaks cardinality for anything that is 1..1 within the element — here `Immunization.protocolApplied.doseNumber[x]`, which ends up absent from the first entry and orphaned in the second.

## Cause

`walkTemplateAndInsertValue` deep-merges an evaluated object into the existing node when both are objects. `deepmerge`'s **default array strategy is concatenation**, so an array nested inside that object is appended to rather than merged.

`buildValuesToInsert` turns `protocolApplied[0].doseNumberPositiveInt` into `{protocolApplied: [{doseNumberPositiveInt: 2}]}`, which is then concatenated onto the static `protocolApplied: [{targetDisease: …}]`.

This only surfaces under a `templateExtractContext`: a gated array element is deleted and re-seeded from the static template, then deep-merged. Without a gate the value is assigned directly and the bug does not appear — which is why the test fixture uses a context-gated Bundle entry.

Note this is a different code path from #1777 / the array fixes in 1.0.15, which addressed insert positioning and index bookkeeping. The object-merge path was untouched.

## Fix

Pass an `arrayMerge` that merges by index, appending only elements beyond the target's length so genuinely new entries behave as before.

The explicit array branches above this one — `existingNode.push(valueToInsert)` and the array-to-array concat, which handle repeating values such as multiple `given` names — are not affected; `deepmerge` is only reached when both sides are non-array objects.

## Tests

- New fixture triple `QArrayElementMerge` / `QRArrayElementMerge` / `extractedArrayElementMerge`, plus one `describe` in `extract.test.ts`. Minimal, no existing goldens touched.
- First commit adds the failing test only (intentionally red, if CI runs per-commit); second commit applies the fix.
- Full suite after the fix: **70/70 passing**, `tsc --noEmit` clean, eslint clean.

Happy to squash the two commits if you would rather not have a red commit in history, and to swap the `any` types in `mergeArrayByIndex` for `deepmerge`'s own `ArrayMergeOptions` — they currently match the surrounding file's style.

## Notes

Found while building an SDC template-based `$extract` for a Swiss public-health IG (CH EKM), where a vaccination row extracts `protocolApplied.targetDisease` statically and the dose count via a value path into the same element.