### PR TITLE
fix(sdc-template-extract): don't drop or collapse repeating values in mergeArrayByIndex

### DIFF
--- a/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/extract.test.ts
+++ b/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/extract.test.ts
@@ -25,6 +25,7 @@ import { extractedSepsisRisk } from './resources/extracted/extractedSepsisRisk';
 import { extractedArrayElementMergeImmunization } from './resources/extracted/extractedArrayElementMerge';
 import { extractedDuplicateValueMergePatient } from './resources/extracted/extractedDuplicateValueMerge';
 import { extractedStaticDataNotDuplicatedPatient } from './resources/extracted/extractedStaticDataNotDuplicated';
+import { extractedRepeatingComplexValueMergeImmunization } from './resources/extracted/extractedRepeatingComplexValueMerge';
 
 // QuestionnaireResponses
 import { QRAllergiesAdverseReactions } from './resources/questionnaireResponses/QRAllergiesAdverseReactions';
@@ -40,6 +41,7 @@ import { QRSepsisRisk } from './resources/questionnaireResponses/QRSepsisRisk';
 import { QRArrayElementMerge } from './resources/questionnaireResponses/QRArrayElementMerge';
 import { QRDuplicateValueMerge } from './resources/questionnaireResponses/QRDuplicateValueMerge';
 import { QRStaticDataNotDuplicated } from './resources/questionnaireResponses/QRStaticDataNotDuplicated';
+import { QRRepeatingComplexValueMerge } from './resources/questionnaireResponses/QRRepeatingComplexValueMerge';
 
 // Questionnaires
 import { QAllergiesAdverseReactions } from './resources/questionnaires/QAllergiesAdverseReactions';
@@ -55,6 +57,7 @@ import { QSepsisRisk } from './resources/questionnaires/QSepsisRisk';
 import { QArrayElementMerge } from './resources/questionnaires/QArrayElementMerge';
 import { QDuplicateValueMerge } from './resources/questionnaires/QDuplicateValueMerge';
 import { QStaticDataNotDuplicated } from './resources/questionnaires/QStaticDataNotDuplicated';
+import { QRepeatingComplexValueMerge } from './resources/questionnaires/QRepeatingComplexValueMerge';
 import { parametersIsFhirPatch } from '../utils/typePredicates';
 
 // Mock the fetchQuestionnaire callback function
@@ -642,5 +645,28 @@ describe('extract StaticDataNotDuplicated', () => {
     expect(extractedPatient.name?.[0]?.prefix).toEqual(['Dr']);
     expect(extractedPatient.name?.[0]?.given).toEqual(['Alex', 'Chris']);
     expect(extractedPatient).toEqual(extractedStaticDataNotDuplicatedPatient);
+  });
+});
+
+describe('extract RepeatingComplexValueMerge', () => {
+  // A repeating templateExtractValue whose evaluated values are objects (Codings, not primitives)
+  // must append each one, not merge the second into the first at the same array index.
+  it('appends repeated complex-typed values instead of collapsing them into one', async () => {
+    const result = await extract(
+      createInputParameters(QRRepeatingComplexValueMerge, QRepeatingComplexValueMerge, undefined),
+      mockFetchQuestionnaire,
+      mockFetchQuestionnaireConfig
+    );
+
+    const returnParam = (result as OutputParameters).parameter.find(
+      (p): p is ReturnParameter => p.name === 'return'
+    );
+
+    const extracted = returnParam?.resource as Bundle;
+    const extractedBundle = extracted.entry?.[0]?.resource as Bundle;
+    const extractedImmunization = extractedBundle.entry?.[0]?.resource as Immunization;
+
+    expect(extractedImmunization.protocolApplied?.[0]?.targetDisease).toHaveLength(2);
+    expect(extractedImmunization).toEqual(extractedRepeatingComplexValueMergeImmunization);
   });
 });

--- a/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/extract.test.ts
+++ b/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/extract.test.ts
@@ -6,6 +6,7 @@ import type {
   Immunization,
   Observation,
   Parameters,
+  Patient,
   QuestionnaireResponseItem,
   QuestionnaireResponseItemAnswer,
   RelatedPerson
@@ -22,6 +23,8 @@ import { extractedRegularMedicationsWithPatchAdd } from './resources/extracted/e
 import { extractedComplexTemplateExtract } from './resources/extracted/extractedComplexTemplateExtract';
 import { extractedSepsisRisk } from './resources/extracted/extractedSepsisRisk';
 import { extractedArrayElementMergeImmunization } from './resources/extracted/extractedArrayElementMerge';
+import { extractedDuplicateValueMergePatient } from './resources/extracted/extractedDuplicateValueMerge';
+import { extractedStaticDataNotDuplicatedPatient } from './resources/extracted/extractedStaticDataNotDuplicated';
 
 // QuestionnaireResponses
 import { QRAllergiesAdverseReactions } from './resources/questionnaireResponses/QRAllergiesAdverseReactions';
@@ -35,6 +38,8 @@ import { QRRegularMedicationsWithPatchAdd } from './resources/questionnaireRespo
 import { QRComplexTemplateExtract } from './resources/questionnaireResponses/QRComplexTemplateExtract';
 import { QRSepsisRisk } from './resources/questionnaireResponses/QRSepsisRisk';
 import { QRArrayElementMerge } from './resources/questionnaireResponses/QRArrayElementMerge';
+import { QRDuplicateValueMerge } from './resources/questionnaireResponses/QRDuplicateValueMerge';
+import { QRStaticDataNotDuplicated } from './resources/questionnaireResponses/QRStaticDataNotDuplicated';
 
 // Questionnaires
 import { QAllergiesAdverseReactions } from './resources/questionnaires/QAllergiesAdverseReactions';
@@ -48,6 +53,8 @@ import { QRegularMedicationsWithPatchAdd } from './resources/questionnaires/QReg
 import { QComplexTemplateExtract } from './resources/questionnaires/QComplexTemplateExtract';
 import { QSepsisRisk } from './resources/questionnaires/QSepsisRisk';
 import { QArrayElementMerge } from './resources/questionnaires/QArrayElementMerge';
+import { QDuplicateValueMerge } from './resources/questionnaires/QDuplicateValueMerge';
+import { QStaticDataNotDuplicated } from './resources/questionnaires/QStaticDataNotDuplicated';
 import { parametersIsFhirPatch } from '../utils/typePredicates';
 
 // Mock the fetchQuestionnaire callback function
@@ -589,5 +596,51 @@ describe('extract ArrayElementMerge', () => {
     expect(extractedImmunization.protocolApplied?.[0]?.targetDisease).toBeDefined();
 
     expect(extractedImmunization).toEqual(extractedArrayElementMergeImmunization);
+  });
+});
+
+describe('extract DuplicateValueMerge', () => {
+  // A repeating templateExtractValue whose evaluated values contain a genuine duplicate (the same
+  // given name answered twice) must merge both occurrences into the array, not drop the repeat.
+  it('appends a repeated primitive value instead of dropping it as an apparent duplicate', async () => {
+    const result = await extract(
+      createInputParameters(QRDuplicateValueMerge, QDuplicateValueMerge, undefined),
+      mockFetchQuestionnaire,
+      mockFetchQuestionnaireConfig
+    );
+
+    const returnParam = (result as OutputParameters).parameter.find(
+      (p): p is ReturnParameter => p.name === 'return'
+    );
+
+    const extracted = returnParam?.resource as Bundle;
+    const extractedPatient = extracted.entry?.[0]?.resource as Patient;
+
+    expect(extractedPatient.name?.[0]?.given).toEqual(['Alex', 'Alex']);
+    expect(extractedPatient).toEqual(extractedDuplicateValueMergePatient);
+  });
+});
+
+describe('extract StaticDataNotDuplicated', () => {
+  // Static template data (here `prefix`) sitting alongside sibling templateExtractValues - two
+  // single-value (`family`, `use`) and one repeating (`given`) - in the same context must be
+  // spread into the merged element exactly once, not once per sibling or per inner repeat value.
+  it('does not duplicate static template data across sibling templateExtractValues', async () => {
+    const result = await extract(
+      createInputParameters(QRStaticDataNotDuplicated, QStaticDataNotDuplicated, undefined),
+      mockFetchQuestionnaire,
+      mockFetchQuestionnaireConfig
+    );
+
+    const returnParam = (result as OutputParameters).parameter.find(
+      (p): p is ReturnParameter => p.name === 'return'
+    );
+
+    const extracted = returnParam?.resource as Bundle;
+    const extractedPatient = extracted.entry?.[0]?.resource as Patient;
+
+    expect(extractedPatient.name?.[0]?.prefix).toEqual(['Dr']);
+    expect(extractedPatient.name?.[0]?.given).toEqual(['Alex', 'Chris']);
+    expect(extractedPatient).toEqual(extractedStaticDataNotDuplicatedPatient);
   });
 });

--- a/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/resources/extracted/extractedDuplicateValueMerge.ts
+++ b/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/resources/extracted/extractedDuplicateValueMerge.ts
@@ -1,0 +1,17 @@
+import type { Patient } from 'fhir/r4';
+
+/**
+ * Expected `Patient` for QDuplicateValueMerge/QRDuplicateValueMerge.
+ *
+ * `given` has both occurrences of the duplicate answer - `mergeArrayByIndex` must append a
+ * repeated primitive value rather than treating it as already-present static data and dropping it.
+ */
+export const extractedDuplicateValueMergePatient: Patient = {
+  resourceType: 'Patient',
+  name: [
+    {
+      family: 'Citizen',
+      given: ['Alex', 'Alex']
+    }
+  ]
+};

--- a/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/resources/extracted/extractedRepeatingComplexValueMerge.ts
+++ b/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/resources/extracted/extractedRepeatingComplexValueMerge.ts
@@ -1,0 +1,48 @@
+import type { Immunization } from 'fhir/r4';
+
+/**
+ * Expected `Immunization` for QRepeatingComplexValueMerge/QRRepeatingComplexValueMerge.
+ *
+ * `protocolApplied[0].targetDisease` must have both evaluated Codings - a repeating
+ * templateExtractValue whose values are objects must append them, not merge the second into the
+ * first at the same array index.
+ *
+ * `targetDisease` is typed as `CodeableConcept[]`, but the engine's Coding-result handling
+ * (`getValueFromResult`) inserts a bare Coding shape rather than wrapping it in `{ coding: [...] }`.
+ * That's a pre-existing, separate quirk unrelated to this fix - this fixture reflects what the
+ * engine actually produces, hence the `@ts-ignore`s below.
+ */
+export const extractedRepeatingComplexValueMergeImmunization: Immunization = {
+  resourceType: 'Immunization',
+  status: 'completed',
+  vaccineCode: {
+    coding: [
+      {
+        system: 'http://snomed.info/sct',
+        code: '1290624003'
+      }
+    ]
+  },
+  patient: {
+    reference: 'Patient/example'
+  },
+  occurrenceDateTime: '2025-01-01',
+  protocolApplied: [
+    {
+      doseNumberPositiveInt: 2,
+      // Bare Coding shapes, not CodeableConcept - see comment above.
+      targetDisease: [
+        {
+          system: 'http://snomed.info/sct',
+          code: '14189004',
+          display: 'Measles'
+        },
+        {
+          system: 'http://snomed.info/sct',
+          code: '36989005',
+          display: 'Mumps'
+        }
+      ] as any[]
+    }
+  ]
+};

--- a/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/resources/extracted/extractedStaticDataNotDuplicated.ts
+++ b/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/resources/extracted/extractedStaticDataNotDuplicated.ts
@@ -1,0 +1,20 @@
+import type { Patient } from 'fhir/r4';
+
+/**
+ * Expected `Patient` for QStaticDataNotDuplicated/QRStaticDataNotDuplicated.
+ *
+ * `prefix` is static template data, unrelated to any of the three templateExtractValues - it must
+ * appear exactly once, not once per sibling value (`family`, `use`, `given`) merged into the same
+ * element, including the repeating `given` merge (which itself has two evaluated values).
+ */
+export const extractedStaticDataNotDuplicatedPatient: Patient = {
+  resourceType: 'Patient',
+  name: [
+    {
+      prefix: ['Dr'],
+      family: 'Citizen',
+      use: 'official',
+      given: ['Alex', 'Chris']
+    }
+  ]
+};

--- a/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/resources/questionnaireResponses/QRDuplicateValueMerge.ts
+++ b/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/resources/questionnaireResponses/QRDuplicateValueMerge.ts
@@ -1,0 +1,32 @@
+import type { QuestionnaireResponse } from 'fhir/r4';
+
+export const QRDuplicateValueMerge: QuestionnaireResponse = {
+  resourceType: 'QuestionnaireResponse',
+  id: 'QR-DuplicateValueMerge',
+  status: 'completed',
+  questionnaire: 'https://smartforms.csiro.au/docs/tests/DuplicateValueMerge',
+  item: [
+    {
+      linkId: 'patient',
+      text: 'Patient Information',
+      item: [
+        {
+          linkId: 'name',
+          text: 'Name',
+          item: [
+            {
+              linkId: 'given',
+              text: 'Given Name(s)',
+              answer: [{ valueString: 'Alex' }, { valueString: 'Alex' }]
+            },
+            {
+              linkId: 'family',
+              text: 'Family/Surname',
+              answer: [{ valueString: 'Citizen' }]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};

--- a/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/resources/questionnaireResponses/QRRepeatingComplexValueMerge.ts
+++ b/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/resources/questionnaireResponses/QRRepeatingComplexValueMerge.ts
@@ -1,0 +1,41 @@
+import type { QuestionnaireResponse } from 'fhir/r4';
+
+export const QRRepeatingComplexValueMerge: QuestionnaireResponse = {
+  resourceType: 'QuestionnaireResponse',
+  id: 'QR-RepeatingComplexValueMerge',
+  status: 'completed',
+  questionnaire: 'https://smartforms.csiro.au/docs/tests/RepeatingComplexValueMerge',
+  item: [
+    {
+      linkId: 'immunisation',
+      text: 'Immunisation',
+      item: [
+        {
+          linkId: 'doses',
+          text: 'Total number of doses',
+          answer: [{ valueInteger: 2 }]
+        },
+        {
+          linkId: 'diseases',
+          text: 'Diseases covered',
+          answer: [
+            {
+              valueCoding: {
+                system: 'http://snomed.info/sct',
+                code: '14189004',
+                display: 'Measles'
+              }
+            },
+            {
+              valueCoding: {
+                system: 'http://snomed.info/sct',
+                code: '36989005',
+                display: 'Mumps'
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};

--- a/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/resources/questionnaireResponses/QRStaticDataNotDuplicated.ts
+++ b/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/resources/questionnaireResponses/QRStaticDataNotDuplicated.ts
@@ -1,0 +1,37 @@
+import type { QuestionnaireResponse } from 'fhir/r4';
+
+export const QRStaticDataNotDuplicated: QuestionnaireResponse = {
+  resourceType: 'QuestionnaireResponse',
+  id: 'QR-StaticDataNotDuplicated',
+  status: 'completed',
+  questionnaire: 'https://smartforms.csiro.au/docs/tests/StaticDataNotDuplicated',
+  item: [
+    {
+      linkId: 'patient',
+      text: 'Patient Information',
+      item: [
+        {
+          linkId: 'name',
+          text: 'Name',
+          item: [
+            {
+              linkId: 'family',
+              text: 'Family/Surname',
+              answer: [{ valueString: 'Citizen' }]
+            },
+            {
+              linkId: 'use',
+              text: 'Name use',
+              answer: [{ valueString: 'official' }]
+            },
+            {
+              linkId: 'given',
+              text: 'Given Name(s)',
+              answer: [{ valueString: 'Alex' }, { valueString: 'Chris' }]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};

--- a/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/resources/questionnaires/QDuplicateValueMerge.ts
+++ b/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/resources/questionnaires/QDuplicateValueMerge.ts
@@ -1,0 +1,98 @@
+import type { Questionnaire } from 'fhir/r4';
+
+/**
+ * Minimal questionnaire reproducing a repeating `templateExtractValue` whose evaluated values
+ * contain a genuine duplicate (the same given name answered twice).
+ *
+ * `buildValuesToInsert` splits a multi-value result into one object per value (e.g. `given: ['Alex']`,
+ * `given: ['Alex']`), which are merged into the same array one after another via `mergeArrayByIndex`.
+ * If a duplicate value is mistaken for the same static data being re-attached and dropped instead of
+ * appended, the second occurrence would be silently lost.
+ */
+export const QDuplicateValueMerge: Questionnaire = {
+  resourceType: 'Questionnaire',
+  id: 'DuplicateValueMerge',
+  url: 'https://smartforms.csiro.au/docs/tests/DuplicateValueMerge',
+  name: 'DuplicateValueMerge',
+  title: 'Duplicate value merge',
+  status: 'draft',
+  experimental: true,
+  subjectType: ['Patient'],
+  contained: [
+    {
+      resourceType: 'Patient',
+      id: 'patTemplate',
+      name: [
+        {
+          extension: [
+            {
+              url: 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-templateExtractContext',
+              valueString: "item.where(linkId = 'name')"
+            }
+          ],
+          // @ts-ignore - TS2353: `_family` carries the templateExtractValue directive.
+          _family: {
+            extension: [
+              {
+                url: 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-templateExtractValue',
+                valueString: "item.where(linkId = 'family').answer.value.first()"
+              }
+            ]
+          },
+          // @ts-ignore - TS2353: `_given` carries the templateExtractValue directive.
+          _given: [
+            {
+              extension: [
+                {
+                  url: 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-templateExtractValue',
+                  valueString: "item.where(linkId = 'given').answer.value"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  item: [
+    {
+      extension: [
+        {
+          url: 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-templateExtract',
+          extension: [
+            {
+              url: 'template',
+              valueReference: {
+                reference: '#patTemplate'
+              }
+            }
+          ]
+        }
+      ],
+      linkId: 'patient',
+      text: 'Patient Information',
+      type: 'group',
+      item: [
+        {
+          linkId: 'name',
+          text: 'Name',
+          type: 'group',
+          repeats: true,
+          item: [
+            {
+              linkId: 'given',
+              text: 'Given Name(s)',
+              type: 'string',
+              repeats: true
+            },
+            {
+              linkId: 'family',
+              text: 'Family/Surname',
+              type: 'string'
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};

--- a/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/resources/questionnaires/QRepeatingComplexValueMerge.ts
+++ b/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/resources/questionnaires/QRepeatingComplexValueMerge.ts
@@ -1,0 +1,147 @@
+import type { Questionnaire } from 'fhir/r4';
+
+/**
+ * Minimal questionnaire reproducing a repeating templateExtractValue whose evaluated result is a
+ * complex type (a Coding) rather than a primitive, merged into an array alongside another sibling
+ * value in the same context.
+ *
+ * `protocolApplied[0]` has two templateExtractValues: `_doseNumberPositiveInt` (single-value,
+ * declared first) and `targetDisease` (repeating, evaluating to two Codings for a combined vaccine).
+ * Because `doseNumberPositiveInt` is processed first and answered, the repeating `targetDisease`
+ * merge goes through the object-merge path rather than a fresh array insert - the case that
+ * previously collapsed repeated Codings into one instead of appending them.
+ */
+export const QRepeatingComplexValueMerge: Questionnaire = {
+  resourceType: 'Questionnaire',
+  id: 'RepeatingComplexValueMerge',
+  url: 'https://smartforms.csiro.au/docs/tests/RepeatingComplexValueMerge',
+  name: 'RepeatingComplexValueMerge',
+  title: 'Repeating complex value merge',
+  status: 'draft',
+  experimental: true,
+  subjectType: ['Patient'],
+  contained: [
+    {
+      resourceType: 'Bundle',
+      id: 'BundleTemplate',
+      type: 'transaction',
+      entry: [
+        {
+          extension: [
+            {
+              url: 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-templateExtractContext',
+              valueString: "iif(item.where(linkId='doses').answer.value.exists(), true, {})"
+            }
+          ],
+          fullUrl: 'urn:uuid:0f9b1a2c-3d4e-5f60-7182-93a4b5c6d7e8',
+          // @ts-ignore - TS2353: `_fullUrl` carries the identity value directive.
+          _fullUrl: {
+            extension: [
+              {
+                url: 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-templateExtractValue',
+                valueString: "'urn:uuid:0f9b1a2c-3d4e-5f60-7182-93a4b5c6d7e8'"
+              }
+            ]
+          },
+          resource: {
+            resourceType: 'Immunization',
+            status: 'completed',
+            vaccineCode: {
+              coding: [
+                {
+                  system: 'http://snomed.info/sct',
+                  code: '1290624003'
+                }
+              ]
+            },
+            patient: {
+              reference: 'Patient/example'
+            },
+            occurrenceDateTime: '2025-01-01',
+            protocolApplied: [
+              {
+                // @ts-ignore - TS2353: `_doseNumberPositiveInt` carries the templateExtractValue directive.
+                _doseNumberPositiveInt: {
+                  extension: [
+                    {
+                      url: 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-templateExtractValue',
+                      valueString:
+                        "%resource.descendants().where(linkId='doses').answer.value.first()"
+                    }
+                  ]
+                },
+                targetDisease: [
+                  {
+                    extension: [
+                      {
+                        url: 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-templateExtractValue',
+                        valueString:
+                          "%resource.descendants().where(linkId='diseases').answer.valueCoding"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  item: [
+    {
+      extension: [
+        {
+          url: 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-templateExtract',
+          extension: [
+            {
+              url: 'template',
+              valueReference: {
+                reference: '#BundleTemplate'
+              }
+            }
+          ]
+        }
+      ],
+      linkId: 'immunisation',
+      text: 'Immunisation',
+      type: 'group',
+      item: [
+        {
+          linkId: 'doses',
+          text: 'Total number of doses',
+          type: 'integer'
+        },
+        {
+          linkId: 'diseases',
+          text: 'Diseases covered',
+          type: 'choice',
+          repeats: true,
+          answerOption: [
+            {
+              valueCoding: {
+                system: 'http://snomed.info/sct',
+                code: '14189004',
+                display: 'Measles'
+              }
+            },
+            {
+              valueCoding: {
+                system: 'http://snomed.info/sct',
+                code: '36989005',
+                display: 'Mumps'
+              }
+            },
+            {
+              valueCoding: {
+                system: 'http://snomed.info/sct',
+                code: '36653000',
+                display: 'Rubella'
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};

--- a/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/resources/questionnaires/QStaticDataNotDuplicated.ts
+++ b/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/tests/resources/questionnaires/QStaticDataNotDuplicated.ts
@@ -1,0 +1,119 @@
+import type { Questionnaire } from 'fhir/r4';
+
+/**
+ * Minimal questionnaire reproducing static (non-templateExtractValue) primitive array data sitting
+ * alongside sibling `templateExtractValue`s in the same `templateExtractContext`.
+ *
+ * Static data must only be spread into the element once, when it's first seeded - if it were
+ * re-attached on every subsequent sibling merge too, a static primitive array like `prefix` here
+ * would collide with itself and duplicate once per sibling value merged in after the first.
+ *
+ * Three siblings prove this: `_family` (seeds the element), `_use` (a second single-value merge),
+ * then a repeating `_given` (a multi-value merge, to also check static data doesn't leak back in
+ * per inner repeat value). The repeating value is deliberately not first, so this fixture isolates
+ * the static-data duplication rather than any behaviour specific to the first value merged.
+ */
+export const QStaticDataNotDuplicated: Questionnaire = {
+  resourceType: 'Questionnaire',
+  id: 'StaticDataNotDuplicated',
+  url: 'https://smartforms.csiro.au/docs/tests/StaticDataNotDuplicated',
+  name: 'StaticDataNotDuplicated',
+  title: 'Static data not duplicated',
+  status: 'draft',
+  experimental: true,
+  subjectType: ['Patient'],
+  contained: [
+    {
+      resourceType: 'Patient',
+      id: 'patTemplate',
+      name: [
+        {
+          extension: [
+            {
+              url: 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-templateExtractContext',
+              valueString: "item.where(linkId = 'name')"
+            }
+          ],
+          // Static template data - not driven by a templateExtractValue.
+          prefix: ['Dr'],
+          // @ts-ignore - TS2353: `_family` carries the templateExtractValue directive.
+          _family: {
+            extension: [
+              {
+                url: 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-templateExtractValue',
+                valueString: "item.where(linkId = 'family').answer.value.first()"
+              }
+            ]
+          },
+          // @ts-ignore - TS2353: `_use` carries the templateExtractValue directive.
+          _use: {
+            extension: [
+              {
+                url: 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-templateExtractValue',
+                valueString: "item.where(linkId = 'use').answer.value.first()"
+              }
+            ]
+          },
+          // @ts-ignore - TS2353: `_given` carries the templateExtractValue directive. Repeating,
+          // and deliberately declared last so it isn't the first sibling merged for this context.
+          _given: [
+            {
+              extension: [
+                {
+                  url: 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-templateExtractValue',
+                  valueString: "item.where(linkId = 'given').answer.value"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  item: [
+    {
+      extension: [
+        {
+          url: 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-templateExtract',
+          extension: [
+            {
+              url: 'template',
+              valueReference: {
+                reference: '#patTemplate'
+              }
+            }
+          ]
+        }
+      ],
+      linkId: 'patient',
+      text: 'Patient Information',
+      type: 'group',
+      item: [
+        {
+          linkId: 'name',
+          text: 'Name',
+          type: 'group',
+          repeats: true,
+          item: [
+            {
+              linkId: 'family',
+              text: 'Family/Surname',
+              type: 'string'
+            },
+            {
+              linkId: 'use',
+              text: 'Name use',
+              type: 'string'
+            },
+            {
+              linkId: 'given',
+              text: 'Given Name(s)',
+              type: 'string',
+              repeats: true
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};

--- a/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/utils/buildValueToInsert.ts
+++ b/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/utils/buildValueToInsert.ts
@@ -31,11 +31,20 @@ export function buildValuesToInsert(
     return valueResultsToInsert as any[];
   }
 
+  // A trailing array index in the value path (e.g. `given[0]`) is just the template's placeholder
+  // position, not a count of values. Bump it per value so a multi-value result lands at consecutive
+  // indices instead of every value colliding on the same one.
+  const trailingIndex = relativeValuePathSegments[relativeValuePathSegments.length - 1];
+  const bumpTrailingIndex = typeof trailingIndex === 'number';
+
   const valuesToInsert = [];
   if (Array.isArray(valueResultsToInsert)) {
-    for (const valueResult of valueResultsToInsert) {
-      const value = getValueFromResult([valueResult]);
-      const valueToInsert = buildSingleValueToInsertRecursive(relativeValuePathSegments, value);
+    for (let i = 0; i < valueResultsToInsert.length; i++) {
+      const value = getValueFromResult([valueResultsToInsert[i]]);
+      const segmentsForThisValue = bumpTrailingIndex
+        ? [...relativeValuePathSegments.slice(0, -1), (trailingIndex as number) + i]
+        : relativeValuePathSegments;
+      const valueToInsert = buildSingleValueToInsertRecursive(segmentsForThisValue, value);
       const fullValueToInsert = combineStaticTemplateData(staticTemplateData, valueToInsert);
       valuesToInsert.push(fullValueToInsert);
     }

--- a/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/utils/templateInsert.ts
+++ b/packages/sdc-template-extract/src/SDCExtractQuestionnaireResponseOperation/utils/templateInsert.ts
@@ -19,7 +19,7 @@ function mergeArrayByIndex(target: any[], source: any[], options: any): any[] {
       destination[index] = options.cloneUnlessOtherwiseSpecified(item, options);
     } else if (options.isMergeableObject(item)) {
       destination[index] = deepmerge(target[index], item, options);
-    } else if (target.indexOf(item) === -1) {
+    } else {
       destination.push(item);
     }
   });
@@ -82,11 +82,14 @@ export function insertValuesToPath(
 ) {
   const entryPathSegments = parseFhirPath(entryPath);
 
-  const staticTemplateData = getStaticTemplateDataAtPath(
-    entryPath,
-    cleanTemplate,
-    populateIntoTemplateWarnings
-  );
+  // Static template data only needs to be spread in once, when this entry is first seeded
+  // (isNewInsert). Later merges into the same already-seeded element don't need it re-attached -
+  // deepmerge already preserves keys it isn't touching - and re-attaching it on every subsequent
+  // sibling value would make any static primitive array (e.g. a hardcoded `given`) duplicate
+  // itself once per sibling value merged in after the first.
+  const staticTemplateData = isNewInsert
+    ? getStaticTemplateDataAtPath(entryPath, cleanTemplate, populateIntoTemplateWarnings)
+    : {};
   const valuesToInsert = buildValuesToInsert(
     entryPathSegments,
     valuePath,


### PR DESCRIPTION
## Summary

Two follow-up fixes to the `mergeArrayByIndex` array-merge logic introduced in #2093, found while reviewing that PR (see the [review comment](https://github.com/aehrc/smart-forms/pull/2093#issuecomment-5564514976) for the original repros and discussion).

1. **Duplicate repeating value silently dropped.** `mergeArrayByIndex`'s dedup guard (`target.indexOf(item) === -1`) couldn't distinguish a genuinely repeated answer (e.g. the same given name entered twice) from static template data being re-attached, and dropped the former. Root cause was `insertValuesToPath` re-fetching and re-spreading the full static template data on every sibling `templateExtractValue` in a context, not just the first — gating that fetch on `isNewInsert` removes the redundant re-spread at its source, so the dedup guard has nothing left to defend against and can be dropped outright.

2. **Repeating complex-typed values collapsing into one.** A repeating `templateExtractValue` whose evaluated result is an object (e.g. two Codings for a combined vaccine's `targetDisease`) had every value built at the same array index (the template's placeholder position), so `mergeArrayByIndex`'s object-merge branch deep-merged them together instead of appending — silently discarding all but the last value. Fixed by bumping the trailing array index per value in a multi-value result, so repeating object values land at consecutive indices.

## Tests

Three new fixture triples (`DuplicateValueMerge`, `StaticDataNotDuplicated`, `RepeatingComplexValueMerge`) plus their `describe` blocks in `extract.test.ts`. Verified each new test fails without its corresponding fix and passes with it. Full suite: 76/76, clean `tsc`, clean `eslint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)