### PR TITLE
fix(renderer): add a clear button to slider items (#2094)

### DIFF
--- a/packages/smart-forms-renderer/src/components/FormComponents/SliderItem/SliderField.tsx
+++ b/packages/smart-forms-renderer/src/components/FormComponents/SliderItem/SliderField.tsx
@@ -18,12 +18,14 @@
 import React from 'react';
 import type { PropsWithIsTabledAttribute } from '../../../interfaces/renderProps.interface';
 import { getSliderMarks } from '../../../utils/slider';
+import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import SliderLabels from './SliderLabels';
 import SliderDisplayValue from './SliderDisplayValue';
 import { useRendererConfigStore } from '../../../stores';
 import { StyledRequiredTypography } from '../Item.styles';
 import { StandardSlider } from './Slider.styles';
+import ClearInputButton from '../ItemParts/ClearInputButton';
 
 interface SliderFieldProps extends PropsWithIsTabledAttribute {
   linkId: string;
@@ -40,6 +42,7 @@ interface SliderFieldProps extends PropsWithIsTabledAttribute {
   readOnly: boolean;
   instructionsId?: string;
   onValueChange: (newValue: number) => void;
+  onClear: () => void;
 }
 
 function SliderField(props: SliderFieldProps) {
@@ -58,7 +61,8 @@ function SliderField(props: SliderFieldProps) {
     readOnly,
     instructionsId,
     isTabled,
-    onValueChange
+    onValueChange,
+    onClear
   } = props;
 
   const readOnlyVisualStyle = useRendererConfigStore.use.readOnlyVisualStyle();
@@ -76,39 +80,47 @@ function SliderField(props: SliderFieldProps) {
 
   return (
     <>
-      <Stack sx={{ ...sliderSx }}>
-        <SliderDisplayValue value={value} hasLabels={hasLabels} isInteracted={isInteracted} />
-        {hasLabels ? <SliderLabels minLabel={minLabel} maxLabel={maxLabel} /> : null}
-        <StandardSlider
-          id={itemType + '-' + linkId}
-          value={value}
-          min={minValue}
-          max={maxValue}
-          step={stepValue}
-          marks={sliderMarks}
-          sx={{ ...sliderSx }}
-          onChange={(_, newValue) => {
-            // If item.readOnly=true, do not allow any changes
-            if (readOnly) {
-              return;
-            }
+      <Box
+        display="flex"
+        alignItems={{ xs: 'start', sm: 'center' }}
+        flexDirection={{ xs: 'column', sm: 'row' }}
+        columnGap={1}>
+        <Stack sx={{ ...sliderSx }}>
+          <SliderDisplayValue value={value} hasLabels={hasLabels} isInteracted={isInteracted} />
+          {hasLabels ? <SliderLabels minLabel={minLabel} maxLabel={maxLabel} /> : null}
+          <StandardSlider
+            id={itemType + '-' + linkId}
+            value={value}
+            min={minValue}
+            max={maxValue}
+            step={stepValue}
+            marks={sliderMarks}
+            sx={{ ...sliderSx }}
+            onChange={(_, newValue) => {
+              // If item.readOnly=true, do not allow any changes
+              if (readOnly) {
+                return;
+              }
 
-            if (typeof newValue === 'number') {
-              onValueChange(newValue);
-            }
-          }}
-          disabled={readOnly && readOnlyVisualStyle === 'disabled'}
-          readOnly={readOnly && readOnlyVisualStyle === 'readonly'}
-          aria-readonly={readOnly && readOnlyVisualStyle === 'readonly'}
-          {...(!isTabled && { 'aria-labelledby': `label-${linkId}` })}
-          {...(isTabled && { 'aria-label': itemText ?? rendererStrings.unnamedSlider })}
-          {...(instructionsId
-            ? { slotProps: { input: { 'aria-describedby': instructionsId } } }
-            : {})}
-          valueLabelDisplay="auto"
-          data-test="q-item-slider-field"
-        />
-      </Stack>
+              if (typeof newValue === 'number') {
+                onValueChange(newValue);
+              }
+            }}
+            disabled={readOnly && readOnlyVisualStyle === 'disabled'}
+            readOnly={readOnly && readOnlyVisualStyle === 'readonly'}
+            aria-readonly={readOnly && readOnlyVisualStyle === 'readonly'}
+            {...(!isTabled && { 'aria-labelledby': `label-${linkId}` })}
+            {...(isTabled && { 'aria-label': itemText ?? rendererStrings.unnamedSlider })}
+            {...(instructionsId
+              ? { slotProps: { input: { 'aria-describedby': instructionsId } } }
+              : {})}
+            valueLabelDisplay="auto"
+            data-test="q-item-slider-field"
+          />
+        </Stack>
+
+        <ClearInputButton buttonShown={isInteracted} readOnly={readOnly} onClear={onClear} />
+      </Box>
 
       {feedback ? <StyledRequiredTypography>{feedback}</StyledRequiredTypography> : null}
     </>

--- a/packages/smart-forms-renderer/src/components/FormComponents/SliderItem/SliderItem.tsx
+++ b/packages/smart-forms-renderer/src/components/FormComponents/SliderItem/SliderItem.tsx
@@ -73,6 +73,12 @@ function SliderItem(props: BaseItemProps) {
     });
   }
 
+  // Clearing removes the answer entirely rather than writing a value, because an unanswered
+  // slider is distinct from one deliberately set to 0
+  function handleClear() {
+    onQrItemChange(createEmptyQrItem(qItem, answerKey));
+  }
+
   if (isRepeated) {
     return (
       <Box px={1} width="100%">
@@ -92,6 +98,7 @@ function SliderItem(props: BaseItemProps) {
           isTabled={isTabled}
           instructionsId={instructionsId}
           onValueChange={handleValueChange}
+          onClear={handleClear}
         />
       </Box>
     );
@@ -126,6 +133,7 @@ function SliderItem(props: BaseItemProps) {
               isTabled={isTabled}
               instructionsId={instructionsId}
               onValueChange={handleValueChange}
+              onClear={handleClear}
             />
           </Box>
         }

--- a/packages/smart-forms-renderer/src/test/clearSliderField.test.tsx
+++ b/packages/smart-forms-renderer/src/test/clearSliderField.test.tsx
@@ -1,0 +1,249 @@
+/// <reference types="jest" />
+/// <reference types="@testing-library/jest-dom" />
+
+/*
+ * Copyright 2025 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, test } from '@jest/globals';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { Questionnaire, QuestionnaireItem, QuestionnaireResponse } from 'fhir/r4';
+import React from 'react';
+
+// react-markdown, react-dnd and react-dnd-html5-backend are ESM-only and cannot be transformed by ts-jest
+jest.mock('react-markdown', () => ({
+  __esModule: true,
+  default: (props: { children?: React.ReactNode }) => <>{props.children}</>
+}));
+jest.mock('react-dnd', () => ({
+  __esModule: true,
+  useDrop: () => [{ isOver: false, canDrop: false }, jest.fn()]
+}));
+jest.mock('react-dnd-html5-backend', () => ({
+  __esModule: true,
+  NativeTypes: { FILE: '__NATIVE_FILE__' }
+}));
+
+import SmartFormsRenderer from '../components/Renderer/SmartFormsRenderer';
+import { questionnaireResponseStore } from '../stores';
+
+// jsdom does not implement ResizeObserver, required by GroupTable's useResizeColumns
+global.ResizeObserver =
+  global.ResizeObserver ||
+  class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+
+// jsdom does not implement matchMedia, required by MUI useMediaQuery
+window.matchMedia =
+  window.matchMedia ||
+  ((query: string) =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn()
+    }) as unknown as MediaQueryList);
+
+const sliderItemControlExtension = {
+  url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl',
+  valueCodeableConcept: {
+    coding: [
+      {
+        system: 'http://hl7.org/fhir/questionnaire-item-control',
+        code: 'slider'
+      }
+    ]
+  }
+};
+
+function sliderStepExtension(step: number) {
+  return {
+    url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-sliderStepValue',
+    valueInteger: step
+  };
+}
+
+function minValueExtension(min: number) {
+  return {
+    url: 'http://hl7.org/fhir/StructureDefinition/minValue',
+    valueInteger: min
+  };
+}
+
+function maxValueExtension(max: number) {
+  return {
+    url: 'http://hl7.org/fhir/StructureDefinition/maxValue',
+    valueInteger: max
+  };
+}
+
+/**
+ * Mirrors the "Pupil Size (mm)" item from issue #2094 - an integer item rendered as a slider with
+ * an explicit min, max and step.
+ */
+function buildSliderQuestionnaire(options?: {
+  minValue?: number;
+  maxValue?: number;
+  readOnly?: boolean;
+}): Questionnaire {
+  const { minValue = 0, maxValue = 10, readOnly } = options ?? {};
+
+  const item: QuestionnaireItem = {
+    linkId: 'pupil-size',
+    text: 'Pupil Size (mm)',
+    type: 'integer',
+    extension: [
+      sliderItemControlExtension,
+      sliderStepExtension(1),
+      minValueExtension(minValue),
+      maxValueExtension(maxValue)
+    ],
+    ...(readOnly ? { readOnly: true } : {})
+  };
+
+  return {
+    resourceType: 'Questionnaire',
+    status: 'active',
+    item: [item]
+  };
+}
+
+function buildSliderResponse(valueInteger: number): QuestionnaireResponse {
+  return {
+    resourceType: 'QuestionnaireResponse',
+    status: 'in-progress',
+    item: [
+      {
+        linkId: 'pupil-size',
+        text: 'Pupil Size (mm)',
+        answer: [{ valueInteger }]
+      }
+    ]
+  };
+}
+
+function getUpdatableResponseString(): string {
+  return JSON.stringify(questionnaireResponseStore.getState().updatableResponse);
+}
+
+function getSliderInput(): HTMLInputElement {
+  const input = document.querySelector('[data-linkid="pupil-size"] input[type="range"]');
+  expect(input).not.toBeNull();
+  return input as HTMLInputElement;
+}
+
+function queryClearButton(): HTMLElement | null {
+  return screen.queryByRole('button', { name: 'Clear' });
+}
+
+describe('slider items expose a clear button (issue #2094)', () => {
+  test('no clear button is rendered while the slider is unanswered', async () => {
+    render(<SmartFormsRenderer questionnaire={buildSliderQuestionnaire()} />);
+
+    await waitFor(() => expect(getSliderInput()).toBeTruthy());
+
+    // The display value reads "-" rather than a number, so the item is visibly unanswered
+    expect(screen.getByText('-')).toBeTruthy();
+    expect(queryClearButton()).toBeNull();
+  });
+
+  test('the clear button appears once the slider is answered', async () => {
+    render(
+      <SmartFormsRenderer
+        questionnaire={buildSliderQuestionnaire()}
+        questionnaireResponse={buildSliderResponse(4)}
+      />
+    );
+
+    await waitFor(() => expect(queryClearButton()).not.toBeNull());
+    expect(getSliderInput().value).toBe('4');
+  });
+
+  test('clearing removes the answer entirely rather than setting it to 0', async () => {
+    render(
+      <SmartFormsRenderer
+        questionnaire={buildSliderQuestionnaire()}
+        questionnaireResponse={buildSliderResponse(4)}
+      />
+    );
+
+    await waitFor(() => expect(queryClearButton()).not.toBeNull());
+    expect(getUpdatableResponseString()).toContain('"valueInteger":4');
+
+    fireEvent.click(queryClearButton() as HTMLElement);
+
+    // The item is gone from the response - not left behind as an answer of 0, which per the issue
+    // is a different thing from "not set"
+    await waitFor(() => expect(getUpdatableResponseString()).not.toContain('"valueInteger":4'));
+    expect(getUpdatableResponseString()).not.toContain('"valueInteger":0');
+    expect(getUpdatableResponseString()).not.toContain('"linkId":"pupil-size"');
+    expect((questionnaireResponseStore.getState().updatableResponse.item ?? []).length).toBe(0);
+  });
+
+  test('clearing returns the item to its visibly unanswered state', async () => {
+    render(
+      <SmartFormsRenderer
+        questionnaire={buildSliderQuestionnaire()}
+        questionnaireResponse={buildSliderResponse(4)}
+      />
+    );
+
+    await waitFor(() => expect(queryClearButton()).not.toBeNull());
+
+    fireEvent.click(queryClearButton() as HTMLElement);
+
+    // Display value falls back to "-" and the button hides itself again
+    await waitFor(() => expect(screen.getByText('-')).toBeTruthy());
+    await waitFor(() => expect(queryClearButton()).toBeNull());
+  });
+
+  test('an answer of 0 still gets a clear button', async () => {
+    // 0 is a legitimate answer on a slider whose range spans zero, so it must count as answered
+    // rather than being mistaken for "no answer"
+    render(
+      <SmartFormsRenderer
+        questionnaire={buildSliderQuestionnaire({ minValue: -5, maxValue: 5 })}
+        questionnaireResponse={buildSliderResponse(0)}
+      />
+    );
+
+    await waitFor(() => expect(queryClearButton()).not.toBeNull());
+
+    expect(getSliderInput().value).toBe('0');
+    expect(screen.queryByText('-')).toBeNull();
+  });
+
+  test('no clear button is rendered when the item is readOnly', async () => {
+    render(
+      <SmartFormsRenderer
+        questionnaire={buildSliderQuestionnaire({ readOnly: true })}
+        questionnaireResponse={buildSliderResponse(4)}
+      />
+    );
+
+    await waitFor(() => expect(getSliderInput()).toBeTruthy());
+
+    expect(getSliderInput().value).toBe('4');
+    expect(queryClearButton()).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #2094

## Problem

Slider items had no way to unset an answer. Once the user moved the thumb, the answer was there for good.

The reporter's assessment form puts a slider (`Pupil Size (mm)`) next to a radio group (`Reaction`). The radio group gets a `CLEAR` button; the slider does not. Users assumed the one `CLEAR` button covered both questions and were confused when the pupil size reading stayed behind.

Every other answerable item type in the renderer offers a way to clear. The slider was the gap.

## Fix

`SliderField` now renders `ClearInputButton` beside the slider, shown only once the item holds an answer. Placement mirrors `RadioFormGroup`, so the two controls in the reporter's form now look and behave the same way.

The slider and the button sit in a flex `Box` that stacks vertically on narrow viewports, matching the responsive treatment `RadioFormGroup` already uses.

### Why `ClearInputButton` and not `ClearButtonAdornment`

The text-field item types (integer, decimal, string) use `ClearButtonAdornment`, an icon inside the input. It is the wrong fit here:

- It ignores the `hideClearButton` renderer config. `ClearInputButton` honours it.
- It is deliberately `aria-hidden` with `tabIndex={-1}`, because a text input can already be cleared by typing. A slider cannot, so the control needs to be keyboard-reachable.
- Its click handler re-focuses via `.MuiOutlinedInput-root`, which a slider does not have.

`ClearInputButton` also renders the literal `CLEAR` label the reporter was comparing against.

### Clearing removes the answer, it does not write 0

`handleClear` writes an empty QrItem, so the item leaves the `QuestionnaireResponse` entirely. The issue is explicit that `0` is a real answer on these forms and is not the same thing as unanswered.

No change was needed for the cleared visual state: `SliderDisplayValue` already falls back to `-` whenever the item has no answer, and `isInteracted` keys off answer presence rather than the value, so an answer of `0` still reads as answered.

## Changes

- `SliderField.tsx` — new `onClear` prop; renders `ClearInputButton` in a flex wrapper beside the slider. The bulk of the diff is JSX re-indentation from that wrapper.
- `SliderItem.tsx` — 8 lines: `handleClear`, passed to both the repeated and non-repeated call sites.
- `test/clearSliderField.test.tsx` — new, 6 tests built on the `Pupil Size (mm)` item from the issue, following the existing `clearChoiceField.test.tsx` pattern.

No version bump. No public API change: `SliderField` is internal, and `onClear` is a required prop on it only.

## A change I tried and backed out

I also changed the unanswered fallback from `0` to `minValue`, on the theory that a `0` thumb would sit off the left end of the track whenever `minValue > 0`, and fixed a coupled truthiness bug on `SliderItem.tsx:53` (`if (qrItem?.answer[0].valueInteger)` treats a real `0` as absent) that would otherwise have made a `0` answer render at `minValue`.

I probed the DOM before trusting it. With `minValue: 2` and no answer, the output is identical either way — thumb at `left: 0%`, `aria-valuenow=2`. MUI clamps the value into `[min, max]` itself, so the premise was wrong and the change had no observable effect. Reverted rather than carry inert diff, along with the test written to guard it, which passed with the fix stashed and was therefore testing MUI rather than this code.

Line 53's truthiness test is still sloppy and worth tidying, but MUI's clamping makes it harmless today, so it is out of scope here.

## Verification

| Check | Result |
| --- | --- |
| New tests | 6 passed |
| New tests, fix stashed | 4 failed, 2 passed |
| Renderer Jest | 2261 passed, 100 suites |
| `npm run build -w packages/smart-forms-renderer` | clean |
| `npm run lint` | 0 errors, 344 pre-existing warnings |
| Prettier | clean on all changed files |

The 2 tests that pass with the fix stashed are the negative cases — no button while unanswered, none when `readOnly`. They guard against over-rendering, so passing before the change is the correct result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
