### PR TITLE
fix(#2107): merge multi-value template-extract splits into one array element

### DIFF
--- a/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/templateExtractGivenNameReversal.test.ts
+++ b/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/templateExtractGivenNameReversal.test.ts
@@ -1,0 +1,210 @@
+import { extract } from '../utils';
+import type { OutputParameters, ReturnParameter } from '../interfaces';
+import { createInputParameters } from '../utils/createInputParameters';
+import type { Bundle, Patient, Questionnaire, QuestionnaireResponse } from 'fhir/r4';
+
+// Mock the fetchQuestionnaire callback function
+const mockFetchQuestionnaire = jest.fn();
+const mockFetchQuestionnaireConfig = {
+  sourceServerUrl: 'https://example.com/fhir',
+  headers: { Authorization: 'Bearer token' }
+};
+
+// Regression test for https://github.com/aehrc/smart-forms/issues/2107
+// Within a single templateExtractContext, a first-declared templateExtractValue evaluating to
+// an empty result (unanswered "family") must not cause a later-declared repeating
+// templateExtractValue ("given") to be split into separate, reversed-order array elements.
+const QGivenNameReversal: Questionnaire = {
+  resourceType: 'Questionnaire',
+  id: 'GivenNameReversal',
+  url: 'https://smartforms.csiro.au/docs/tests/GivenNameReversal',
+  status: 'draft',
+  subjectType: ['Patient'],
+  contained: [
+    {
+      resourceType: 'Patient',
+      id: 'patTemplate',
+      name: [
+        {
+          extension: [
+            {
+              url: 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-templateExtractContext',
+              valueString: "item.where(linkId = 'name')"
+            }
+          ],
+          _family: {
+            extension: [
+              {
+                url: 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-templateExtractValue',
+                valueString: "item.where(linkId = 'family').answer.value.first()"
+              }
+            ]
+          },
+          _given: [
+            {
+              extension: [
+                {
+                  url: 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-templateExtractValue',
+                  valueString: "item.where(linkId = 'given').answer.value"
+                }
+              ]
+            }
+          ]
+        } as any
+      ]
+    }
+  ],
+  item: [
+    {
+      extension: [
+        {
+          url: 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-templateExtract',
+          extension: [
+            {
+              url: 'template',
+              valueReference: { reference: '#patTemplate' }
+            }
+          ]
+        }
+      ],
+      linkId: 'patient',
+      text: 'Patient Information',
+      type: 'group',
+      item: [
+        {
+          linkId: 'name',
+          text: 'Name',
+          type: 'group',
+          repeats: true,
+          item: [
+            { linkId: 'given', text: 'Given Name(s)', type: 'string', repeats: true },
+            { linkId: 'family', text: 'Family/Surname', type: 'string' }
+          ]
+        }
+      ]
+    }
+  ]
+};
+
+function buildQR(givenAnswers: string[], familyAnswer?: string): QuestionnaireResponse {
+  return {
+    resourceType: 'QuestionnaireResponse',
+    status: 'completed',
+    questionnaire: 'https://smartforms.csiro.au/docs/tests/GivenNameReversal',
+    item: [
+      {
+        linkId: 'patient',
+        item: [
+          {
+            linkId: 'name',
+            item: [
+              {
+                linkId: 'given',
+                answer: givenAnswers.map((value) => ({ valueString: value }))
+              },
+              ...(familyAnswer !== undefined
+                ? [{ linkId: 'family', answer: [{ valueString: familyAnswer }] }]
+                : [])
+            ]
+          }
+        ]
+      }
+    ]
+  };
+}
+
+// Same template as above, but with the repeating value (_given) declared BEFORE the
+// single value (_family). This is the case a naive "declaration order" fix would miss:
+// the repeating value is the very first entry evaluated for the context, so the outer
+// isNewInsert flag is true regardless of whether family has an answer.
+const QGivenDeclaredFirst: Questionnaire = {
+  ...QGivenNameReversal,
+  id: 'GivenNameReversalGivenFirst',
+  contained: [
+    {
+      resourceType: 'Patient',
+      id: 'patTemplate',
+      name: [
+        {
+          extension: [
+            {
+              url: 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-templateExtractContext',
+              valueString: "item.where(linkId = 'name')"
+            }
+          ],
+          _given: [
+            {
+              extension: [
+                {
+                  url: 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-templateExtractValue',
+                  valueString: "item.where(linkId = 'given').answer.value"
+                }
+              ]
+            }
+          ],
+          _family: {
+            extension: [
+              {
+                url: 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-templateExtractValue',
+                valueString: "item.where(linkId = 'family').answer.value.first()"
+              }
+            ]
+          }
+        } as any
+      ]
+    }
+  ]
+};
+
+describe('extract GivenNameReversal (issue #2107)', () => {
+  it('merges a repeating value into a single array element in order when an earlier sibling value is empty', async () => {
+    const result = await extract(
+      createInputParameters(buildQR(['a', 'b']), QGivenNameReversal, undefined),
+      mockFetchQuestionnaire,
+      mockFetchQuestionnaireConfig
+    );
+
+    const returnParam = (result as OutputParameters).parameter.find(
+      (p): p is ReturnParameter => p.name === 'return'
+    );
+
+    const extracted = returnParam?.resource as Bundle;
+    const patient = extracted.entry?.[0]?.resource as Patient;
+
+    expect(patient.name).toEqual([{ given: ['a', 'b'] }]);
+  });
+
+  it('preserves order and merges into one element for three repeating values', async () => {
+    const result = await extract(
+      createInputParameters(buildQR(['a', 'b', 'c']), QGivenNameReversal, undefined),
+      mockFetchQuestionnaire,
+      mockFetchQuestionnaireConfig
+    );
+
+    const returnParam = (result as OutputParameters).parameter.find(
+      (p): p is ReturnParameter => p.name === 'return'
+    );
+
+    const extracted = returnParam?.resource as Bundle;
+    const patient = extracted.entry?.[0]?.resource as Patient;
+
+    expect(patient.name).toEqual([{ given: ['a', 'b', 'c'] }]);
+  });
+
+  it('still merges correctly when the repeating value is declared before the single value and both are answered', async () => {
+    const result = await extract(
+      createInputParameters(buildQR(['a', 'b'], 'Smith'), QGivenDeclaredFirst, undefined),
+      mockFetchQuestionnaire,
+      mockFetchQuestionnaireConfig
+    );
+
+    const returnParam = (result as OutputParameters).parameter.find(
+      (p): p is ReturnParameter => p.name === 'return'
+    );
+
+    const extracted = returnParam?.resource as Bundle;
+    const patient = extracted.entry?.[0]?.resource as Patient;
+
+    expect(patient.name).toEqual([{ given: ['a', 'b'], family: 'Smith' }]);
+  });
+});

--- a/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/utils/templateInsert.ts
+++ b/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/utils/templateInsert.ts
@@ -75,6 +75,9 @@ export function insertValuesToPath(
 
   // Insert each valueToInsert instance into template at the correct location, taking into account context index
   // We can have multiple values to insert eg. given names ['First', 'Middle'] which will result in two objects like [{given: ['First']}, {given: ['Middle']}] which are merged
+  // Only the first item of this split can be a genuinely new array insert - the rest always merge into the
+  // element that first item just created (or already existed), regardless of the outer isNewInsert flag.
+  let isFirstInsert = isNewInsert;
   for (let i = 0; i < valuesToInsert.length; i++) {
     const valueToInsert = valuesToInsert[i];
     const cleanedEntryPathSegments = cleanEntryPathSegments(entryPathSegments, insertIndex);
@@ -83,9 +86,10 @@ export function insertValuesToPath(
       templateToMutate,
       entryPath,
       cleanedEntryPathSegments,
-      isNewInsert,
+      isFirstInsert,
       valueToInsert
     );
+    isFirstInsert = false;
   }
 }
 


### PR DESCRIPTION
## Summary
- Fixes #2107: within a single `templateExtractContext`, when an earlier-declared `templateExtractValue` evaluates empty and a later-declared one evaluates to multiple values (e.g. a repeating question), the values were being split into separate array elements in reverse order instead of merged into one.
- Root cause: `insertValuesToPath` reused the caller's `isNewInsert` flag for every item produced by a single value's multi-value split, instead of only the first. Introduces a local `isFirstInsert` flag so only the first item of a split can create a new array element; subsequent items from that same split always merge into it, regardless of the outer flag.

## Test plan
- [x] Added `templateExtractGivenNameReversal.test.ts` reproducing the issue's exact repro (unanswered `family`, repeating `given`), plus a 3-value variant and a case with the repeating value declared *before* the single value (both answered) — the latter shows the bug isn't actually about declaration order.
- [x] Verified each new test fails against the pre-fix code with the exact symptom described (reversed order, split elements) and passes with the fix.
- [x] Full `sdc-template-extract` suite passes: 72/72, no regressions (including the `QComplexTemplateExtract` real-world fixture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)