### PR TITLE
fix (sdc-populate) `$populate` silently drops open-choice answers that are not in answerOption

### DIFF
--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/answerOption.test.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/answerOption.test.ts
@@ -83,4 +83,37 @@ describe('findInAnswerOptions', () => {
     const result = findInAnswerOptions([], 'anything');
     expect(result).toBeUndefined();
   });
+
+  it('finds option by Coding value matching system and code', () => {
+    const result = findInAnswerOptions(options, { system: 'http://loinc.org', code: '1234-5' });
+    expect(result).toEqual({
+      valueCoding: { ...codingOption.valueCoding }
+    });
+  });
+
+  it('finds option by Coding value without a system when codes match', () => {
+    const result = findInAnswerOptions(options, { code: '1234-5' });
+    expect(result).toEqual({
+      valueCoding: { ...codingOption.valueCoding }
+    });
+  });
+
+  it('returns undefined for Coding value with a different system', () => {
+    const result = findInAnswerOptions(options, {
+      system: 'http://snomed.info/sct',
+      code: '1234-5'
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined for Coding value with a non-matching code', () => {
+    const result = findInAnswerOptions(options, { system: 'http://loinc.org', code: '9999-9' });
+    expect(result).toBeUndefined();
+  });
+
+  it('does not match a Quantity-like object against coding options', () => {
+    const quantity = { value: 10, unit: '1234-5', system: 'http://loinc.org', code: '1234-5' };
+    const result = findInAnswerOptions(options, quantity as never);
+    expect(result).toBeUndefined();
+  });
 });

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/answerOption.test.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/answerOption.test.ts
@@ -117,3 +117,12 @@ describe('findInAnswerOptions', () => {
     expect(result).toBeUndefined();
   });
 });
+
+describe('findInAnswerOptions zero-valued integer options', () => {
+  it('matches answerOption valueInteger 0 for a populated string "0"', () => {
+    const options = [{ valueInteger: 0 }, { valueInteger: 5 }];
+
+    expect(findInAnswerOptions(options, '0')).toEqual({ valueInteger: 0 });
+    expect(findInAnswerOptions(options, '5')).toEqual({ valueInteger: 5 });
+  });
+});

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/answerOption.test.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/answerOption.test.ts
@@ -33,7 +33,7 @@
  */
 
 import { describe, expect, it } from '@jest/globals';
-import { findInAnswerOptions } from '../utils/answerOption';
+import { findInAnswerOptions, valueIsCoding } from '../utils/answerOption';
 
 describe('findInAnswerOptions', () => {
   const codingOption = {
@@ -145,5 +145,44 @@ describe('findInAnswerOptions rejects non-Coding code-bearing objects', () => {
     expect(findInAnswerOptions(options, { code: 'mg' })).toEqual({
       valueCoding: { system: 'sys', code: 'mg', display: 'milligram' }
     });
+  });
+});
+
+describe('findInAnswerOptions codeless Coding values', () => {
+  const displayOnlyOption = {
+    valueCoding: { system: 'http://example.com/local-codes', display: 'Query positive' }
+  };
+
+  it('matches a codeless Coding against a display-only option by display', () => {
+    const value = { system: 'http://example.com/local-codes', display: 'Query positive' };
+
+    expect(findInAnswerOptions([displayOnlyOption], value)).toEqual({
+      valueCoding: displayOnlyOption.valueCoding
+    });
+  });
+
+  it('does not match a codeless Coding from a different system', () => {
+    const value = { system: 'http://example.com/other-codes', display: 'Query positive' };
+
+    expect(findInAnswerOptions([displayOnlyOption], value)).toBeUndefined();
+  });
+
+  it('does not match a codeless Coding with a different display', () => {
+    const value = { system: 'http://example.com/local-codes', display: 'Query negative' };
+
+    expect(findInAnswerOptions([displayOnlyOption], value)).toBeUndefined();
+  });
+});
+
+describe('valueIsCoding content requirement', () => {
+  it('accepts a codeless Coding with system and display', () => {
+    expect(valueIsCoding({ system: 'sys', display: 'Query positive' })).toBe(true);
+  });
+
+  it('rejects objects with neither system nor code', () => {
+    expect(valueIsCoding({})).toBe(false);
+    expect(valueIsCoding({ userSelected: true })).toBe(false);
+    expect(valueIsCoding({ id: 'x' })).toBe(false);
+    expect(valueIsCoding({ display: 'just text' })).toBe(false);
   });
 });

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/answerOption.test.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/answerOption.test.ts
@@ -126,3 +126,24 @@ describe('findInAnswerOptions zero-valued integer options', () => {
     expect(findInAnswerOptions(options, '5')).toEqual({ valueInteger: 5 });
   });
 });
+
+describe('findInAnswerOptions rejects non-Coding code-bearing objects', () => {
+  it('does not match a value-less Quantity against a coding option by code', () => {
+    const options = [{ valueCoding: { code: 'mg', display: 'milligram' } }];
+    const quantityLike = {
+      system: 'http://unitsofmeasure.org',
+      code: 'mg',
+      comparator: '<'
+    };
+
+    expect(findInAnswerOptions(options, quantityLike as never)).toBeUndefined();
+  });
+
+  it('still matches a genuine systemless coding by code', () => {
+    const options = [{ valueCoding: { system: 'sys', code: 'mg', display: 'milligram' } }];
+
+    expect(findInAnswerOptions(options, { code: 'mg' })).toEqual({
+      valueCoding: { system: 'sys', code: 'mg', display: 'milligram' }
+    });
+  });
+});

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/parse.test.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/parse.test.ts
@@ -138,6 +138,34 @@ describe('parseValueToAnswer', () => {
     expect(result).toEqual({ valueCoding: { code: 'J44.9', display: 'COPD' } });
   });
 
+  it('returns valueCoding for a codeless coding instead of flattening it to valueString', () => {
+    const qItem = {
+      linkId: 'query',
+      type: 'choice' as const,
+      answerOption: [
+        {
+          valueCoding: { system: 'http://example.com/local-codes', display: 'Query positive' }
+        }
+      ]
+    };
+
+    const matched = parseValueToAnswer(qItem, {
+      system: 'http://example.com/local-codes',
+      display: 'Query positive'
+    });
+    expect(matched).toEqual({
+      valueCoding: { system: 'http://example.com/local-codes', display: 'Query positive' }
+    });
+
+    const unmatched = parseValueToAnswer(qItem, {
+      system: 'http://example.com/other-codes',
+      display: 'Query unknown'
+    });
+    expect(unmatched).toEqual({
+      valueCoding: { system: 'http://example.com/other-codes', display: 'Query unknown' }
+    });
+  });
+
   it('never emits an object inside valueString for unrecognised object values', () => {
     const qItem = { linkId: 'q', type: 'string' as const };
 

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/parse.test.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/parse.test.ts
@@ -118,6 +118,36 @@ describe('parseItemInitialToAnswer', () => {
 });
 
 describe('parseValueToAnswer', () => {
+  it('returns valueCoding for a systemless coding that matches no answerOption', () => {
+    const qItem = {
+      linkId: 'dx',
+      type: 'open-choice' as const,
+      answerOption: [
+        {
+          valueCoding: {
+            system: 'http://hl7.org/fhir/sid/icd-10-cm',
+            code: 'E11.9',
+            display: 'T2DM'
+          }
+        }
+      ]
+    };
+
+    const result = parseValueToAnswer(qItem, { code: 'J44.9', display: 'COPD' });
+
+    expect(result).toEqual({ valueCoding: { code: 'J44.9', display: 'COPD' } });
+  });
+
+  it('never emits an object inside valueString for unrecognised object values', () => {
+    const qItem = { linkId: 'q', type: 'string' as const };
+
+    const withDisplay = parseValueToAnswer(qItem, { display: 'just text' });
+    expect(withDisplay).toEqual({ valueString: 'just text' });
+
+    const opaque = parseValueToAnswer(qItem, { reference: 'Patient/1' });
+    expect(typeof opaque.valueString).toBe('string');
+  });
+
   it('returns answerOption if found', () => {
     const qItem: QuestionnaireItem = {
       linkId: 'q1',

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/parse.test.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/parse.test.ts
@@ -136,6 +136,20 @@ describe('parseValueToAnswer', () => {
     });
   });
 
+  it('returns answerOption for a Coding value found in answerOption', () => {
+    const qItem: QuestionnaireItem = {
+      linkId: 'q1',
+      type: 'choice',
+      answerOption: [{ valueCoding: { system: 'sys', code: 'code1', display: 'Code One' } }]
+    };
+
+    // Coding values come from FHIRPath results, e.g. %condition.code.coding.first()
+    const result = parseValueToAnswer(qItem, { system: 'sys', code: 'code1' });
+    expect(result).toEqual({
+      valueCoding: { system: 'sys', code: 'code1', display: 'Code One' }
+    });
+  });
+
   it('returns valueBoolean for boolean type and boolean value', () => {
     const qItem: QuestionnaireItem = {
       linkId: 'q1',

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/populate.test.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/populate.test.ts
@@ -356,3 +356,122 @@ describe('populate - non-repeating itemPopulationContext children evaluated glob
     expect(patientIdItem?.answer?.[0]?.valueString).toBe('test-patient-123');
   });
 });
+
+// Minimal questionnaire with an open-choice item and a choice item, both with answerOptions
+// and initialExpressions that resolve to a Coding NOT present in the answerOptions.
+// Open-choice must keep the answer (arbitrary values are allowed), choice must filter it out.
+const qOpenChoicePrefill = {
+  resourceType: 'Questionnaire',
+  id: 'open-choice-prefill-test',
+  status: 'active',
+  item: [
+    {
+      linkId: 'dx-open-choice',
+      type: 'open-choice',
+      answerOption: [
+        {
+          valueCoding: {
+            system: 'http://hl7.org/fhir/sid/icd-10-cm',
+            code: 'E11.9',
+            display: 'Type 2 diabetes mellitus without complications'
+          }
+        }
+      ],
+      extension: [
+        {
+          url: SDC_INITIAL_EXPR,
+          valueExpression: {
+            language: 'text/fhirpath',
+            expression: '%ConditionBundle.entry.resource.code.coding.first()'
+          }
+        }
+      ]
+    },
+    {
+      linkId: 'dx-choice',
+      type: 'choice',
+      answerOption: [
+        {
+          valueCoding: {
+            system: 'http://hl7.org/fhir/sid/icd-10-cm',
+            code: 'E11.9',
+            display: 'Type 2 diabetes mellitus without complications'
+          }
+        }
+      ],
+      extension: [
+        {
+          url: SDC_INITIAL_EXPR,
+          valueExpression: {
+            language: 'text/fhirpath',
+            expression: '%ConditionBundle.entry.resource.code.coding.first()'
+          }
+        }
+      ]
+    }
+  ]
+};
+
+describe('populate - open-choice answers outside answerOptions', () => {
+  it('keeps a coding answer outside answerOptions for open-choice, filters it for choice', async () => {
+    const mockContext = {
+      resource: { resourceType: 'QuestionnaireResponse', status: 'in-progress' },
+      rootResource: { resourceType: 'QuestionnaireResponse', status: 'in-progress' },
+      patient: { resourceType: 'Patient', id: 'test-patient' },
+      ConditionBundle: {
+        resourceType: 'Bundle',
+        type: 'searchset',
+        entry: [
+          {
+            resource: {
+              resourceType: 'Condition',
+              id: 'cond-copd',
+              code: {
+                coding: [
+                  {
+                    system: 'http://hl7.org/fhir/sid/icd-10-cm',
+                    code: 'J44.9',
+                    display: 'Chronic obstructive pulmonary disease, unspecified'
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    };
+
+    (createFhirPathContext as jest.Mock).mockImplementation(async () => mockContext);
+    (resolveLookupPromises as jest.Mock).mockImplementation(async () => ({}));
+
+    const inputParameters: InputParameters = {
+      resourceType: 'Parameters',
+      parameter: [
+        { name: 'questionnaire', resource: qOpenChoicePrefill as any },
+        { name: 'subject', valueReference: { type: 'Patient', reference: 'Patient/test-patient' } }
+      ]
+    };
+
+    const result = await populate(
+      inputParameters,
+      mockFetchResourceCallback,
+      mockFetchResourceCallbackConfig,
+      mockTerminologyCallback,
+      mockTerminologyCallbackConfig
+    );
+
+    const response = (result as OutputParameters).parameter.find((p) => p.name === 'response')
+      ?.resource as QuestionnaireResponse;
+
+    // Open-choice: the answer survives even though it is not in answerOptions
+    const openChoiceItem = response.item?.find((i) => i.linkId === 'dx-open-choice');
+    expect(openChoiceItem?.answer?.[0]?.valueCoding).toMatchObject({
+      system: 'http://hl7.org/fhir/sid/icd-10-cm',
+      code: 'J44.9'
+    });
+
+    // Choice: the non-matching answer is filtered out
+    const choiceItem = response.item?.find((i) => i.linkId === 'dx-choice');
+    expect(choiceItem?.answer).toBeUndefined();
+  });
+});

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/resolveValueSetPromises.test.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/resolveValueSetPromises.test.ts
@@ -206,6 +206,60 @@ describe('filterValueSetAnswersRecursive', () => {
     expect(result?.answer).toEqual([{ valueCoding: { system: 'sys', code: 'a', display: 'A' } }]);
   });
 
+  it('does not rewrite a same-code coding from a different system to the option coding', () => {
+    const input = {
+      linkId: 'q1',
+      answer: [
+        { valueCoding: { system: 'http://snomed.info/sct', code: 'a', display: 'SNOMED A' } }
+      ]
+    };
+
+    const choiceResult = filterValueSetAnswersRecursive(
+      input,
+      {},
+      mockAnswerOptions,
+      {},
+      { q1: 'choice' }
+    );
+    // dropped, not substituted with { system: 'sys', code: 'a' }
+    expect(choiceResult?.answer).toEqual([]);
+
+    const openChoiceResult = filterValueSetAnswersRecursive(
+      input,
+      {},
+      mockAnswerOptions,
+      {},
+      { q1: 'open-choice' }
+    );
+    // kept exactly as populated, still SNOMED
+    expect(openChoiceResult?.answer).toEqual([
+      { valueCoding: { system: 'http://snomed.info/sct', code: 'a', display: 'SNOMED A' } }
+    ]);
+  });
+
+  it('matches display-only codings by display instead of undefined === undefined', () => {
+    const displayOnlyOptions = {
+      q1: [{ valueCoding: { display: 'A' } }, { valueCoding: { display: 'B' } }]
+    };
+    const input = {
+      linkId: 'q1',
+      answer: [{ valueCoding: { display: 'B' } }]
+    };
+
+    const result = filterValueSetAnswersRecursive(
+      input,
+      {},
+      displayOnlyOptions,
+      {},
+      {
+        q1: 'choice'
+      }
+    );
+
+    // stays B; a code-only comparison would find option A first
+    expect(result?.answer).toEqual([{ valueCoding: { display: 'B' } }]);
+  });
+
   it('preserves coding answers outside a contained valueSet for open-choice items', () => {
     const input = {
       linkId: 'q3',

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/resolveValueSetPromises.test.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/resolveValueSetPromises.test.ts
@@ -157,4 +157,84 @@ describe('filterValueSetAnswersRecursive', () => {
 
     expect(result).toEqual(input);
   });
+
+  it('preserves coding answers outside answerOptions for open-choice items', () => {
+    const input = {
+      linkId: 'q1',
+      answer: [
+        { valueCoding: { system: 'sys', code: 'a' } },
+        { valueCoding: { system: 'http://hl7.org/fhir/sid/icd-10-cm', code: 'J44.9' } }
+      ]
+    };
+
+    const result = filterValueSetAnswersRecursive(
+      input,
+      {},
+      mockAnswerOptions,
+      {},
+      {
+        q1: 'open-choice'
+      }
+    );
+
+    // Matching coding is normalised to the option's coding, non-matching coding is kept as is
+    expect(result?.answer).toEqual([
+      { valueCoding: { system: 'sys', code: 'a', display: 'A' } },
+      { valueCoding: { system: 'http://hl7.org/fhir/sid/icd-10-cm', code: 'J44.9' } }
+    ]);
+  });
+
+  it('still filters out non-matching coding answers for choice items', () => {
+    const input = {
+      linkId: 'q1',
+      answer: [
+        { valueCoding: { system: 'sys', code: 'a' } },
+        { valueCoding: { system: 'http://hl7.org/fhir/sid/icd-10-cm', code: 'J44.9' } }
+      ]
+    };
+
+    const result = filterValueSetAnswersRecursive(
+      input,
+      {},
+      mockAnswerOptions,
+      {},
+      {
+        q1: 'choice'
+      }
+    );
+
+    expect(result?.answer).toEqual([{ valueCoding: { system: 'sys', code: 'a', display: 'A' } }]);
+  });
+
+  it('preserves coding answers outside a contained valueSet for open-choice items', () => {
+    const input = {
+      linkId: 'q3',
+      answer: [{ valueCoding: { system: 'sys', code: 'z', display: 'Z' } }]
+    };
+
+    const result = filterValueSetAnswersRecursive(input, {}, {}, mockContainedResources, {
+      q3: 'open-choice'
+    });
+
+    expect(result?.answer).toEqual([{ valueCoding: { system: 'sys', code: 'z', display: 'Z' } }]);
+  });
+
+  it('preserves coding answers outside an expanded valueSet for open-choice items', () => {
+    const input = {
+      linkId: 'q2',
+      answer: [{ valueCoding: { system: 'sys', code: '9' } }]
+    };
+
+    const result = filterValueSetAnswersRecursive(
+      input,
+      mockResolvedValueSetPromises,
+      {},
+      {},
+      {
+        q2: 'open-choice'
+      }
+    );
+
+    expect(result?.answer).toEqual([{ valueCoding: { system: 'sys', code: '9' } }]);
+  });
 });

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/resolveValueSetPromises.test.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/test/resolveValueSetPromises.test.ts
@@ -108,7 +108,8 @@ describe('filterValueSetAnswersRecursive', () => {
       input,
       mockResolvedValueSetPromises,
       mockAnswerOptions,
-      mockContainedResources
+      mockContainedResources,
+      new Set<string>()
     );
 
     expect(result).toBeDefined();
@@ -142,7 +143,13 @@ describe('filterValueSetAnswersRecursive', () => {
       ]
     };
 
-    const result = filterValueSetAnswersRecursive(input, {}, {}, mockContainedResources);
+    const result = filterValueSetAnswersRecursive(
+      input,
+      {},
+      {},
+      mockContainedResources,
+      new Set<string>()
+    );
 
     expect(result).toBeNull();
   });
@@ -153,7 +160,7 @@ describe('filterValueSetAnswersRecursive', () => {
       text: 'No answers'
     };
 
-    const result = filterValueSetAnswersRecursive(input, {}, {}, {});
+    const result = filterValueSetAnswersRecursive(input, {}, {}, {}, new Set<string>());
 
     expect(result).toEqual(input);
   });
@@ -172,9 +179,7 @@ describe('filterValueSetAnswersRecursive', () => {
       {},
       mockAnswerOptions,
       {},
-      {
-        q1: 'open-choice'
-      }
+      new Set(['q1'])
     );
 
     // Matching coding is normalised to the option's coding, non-matching coding is kept as is
@@ -198,9 +203,7 @@ describe('filterValueSetAnswersRecursive', () => {
       {},
       mockAnswerOptions,
       {},
-      {
-        q1: 'choice'
-      }
+      new Set<string>()
     );
 
     expect(result?.answer).toEqual([{ valueCoding: { system: 'sys', code: 'a', display: 'A' } }]);
@@ -219,7 +222,7 @@ describe('filterValueSetAnswersRecursive', () => {
       {},
       mockAnswerOptions,
       {},
-      { q1: 'choice' }
+      new Set<string>()
     );
     // dropped, not substituted with { system: 'sys', code: 'a' }
     expect(choiceResult?.answer).toEqual([]);
@@ -229,7 +232,7 @@ describe('filterValueSetAnswersRecursive', () => {
       {},
       mockAnswerOptions,
       {},
-      { q1: 'open-choice' }
+      new Set(['q1'])
     );
     // kept exactly as populated, still SNOMED
     expect(openChoiceResult?.answer).toEqual([
@@ -251,9 +254,7 @@ describe('filterValueSetAnswersRecursive', () => {
       {},
       displayOnlyOptions,
       {},
-      {
-        q1: 'choice'
-      }
+      new Set<string>()
     );
 
     // stays B; a code-only comparison would find option A first
@@ -266,9 +267,13 @@ describe('filterValueSetAnswersRecursive', () => {
       answer: [{ valueCoding: { system: 'sys', code: 'z', display: 'Z' } }]
     };
 
-    const result = filterValueSetAnswersRecursive(input, {}, {}, mockContainedResources, {
-      q3: 'open-choice'
-    });
+    const result = filterValueSetAnswersRecursive(
+      input,
+      {},
+      {},
+      mockContainedResources,
+      new Set(['q3'])
+    );
 
     expect(result?.answer).toEqual([{ valueCoding: { system: 'sys', code: 'z', display: 'Z' } }]);
   });
@@ -284,9 +289,7 @@ describe('filterValueSetAnswersRecursive', () => {
       mockResolvedValueSetPromises,
       {},
       {},
-      {
-        q2: 'open-choice'
-      }
+      new Set(['q2'])
     );
 
     expect(result?.answer).toEqual([{ valueCoding: { system: 'sys', code: '9' } }]);

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/answerOption.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/answerOption.ts
@@ -64,7 +64,7 @@ export function findInAnswerOptions(
       }
     }
 
-    if (option.valueInteger) {
+    if (typeof option.valueInteger === 'number') {
       if (value === option.valueInteger.toString()) {
         return {
           valueInteger: option.valueInteger

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/answerOption.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/answerOption.ts
@@ -26,7 +26,8 @@ import { getRelevantCodingProperties } from './codingProperties';
  * Find and return corresponding answerOption based on a populated or selected answer value.
  * String values match by code, display, string, or integer value.
  * Coding values (e.g. from an initialExpression FHIRPath result) match coding options by code,
- * with system agreement when both sides specify one.
+ * with system agreement when both sides specify one; codeless Codings match display-only
+ * options by display.
  *
  * @author Sean Fong
  */
@@ -92,10 +93,17 @@ const CODING_PROPERTIES = new Set([
 ]);
 
 export function valueIsCoding(value: unknown): value is Coding {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const coding = value as Coding;
   return (
-    typeof value === 'object' &&
-    value !== null &&
-    typeof (value as Coding).code === 'string' &&
+    // code is optional in a Coding, but when present it must be a string
+    (coding.code === undefined || typeof coding.code === 'string') &&
+    // require a system or code so bare {display} objects, {} or {userSelected: true}
+    // are not treated as Codings
+    (coding.system !== undefined || coding.code !== undefined) &&
     Object.keys(value).every((key) => CODING_PROPERTIES.has(key))
   );
 }

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/answerOption.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/answerOption.ts
@@ -92,9 +92,6 @@ const CODING_PROPERTIES = new Set([
 ]);
 
 export function valueIsCoding(value: unknown): value is Coding {
-  // An allowlist rather than excluding known Quantity properties: other code-bearing
-  // FHIR types (e.g. a value-less Quantity carrying only system/code/comparator) must
-  // not pass as Codings just because the excluded keys happen to be absent.
   return (
     typeof value === 'object' &&
     value !== null &&
@@ -113,9 +110,7 @@ export function codingMatchesOption(coding: Coding, optionCoding: Coding): boole
     return coding.code === optionCoding.code;
   }
 
-  // display-only codings are legal in answerOption; when neither side carries a
-  // code, fall back to display equality rather than treating undefined === undefined
-  // as a match
+  // display-only codings are legal in answerOption; match them by display
   if (!coding.code && !optionCoding.code) {
     return Boolean(coding.display) && coding.display === optionCoding.display;
   }

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/answerOption.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/answerOption.ts
@@ -15,29 +15,41 @@
  * limitations under the License.
  */
 
-import type { QuestionnaireItemAnswerOption, QuestionnaireResponseItemAnswer } from 'fhir/r4';
+import type {
+  Coding,
+  QuestionnaireItemAnswerOption,
+  QuestionnaireResponseItemAnswer
+} from 'fhir/r4';
 import { getRelevantCodingProperties } from './codingProperties';
 
 /**
- * Find and return corresponding answerOption based on selected answer in form.
- * Matches by code, display, string, or integer value.
+ * Find and return corresponding answerOption based on a populated or selected answer value.
+ * String values match by code, display, string, or integer value.
+ * Coding values (e.g. from an initialExpression FHIRPath result) match coding options by code,
+ * with system agreement when both sides specify one.
  *
  * @author Sean Fong
  */
 export function findInAnswerOptions(
   options: QuestionnaireItemAnswerOption[],
-  str: string
+  value: string | Coding
 ): QuestionnaireResponseItemAnswer | undefined {
   for (const option of options) {
     if (option.valueCoding) {
-      if (str === option.valueCoding.code) {
-        return {
-          valueCoding: getRelevantCodingProperties(option.valueCoding)
-        };
-      }
+      if (typeof value === 'string') {
+        if (value === option.valueCoding.code) {
+          return {
+            valueCoding: getRelevantCodingProperties(option.valueCoding)
+          };
+        }
 
-      // handle case where valueCoding.code is not present
-      if (str === option.valueCoding.display) {
+        // handle case where valueCoding.code is not present
+        if (value === option.valueCoding.display) {
+          return {
+            valueCoding: getRelevantCodingProperties(option.valueCoding)
+          };
+        }
+      } else if (valueIsCoding(value) && codingMatchesOption(value, option.valueCoding)) {
         return {
           valueCoding: getRelevantCodingProperties(option.valueCoding)
         };
@@ -45,7 +57,7 @@ export function findInAnswerOptions(
     }
 
     if (option.valueString) {
-      if (str === option.valueString) {
+      if (value === option.valueString) {
         return {
           valueString: option.valueString
         };
@@ -53,7 +65,7 @@ export function findInAnswerOptions(
     }
 
     if (option.valueInteger) {
-      if (str === option.valueInteger.toString()) {
+      if (value === option.valueInteger.toString()) {
         return {
           valueInteger: option.valueInteger
         };
@@ -62,4 +74,31 @@ export function findInAnswerOptions(
   }
 
   return;
+}
+
+/**
+ * Check that a non-string answer value is a Coding, and not another complex type
+ * carrying a "code" property such as a Quantity.
+ */
+function valueIsCoding(value: Coding): value is Coding {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof value.code === 'string' &&
+    !('value' in value) &&
+    !('unit' in value)
+  );
+}
+
+function codingMatchesOption(coding: Coding, optionCoding: Coding): boolean {
+  if (!coding.code || !optionCoding.code || coding.code !== optionCoding.code) {
+    return false;
+  }
+
+  // when both codings specify a system, they must agree
+  if (coding.system && optionCoding.system && coding.system !== optionCoding.system) {
+    return false;
+  }
+
+  return true;
 }

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/answerOption.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/answerOption.ts
@@ -90,15 +90,22 @@ function valueIsCoding(value: Coding): value is Coding {
   );
 }
 
-function codingMatchesOption(coding: Coding, optionCoding: Coding): boolean {
-  if (!coding.code || !optionCoding.code || coding.code !== optionCoding.code) {
-    return false;
-  }
-
+export function codingMatchesOption(coding: Coding, optionCoding: Coding): boolean {
   // when both codings specify a system, they must agree
   if (coding.system && optionCoding.system && coding.system !== optionCoding.system) {
     return false;
   }
 
-  return true;
+  if (coding.code && optionCoding.code) {
+    return coding.code === optionCoding.code;
+  }
+
+  // display-only codings are legal in answerOption; when neither side carries a
+  // code, fall back to display equality rather than treating undefined === undefined
+  // as a match
+  if (!coding.code && !optionCoding.code) {
+    return Boolean(coding.display) && coding.display === optionCoding.display;
+  }
+
+  return false;
 }

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/answerOption.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/answerOption.ts
@@ -80,13 +80,26 @@ export function findInAnswerOptions(
  * Check that a non-string answer value is a Coding, and not another complex type
  * carrying a "code" property such as a Quantity.
  */
-function valueIsCoding(value: Coding): value is Coding {
+// Element properties (id, extension) plus everything a Coding can carry
+const CODING_PROPERTIES = new Set([
+  'id',
+  'extension',
+  'system',
+  'version',
+  'code',
+  'display',
+  'userSelected'
+]);
+
+export function valueIsCoding(value: unknown): value is Coding {
+  // An allowlist rather than excluding known Quantity properties: other code-bearing
+  // FHIR types (e.g. a value-less Quantity carrying only system/code/comparator) must
+  // not pass as Codings just because the excluded keys happen to be absent.
   return (
     typeof value === 'object' &&
     value !== null &&
-    typeof value.code === 'string' &&
-    !('value' in value) &&
-    !('unit' in value)
+    typeof (value as Coding).code === 'string' &&
+    Object.keys(value).every((key) => CODING_PROPERTIES.has(key))
   );
 }
 

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/constructResponse.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/constructResponse.ts
@@ -100,7 +100,7 @@ export async function constructResponse(
 
   // Filled during the population walk below, alongside answerOptions and
   // containedValueSets, so open-choice items can be identified when filtering
-  // valueSet answers — the filter only ever consults items that walk visited
+  // valueSet answers
   const openChoiceLinkIds = new Set<string>();
 
   // Populate questionnaire response as a two-step process

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/constructResponse.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/constructResponse.ts
@@ -98,9 +98,10 @@ export async function constructResponse(
 
   const containedResources = questionnaire.contained ?? [];
 
-  // Record item types so open-choice items can be identified when filtering valueSet answers
-  const itemTypes: Record<string, QuestionnaireItem['type']> = {};
-  recordItemTypesRecursive(questionnaire.item, itemTypes);
+  // Filled during the population walk below, alongside answerOptions and
+  // containedValueSets, so open-choice items can be identified when filtering
+  // valueSet answers — the filter only ever consults items that walk visited
+  const openChoiceLinkIds = new Set<string>();
 
   // Populate questionnaire response as a two-step process
   // In first step, populate answers from initialExpressions and get answerValueSet promises wherever population of valueSet answers are required
@@ -119,6 +120,7 @@ export async function constructResponse(
       valueSetPromises,
       answerOptions,
       containedValueSets,
+      openChoiceLinkIds,
       fetchTerminologyCallback,
       fetchTerminologyRequestConfig,
       fetchResourceRequestConfig
@@ -151,7 +153,7 @@ export async function constructResponse(
         valueSetPromises,
         answerOptions,
         containedValueSets,
-        itemTypes
+        openChoiceLinkIds
       )
     )
     .filter((item): item is QuestionnaireResponseItem => item !== null);
@@ -203,6 +205,7 @@ interface ConstructResponseItemRecursiveParams {
   valueSetPromises: Record<string, ValueSetPromise>;
   answerOptions: Record<string, QuestionnaireItemAnswerOption[]>;
   containedValueSets: Record<string, ValueSet>;
+  openChoiceLinkIds: Set<string>;
   fetchTerminologyCallback?: FetchTerminologyCallback;
   fetchTerminologyRequestConfig?: FetchTerminologyRequestConfig;
   fetchResourceRequestConfig?: FetchResourceRequestConfig;
@@ -225,6 +228,7 @@ async function constructResponseItemRecursive(
     valueSetPromises,
     answerOptions,
     containedValueSets,
+    openChoiceLinkIds,
     fetchTerminologyCallback,
     fetchTerminologyRequestConfig,
     fetchResourceRequestConfig
@@ -247,6 +251,7 @@ async function constructResponseItemRecursive(
         valueSetPromises,
         answerOptions,
         containedValueSets,
+        openChoiceLinkIds,
         fetchTerminologyCallback,
         fetchTerminologyRequestConfig,
         fetchResourceRequestConfig
@@ -264,6 +269,7 @@ async function constructResponseItemRecursive(
         valueSetPromises,
         answerOptions,
         containedValueSets,
+        openChoiceLinkIds,
         fetchTerminologyCallback: fetchTerminologyCallback,
         fetchTerminologyRequestConfig: fetchTerminologyRequestConfig,
         fetchResourceRequestConfig: fetchResourceRequestConfig
@@ -286,6 +292,7 @@ async function constructResponseItemRecursive(
       valueSetPromises,
       answerOptions,
       containedValueSets,
+      openChoiceLinkIds,
       fetchTerminologyCallback: fetchTerminologyCallback,
       fetchTerminologyRequestConfig: fetchTerminologyRequestConfig
     });
@@ -298,6 +305,7 @@ async function constructResponseItemRecursive(
     valueSetPromises,
     answerOptions,
     containedValueSets,
+    openChoiceLinkIds,
     fetchTerminologyCallback: fetchTerminologyCallback,
     fetchTerminologyRequestConfig: fetchTerminologyRequestConfig
   });
@@ -311,6 +319,7 @@ interface ConstructGroupItemParams {
   valueSetPromises: Record<string, ValueSetPromise>;
   answerOptions: Record<string, QuestionnaireItemAnswerOption[]>;
   containedValueSets: Record<string, ValueSet>;
+  openChoiceLinkIds: Set<string>;
   fetchTerminologyCallback?: FetchTerminologyCallback | undefined;
   fetchTerminologyRequestConfig?: FetchTerminologyRequestConfig;
 }
@@ -324,6 +333,7 @@ function constructGroupItem(params: ConstructGroupItemParams): QuestionnaireResp
     valueSetPromises,
     answerOptions,
     containedValueSets,
+    openChoiceLinkIds,
     fetchTerminologyCallback,
     fetchTerminologyRequestConfig
   } = params;
@@ -362,6 +372,7 @@ function constructGroupItem(params: ConstructGroupItemParams): QuestionnaireResp
 
         recordAnswerOption(qItem, answerOptions);
         recordContainedValueSet(qItem, qContainedResources, containedValueSets);
+        recordOpenChoiceItem(qItem, openChoiceLinkIds);
       }
     }
   }
@@ -393,6 +404,7 @@ interface ConstructSingleItemParams {
   valueSetPromises: Record<string, ValueSetPromise>;
   answerOptions: Record<string, QuestionnaireItemAnswerOption[]>;
   containedValueSets: Record<string, ValueSet>;
+  openChoiceLinkIds: Set<string>;
   fetchTerminologyCallback?: FetchTerminologyCallback | undefined;
   fetchTerminologyRequestConfig?: FetchTerminologyRequestConfig;
 }
@@ -405,6 +417,7 @@ function constructSingleItem(params: ConstructSingleItemParams): QuestionnaireRe
     valueSetPromises,
     answerOptions,
     containedValueSets,
+    openChoiceLinkIds,
     fetchTerminologyCallback,
     fetchTerminologyRequestConfig
   } = params;
@@ -430,6 +443,7 @@ function constructSingleItem(params: ConstructSingleItemParams): QuestionnaireRe
 
       recordAnswerOption(qItem, answerOptions);
       recordContainedValueSet(qItem, qContainedResources, containedValueSets);
+      recordOpenChoiceItem(qItem, openChoiceLinkIds);
 
       return {
         linkId: qItem.linkId,
@@ -479,15 +493,9 @@ function recordAnswerOption(
   }
 }
 
-function recordItemTypesRecursive(
-  qItems: QuestionnaireItem[],
-  itemTypes: Record<string, QuestionnaireItem['type']>
-) {
-  for (const qItem of qItems) {
-    itemTypes[qItem.linkId] = qItem.type;
-    if (qItem.item) {
-      recordItemTypesRecursive(qItem.item, itemTypes);
-    }
+function recordOpenChoiceItem(qItem: QuestionnaireItem, openChoiceLinkIds: Set<string>) {
+  if (qItem.type === 'open-choice') {
+    openChoiceLinkIds.add(qItem.linkId);
   }
 }
 
@@ -585,6 +593,7 @@ async function constructRepeatGroupInstances(
   valueSetPromises: Record<string, ValueSetPromise>,
   answerOptions: Record<string, QuestionnaireItemAnswerOption[]>,
   containedValueSets: Record<string, ValueSet>,
+  openChoiceLinkIds: Set<string>,
   fetchTerminologyCallback?: FetchTerminologyCallback,
   fetchTerminologyRequestConfig?: FetchTerminologyRequestConfig,
   fetchResourceRequestConfig?: FetchResourceRequestConfig
@@ -688,6 +697,7 @@ async function constructRepeatGroupInstances(
 
             recordAnswerOption(childItem, answerOptions);
             recordContainedValueSet(childItem, qContainedResources, containedValueSets);
+            recordOpenChoiceItem(childItem, openChoiceLinkIds);
 
             qrRepeatGroupInstance.item?.push({
               linkId: childItem.linkId,
@@ -724,6 +734,7 @@ async function constructRepeatGroupInstances(
           valueSetPromises,
           answerOptions,
           containedValueSets,
+          openChoiceLinkIds,
           fetchTerminologyCallback,
           fetchTerminologyRequestConfig,
           fetchResourceRequestConfig

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/constructResponse.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/constructResponse.ts
@@ -98,6 +98,10 @@ export async function constructResponse(
 
   const containedResources = questionnaire.contained ?? [];
 
+  // Record item types so open-choice items can be identified when filtering valueSet answers
+  const itemTypes: Record<string, QuestionnaireItem['type']> = {};
+  recordItemTypesRecursive(questionnaire.item, itemTypes);
+
   // Populate questionnaire response as a two-step process
   // In first step, populate answers from initialExpressions and get answerValueSet promises wherever population of valueSet answers are required
   // In second step, resolves all promises in parallel and populate valueSet answers by comparing their codes
@@ -142,7 +146,13 @@ export async function constructResponse(
   valueSetPromises = await resolveValueSetPromises(valueSetPromises);
   const updatedTopLevelQRItems: QuestionnaireResponseItem[] = topLevelQRItems
     .map((qrItem) =>
-      filterValueSetAnswersRecursive(qrItem, valueSetPromises, answerOptions, containedValueSets)
+      filterValueSetAnswersRecursive(
+        qrItem,
+        valueSetPromises,
+        answerOptions,
+        containedValueSets,
+        itemTypes
+      )
     )
     .filter((item): item is QuestionnaireResponseItem => item !== null);
 
@@ -466,6 +476,18 @@ function recordAnswerOption(
 ) {
   if (qItem.answerOption) {
     answerOptions[qItem.linkId] = qItem.answerOption;
+  }
+}
+
+function recordItemTypesRecursive(
+  qItems: QuestionnaireItem[],
+  itemTypes: Record<string, QuestionnaireItem['type']>
+) {
+  for (const qItem of qItems) {
+    itemTypes[qItem.linkId] = qItem.type;
+    if (qItem.item) {
+      recordItemTypesRecursive(qItem.item, itemTypes);
+    }
   }
 }
 

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/parse.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/parse.ts
@@ -20,7 +20,7 @@ import type {
   QuestionnaireItemInitial,
   QuestionnaireResponseItemAnswer
 } from 'fhir/r4';
-import { findInAnswerOptions } from './answerOption';
+import { findInAnswerOptions, valueIsCoding } from './answerOption';
 import { checkIsDateTime, checkIsTime, convertDateTimeToDate } from './constructResponse';
 import { getRelevantCodingProperties } from './codingProperties';
 
@@ -117,9 +117,9 @@ export function parseValueToAnswer(
     return { valueQuantity: value };
   }
 
-  // A Coding may legally omit its system; require a code and exclude Quantity-shaped
-  // objects, which also carry a `code` property
-  if (typeof value === 'object' && value.code && !('value' in value) && !('unit' in value)) {
+  // A Coding may legally omit its system; valueIsCoding requires a code and rejects
+  // any object carrying non-Coding properties (e.g. a value-less Quantity)
+  if (valueIsCoding(value)) {
     return {
       valueCoding: getRelevantCodingProperties(value)
     };

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/parse.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/parse.ts
@@ -117,17 +117,15 @@ export function parseValueToAnswer(
     return { valueQuantity: value };
   }
 
-  // A Coding may legally omit its system; valueIsCoding requires a code and rejects
-  // any object carrying non-Coding properties (e.g. a value-less Quantity)
+  // A Coding may legally omit its system
   if (valueIsCoding(value)) {
     return {
       valueCoding: getRelevantCodingProperties(value)
     };
   }
 
-  // No branch below can represent an object. Fall back to its display text rather than
-  // emitting an object inside valueString, which is structurally invalid in a
-  // QuestionnaireResponse and survives removeEmptyAnswersFromResponse.
+  // No branch below can represent an object; fall back to its display text so an
+  // object never ends up inside valueString
   if (typeof value === 'object') {
     return {
       valueString: typeof value.display === 'string' ? value.display : JSON.stringify(value)

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/parse.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/parse.ts
@@ -117,9 +117,20 @@ export function parseValueToAnswer(
     return { valueQuantity: value };
   }
 
-  if (typeof value === 'object' && value.system && value.code) {
+  // A Coding may legally omit its system; require a code and exclude Quantity-shaped
+  // objects, which also carry a `code` property
+  if (typeof value === 'object' && value.code && !('value' in value) && !('unit' in value)) {
     return {
       valueCoding: getRelevantCodingProperties(value)
+    };
+  }
+
+  // No branch below can represent an object. Fall back to its display text rather than
+  // emitting an object inside valueString, which is structurally invalid in a
+  // QuestionnaireResponse and survives removeEmptyAnswersFromResponse.
+  if (typeof value === 'object') {
+    return {
+      valueString: typeof value.display === 'string' ? value.display : JSON.stringify(value)
     };
   }
 

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/parse.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/parse.ts
@@ -117,7 +117,7 @@ export function parseValueToAnswer(
     return { valueQuantity: value };
   }
 
-  // A Coding may legally omit its system
+  // A Coding may legally omit its system or code
   if (valueIsCoding(value)) {
     return {
       valueCoding: getRelevantCodingProperties(value)

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/processValueSets.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/processValueSets.ts
@@ -25,6 +25,7 @@ import type {
 } from 'fhir/r4';
 import type { ValueSetPromise } from '../interfaces/expressions.interface';
 import { getRelevantCodingProperties } from './codingProperties';
+import { codingMatchesOption } from './answerOption';
 
 export async function resolveValueSetPromises(
   valueSetPromises: Record<string, ValueSetPromise>
@@ -208,7 +209,12 @@ function codingIsInOptions(answerCoding: Coding, options: (Coding | undefined)[]
     return null;
   }
 
-  const foundCoding = options.find((option) => option?.code === answerCoding.code);
+  // Must mirror the step-1 matching in findInAnswerOptions: bare-code comparison here
+  // would silently rewrite a same-code coding from a different system to the option's
+  // coding, undoing the system-agreement rule applied during initial population.
+  const foundCoding = options.find(
+    (option) => option !== undefined && codingMatchesOption(answerCoding, option)
+  );
   if (foundCoding) {
     return getRelevantCodingProperties(foundCoding);
   }

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/processValueSets.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/processValueSets.ts
@@ -208,9 +208,8 @@ function codingIsInOptions(answerCoding: Coding, options: (Coding | undefined)[]
     return null;
   }
 
-  // Must mirror the step-1 matching in findInAnswerOptions: bare-code comparison here
-  // would silently rewrite a same-code coding from a different system to the option's
-  // coding, undoing the system-agreement rule applied during initial population.
+  // Must stay in step with findInAnswerOptions: both run on the same answers, and any
+  // disagreement between the two matchers silently rewrites or drops an answer
   const foundCoding = options.find(
     (option) => option !== undefined && codingMatchesOption(answerCoding, option)
   );

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/processValueSets.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/processValueSets.ts
@@ -17,6 +17,7 @@
 
 import type {
   Coding,
+  QuestionnaireItem,
   QuestionnaireItemAnswerOption,
   QuestionnaireResponseItem,
   QuestionnaireResponseItemAnswer,
@@ -68,13 +69,17 @@ function responseIsValueSet(response: any): response is ValueSet {
 /**
  * Read a questionnaire response item recursively and retrieve valueSet answers if present
  *
+ * @param itemTypes - Questionnaire item types keyed by linkId, used to identify open-choice items
+ * whose answers are allowed to fall outside the provided options
+ *
  * @author Sean Fong
  */
 export function filterValueSetAnswersRecursive(
   qrItem: QuestionnaireResponseItem,
   valueSetPromises: Record<string, ValueSetPromise>,
   answerOptions: Record<string, QuestionnaireItemAnswerOption[]>,
-  containedResources: Record<string, ValueSet>
+  containedResources: Record<string, ValueSet>,
+  itemTypes: Record<string, QuestionnaireItem['type']> = {}
 ): QuestionnaireResponseItem | null {
   const items = qrItem.item;
 
@@ -82,7 +87,13 @@ export function filterValueSetAnswersRecursive(
     // iterate through items of item recursively
     const qrItems: QuestionnaireResponseItem[] = items
       .map((item) =>
-        filterValueSetAnswersRecursive(item, valueSetPromises, answerOptions, containedResources)
+        filterValueSetAnswersRecursive(
+          item,
+          valueSetPromises,
+          answerOptions,
+          containedResources,
+          itemTypes
+        )
       )
       .filter((item): item is QuestionnaireResponseItem => item !== null);
 
@@ -90,27 +101,33 @@ export function filterValueSetAnswersRecursive(
   }
 
   const linkId = qrItem.linkId;
+  const isOpenChoice = itemTypes[linkId] === 'open-choice';
 
   const valueSetOptionCodings = valueSetPromises[linkId]?.valueSet?.expansion?.contains;
   if (qrItem.answer && valueSetOptionCodings) {
-    return { ...qrItem, answer: filterAndNormaliseAnswers(qrItem.answer, valueSetOptionCodings) };
+    return {
+      ...qrItem,
+      answer: filterAndNormaliseAnswers(qrItem.answer, valueSetOptionCodings, isOpenChoice)
+    };
   }
 
   const answerOptionCodings = answerOptions[linkId]?.map((option) => option.valueCoding);
   if (qrItem.answer && answerOptionCodings) {
-    return { ...qrItem, answer: filterAndNormaliseAnswers(qrItem.answer, answerOptionCodings) };
+    return {
+      ...qrItem,
+      answer: filterAndNormaliseAnswers(qrItem.answer, answerOptionCodings, isOpenChoice)
+    };
   }
 
   const containedValueSetOptionCodings = containedResources[linkId]?.expansion?.contains;
   if (qrItem.answer && containedValueSetOptionCodings) {
-    const cleanedAnswers = filterAndNormaliseAnswers(qrItem.answer, containedValueSetOptionCodings);
+    const cleanedAnswers = filterAndNormaliseAnswers(
+      qrItem.answer,
+      containedValueSetOptionCodings,
+      isOpenChoice
+    );
 
-    return cleanedAnswers.length > 0
-      ? {
-          ...qrItem,
-          answer: filterAndNormaliseAnswers(qrItem.answer, containedValueSetOptionCodings)
-        }
-      : null;
+    return cleanedAnswers.length > 0 ? { ...qrItem, answer: cleanedAnswers } : null;
   }
 
   // If item does not have any valueSet nor answerOption
@@ -119,14 +136,16 @@ export function filterValueSetAnswersRecursive(
 
 /**
  * Normalises a list of QuestionnaireResponse answers by:
- * - Filtering out valueCoding answers that are not present in the provided options
+ * - Filtering out valueCoding answers that are not present in the provided options,
+ *   unless the item is open-choice, where answers outside the options are allowed
  * - Converting valueString answers to valueCoding when matching codes are found in options
  * - Preserving all other answers, including valueString answers that do not match any coding,
  *   to support open-choice questions where arbitrary strings are allowed
  */
 function filterAndNormaliseAnswers(
   answers: QuestionnaireResponseItemAnswer[],
-  options: (Coding | undefined)[]
+  options: (Coding | undefined)[],
+  isOpenChoice: boolean
 ) {
   const newAnswers: QuestionnaireResponseItemAnswer[] = [];
 
@@ -139,6 +158,9 @@ function filterAndNormaliseAnswers(
           valueCoding: valueCoding
         };
         newAnswers.push(newAnswer);
+      } else if (isOpenChoice) {
+        // Open-choice items accept answers outside the provided options, keep the answer as is
+        newAnswers.push(answer);
       }
 
       // Add continue here to skip to the next iteration if answer coding is not in options

--- a/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/processValueSets.ts
+++ b/packages/sdc-populate/src/SDCPopulateQuestionnaireOperation/utils/processValueSets.ts
@@ -17,7 +17,6 @@
 
 import type {
   Coding,
-  QuestionnaireItem,
   QuestionnaireItemAnswerOption,
   QuestionnaireResponseItem,
   QuestionnaireResponseItemAnswer,
@@ -70,8 +69,8 @@ function responseIsValueSet(response: any): response is ValueSet {
 /**
  * Read a questionnaire response item recursively and retrieve valueSet answers if present
  *
- * @param itemTypes - Questionnaire item types keyed by linkId, used to identify open-choice items
- * whose answers are allowed to fall outside the provided options
+ * @param openChoiceLinkIds - linkIds of open-choice items, whose answers are allowed to
+ * fall outside the provided options
  *
  * @author Sean Fong
  */
@@ -80,7 +79,7 @@ export function filterValueSetAnswersRecursive(
   valueSetPromises: Record<string, ValueSetPromise>,
   answerOptions: Record<string, QuestionnaireItemAnswerOption[]>,
   containedResources: Record<string, ValueSet>,
-  itemTypes: Record<string, QuestionnaireItem['type']> = {}
+  openChoiceLinkIds: Set<string>
 ): QuestionnaireResponseItem | null {
   const items = qrItem.item;
 
@@ -93,7 +92,7 @@ export function filterValueSetAnswersRecursive(
           valueSetPromises,
           answerOptions,
           containedResources,
-          itemTypes
+          openChoiceLinkIds
         )
       )
       .filter((item): item is QuestionnaireResponseItem => item !== null);
@@ -102,7 +101,7 @@ export function filterValueSetAnswersRecursive(
   }
 
   const linkId = qrItem.linkId;
-  const isOpenChoice = itemTypes[linkId] === 'open-choice';
+  const isOpenChoice = openChoiceLinkIds.has(linkId);
 
   const valueSetOptionCodings = valueSetPromises[linkId]?.valueSet?.expansion?.contains;
   if (qrItem.answer && valueSetOptionCodings) {


### PR DESCRIPTION
## Summary

Fixes #2095.

`$populate` was silently dropping or rewriting pre-populated coding answers. The pattern behind every defect here is the same: population matches codings in two places (`findInAnswerOptions` during initial population, the valueSet answers filter in `processValueSets.ts`) with different rules, and each disagreement between the two produces a silently wrong answer.

One commit per defect, details in the commit messages; the reproduction is in #2095:

- open-choice answers outside answerOption/valueSet options were filtered out
- Coding values from FHIRPath results never matched answerOptions (string-only comparison)
- the valueSet answers filter matched by bare code: a same-code coding from a different system was rewritten to the option's coding, and display-only options matched by `undefined === undefined`; both steps now share one matcher
- a systemless Coding fell through to `valueString` with the object as its payload, a structurally invalid answer
- answerOption `{valueInteger: 0}` never matched (falsy guard)
- a value-less Quantity could pass as a Coding; `valueIsCoding` is now a property allowlist
- cleanup: open-choice items are recorded during the existing population walk instead of a second traversal, and the filter's new parameter is required instead of defaulting to empty

## A related renderer gap

The `valueCoding` outliers this PR preserves are visible in the select/autocomplete open-choice variants but not in the radio/checkbox variants: `OpenChoiceRadioAnswerOptionItem` and `useOpenLabel` surface out-of-option answers only via `valueString`, so a preserved coding renders as an unanswered item while the response still carries it. The gap predates this PR, but this change makes it reachable through `$populate` alone. I can file it as a separate issue if you agree it is renderer scope rather than population scope.

## Backwards Compatibility

- `choice` items keep the current filtering behaviour; only `open-choice` items keep out-of-option codings
- `findInAnswerOptions()` still accepts plain strings with unchanged matching; Coding support is additive
- System agreement applies only when both codings specify a system, so systemless data keeps matching as before
- The one intentional break is compile-time only: `filterValueSetAnswersRecursive()` gained a required parameter. All in-repo callers are updated; external callers get a type error, not a behaviour change

## Test Plan

- [x] Full `sdc-populate` suite passes, `tsc --noEmit` and prettier clean
- [x] Every new regression test was run against the unfixed code and observed to fail
- [x] End-to-end `populate()` test: an open-choice and a choice item prefilled from the same out-of-options Condition coding; the open-choice answer survives, the choice answer is filtered